### PR TITLE
Remove RI folder if it already exists

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -88,6 +88,7 @@ if [ -z "${GF_BUNDLE_URL}" ]; then
   exit 1
 fi
 wget --progress=bar:force --no-cache $GF_BUNDLE_URL -O ${CTS_HOME}/latest-glassfish.zip
+rm -Rf ${CTS_HOME}/ri
 mkdir -p ${CTS_HOME}/ri
 unzip ${CTS_HOME}/latest-glassfish.zip -d ${CTS_HOME}/ri
 chmod -R 777 ${CTS_HOME}/ri


### PR DESCRIPTION
When running all tests locally in sequence, the unzipped GlassFish was preserved, preventing a clean installation. Also, the shell required manual interaction to confirm you want to overwrite the files.