### PR TITLE
Fixed TS_HOME env variable

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -34,7 +34,11 @@ fi
 if [ -z "${CTS_HOME}" ]; then
   export CTS_HOME="${WORKSPACE}"
 fi
-export TS_HOME=${CTS_HOME}/javaeetck/
+
+if [ -z "$TS_HOME" ]; then
+  export TS_HOME=${CTS_HOME}/install/j2ee
+fi
+
 # Run CTS related steps
 echo "JAVA_HOME ${JAVA_HOME}"
 echo "ANT_HOME ${ANT_HOME}"


### PR DESCRIPTION
At least on my local machine the correct path seems to be `/install/j2ee` inside the cloned repository. Also it shouldn't replace the variable if it was already defined.