### PR TITLE
Initial step toward conversion to Jakarta EE

### DIFF
--- a/user_guides/Template/src/main/jbake/content/README
+++ b/user_guides/Template/src/main/jbake/content/README
@@ -20,7 +20,7 @@ for the specific technology:
 
 - packages.inc
 
-	A simple list of Java package names for the technology.
+	A simple list of Jakarta EE package names for the technology.
 
 - tck-packages.inc
 
@@ -28,11 +28,11 @@ for the specific technology:
 
 - req-software.inc
 
-	A list of software required in addition to the TCK and RI.
+	A list of software required in addition to the TCK and CI.
 
 - install-server.inc
 
-	Steps to install the Java EE RI, if needed.
+	Steps to install the Jakarta EE CI, if needed.
 	For standalone technologies, no server may be required,
 	and this file can be empty.
 	This is used in install.adoc in section 3.2.
@@ -60,10 +60,10 @@ for the specific technology:
 
 - rebuild.inc
 
-	Special instructions for rebuilding the war files used by some TCKs.
+	Special instructions for rebuilding the WAR files used by some TCKs.
 	If needed, customize it appropriately and define the "rebuild"
 	attribute in attributes.conf.
 
 
-Note that this template is NOT sufficient for the Java EE platform
-or Web Profile.
+Note that this template is NOT sufficient for the Jakarta EE platform
+or Jakarta EE Web Profile.

--- a/user_guides/Template/src/main/jbake/content/attributes.conf
+++ b/user_guides/Template/src/main/jbake/content/attributes.conf
@@ -1,5 +1,6 @@
 :TechnologyFullName: Wombat API
 :TechnologyShortName: Wombat
+:LegacyAcronym: JWB		   
 :TechnologyVersion: X.X
 :TechnologyRI: FruitBat
 :TechnologyRIURL: http://fruitbat.github.io

--- a/user_guides/Template/src/main/jbake/content/config.adoc
+++ b/user_guides/Template/src/main/jbake/content/config.adoc
@@ -47,7 +47,7 @@ with the necessary configuration steps for your implementation and place
 the file under the `<TS_HOME>/bin/xml/impl/<your_impl>` directory.
 
 For more information, see `<TS_HOME>/bin/xml/impl/glassfish/config.vi.xml`,
-the configuration file for the Java EE 8 RI.
+the configuration file for the Jakarta EE 8 Compatible Implementation, Eclipse GlassFish.
 
 [[GBFWG]][[custom-deployment-handlers]]
 
@@ -65,7 +65,7 @@ The {TechnologyShortName} TCK provides these deployment handlers:
 
 The `deploy.xml` files in each of these directories are used to control
 deployment to a specific container (no deployment, deployment to
-the GlassFish Web container, deployment to the Tomcat Web container)
+the Eclipse GlassFish Web container, deployment to the Tomcat Web container)
 denoted by the name of the directory in which each `deploy.xml` file
 resides. The primary `build.xml` file in the `<TS_HOME>/bin` directory
 has a target to invoke any of the required targets (-deploy, -undeploy,
@@ -115,7 +115,7 @@ Although this example just echoes messages, it does include the four
 required Ant targets (-deploy, -undeploy, -deploy.all, -undeploy.all)
 that your custom deploy.xml file must contain. With this as your
 starting point, look at the required targets in the deploy.xml files
-in the tomcat and glassfish directories for guidance as you create
+in the Tomcat and Eclipse Glassfish directories for guidance as you create
 the same targets for the Web container in which you will run your
 implementation of {TechnologyShortName}.
 

--- a/user_guides/Template/src/main/jbake/content/config.adoc
+++ b/user_guides/Template/src/main/jbake/content/config.adoc
@@ -11,6 +11,13 @@ Setup and Configuration
 [[GBFVV]]
 
 
+[WARNING]
+====
+Currently, this is written to describe configuration for only one compatible implementation. 
+This must be expanded to provide for the possibility of multiple compatible implementations.
+
+====
+
 [[setup-and-configuration]]
 4 Setup and Configuration
 -------------------------

--- a/user_guides/Template/src/main/jbake/content/config.inc
+++ b/user_guides/Template/src/main/jbake/content/config.inc
@@ -12,8 +12,8 @@ as toc.adoc.
 
 [[GBFVU]][[configuring-your-environment-to-run-the-tck-against-the-reference-implementation]]
 
-4.1 Configuring Your Environment to Run the TCK Against the Reference Implementation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+4.1 Configuring Your Environment to Run the TCK Against the Compatible Implementation (CI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After configuring your environment as described in this section,
 continue with the instructions in link:#GBFUY[Section 4.6, "Using the
@@ -43,25 +43,25 @@ slashes as a path separator instead.
   b.  `TS_HOME` to the directory in which the {TechnologyShortName} TCK
   {TechnologyVersion} software is installed
   c.  +{TechnologyHomeEnv}+ to the directory in which the {TechnologyShortName}
-  {TechnologyVersion} RI has been installed
+  {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `<TS_HOME>/tools/ant/bin`
 2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
-  Java EE 8 RI is running. +
+  Jakarta EE 8 CI is running. +
   The default setting is `localhost`.
   b.  Set the `webServerPort` property to the port number of the host on
-  which Java EE 8 RI is running. +
+  which Jakarta EE 8 CI is running. +
   The default setting is `8080`.
-  c.  Set the `web.home` property to the installation directory of Java EE
-  8 RI.
+  c.  Set the `web.home` property to the installation directory of Jakarta EE
+  8 CI.
   d.  Set the `jaxrs.classes` property to point to the classes or JAR file
   for the JSR 370 API. +
   The default setting for this property is
   `${web.home}/modules/javax.ws.rs-api.jar`.
   e.  Set the `jaxrs_impl_lib` and `jaxrs_impl.classes` properties to
-  point to the Jersey RI. +
+  point to the Jersey CI. +
   The default setting for the `jaxrs_impl_lib` property is
   `${web.home}/modules/jersey-container-servlet-core.jar`. +
   The default setting for the `jaxrs_impl.`classes property is as follows
@@ -93,18 +93,18 @@ ${web.home}/modules/endorsed/javax.annotation-api.jar
   class for the {TechnologyShortName} implementation. +
   The default setting for this property is
   `org/glassfish/jersey/servlet/ServletContainer.class`.
-  g.  Set the `impl.vi` property to the name of the Java EE 8 RI . +
+  g.  Set the `impl.vi` property to the name of the Jakarta EE 8 CI . +
   The relevant porting files are located under the
   `$TS_HOME/bin/xml/impl/glassfish/` directory. +
   The default setting for this property is `glassfish`.
   h.  Set the `jaxrs_impl_name` property to the name of the
-  {TechnologyShortName} RI. +
+  {TechnologyShortName} CI. +
   A file bearing this name has been created under
   `<TS_HOME>/bin/xml/impl/glassfish/jersey.xml` with packaging
   instructions. +
   The default setting for this property is `jersey`.
   i.  Set the `impl.vi.deploy.dir` property to point to the `autodeploy`
-  directory of the Java EE 8 RI . +
+  directory of the Jakarta EE 8 CI . +
   The default setting for this property is
   `${web.home}/domains/domain1/autodeploy`.
   j. Verify that the `tools.jar` property is set to the location of the
@@ -161,7 +161,7 @@ ant config.vi
 ----
 +
 This target performs the following tasks:
-* Stops the application server running the {TechnologyShortName} {TechnologyVersion} RI
+* Stops the application server running the {TechnologyShortName} {TechnologyVersion} CI
 * Copies the TCK-dependent files `${tslib.name}.jar` and `tsharness.jar`
 into the application server's external library folder
 * Starts the application server
@@ -238,7 +238,7 @@ environment variables:
   The default setting for this property is
   `${web.home}/modules/javax.ws.rs-api.jar`.
   e.  Set the `jaxrs_impl_lib` and `jaxrs_impl.classes` properties to
-  point to the Jersey RI. +
+  point to the Jersey CI. +
   The default setting for the `jaxrs_impl_lib` property is
   `${web.home}/modules/jersey-container-servlet-core.jar` . +
   The default setting for the `jaxrs_impl.`classes property is as follows
@@ -322,8 +322,8 @@ both the prebuilt and Vendor-built archives to the configured web
 container or containers by using deployment handlers.
 
 The handler file (`<TS_HOME>/bin/xml/impl/glassfish/jersey.xml` is
-written to be used with Jersey and Java EE 8 RI . If the Vendor chooses
-not to use Java EE 8 RI to run with their implementation but still
+written to be used with Jersey and Jakarta EE 8 CI . If the Vendor chooses
+not to use Jakarta EE 8 CI to run with their implementation but still
 chooses to publish to a Servlet-compliant Web container, then a
 VI-specific {TechnologyShortName} TCK tests Web archive needs to be created.
 This archive contains the VI-specific servlet class, and the Vendor should
@@ -346,7 +346,7 @@ classes or WAR files to the configured web container.
 4.3.1 Generic Deployment Command Scenarios
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can deploy all {TechnologyShortName} WAR files to Java EE 8 RI or
+You can deploy all {TechnologyShortName} WAR files to Jakarta EE 8 CI or
 the Web server chosen by a Vendor, deploy just a single test directory,
 or deploy of subset of test directories.
 
@@ -397,21 +397,21 @@ This section explains issues regarding the deployment of the
 {TechnologyShortName} TCK prebuilt archives. Before conducting any
 deployment, ensure that your environment has been configured by
 following the instructions in either link:#GBFVU[Section 4.1,
-"Configuring Your Environment to Run the TCK Against the Reference
+"Configuring Your Environment to Run the TCK Against the Compatible
 Implementation,"] or link:#GCLHU[Section 4.2, "Configuring Your
 Environment to Repackage and Run the TCK Against the Vendor
 Implementation."]
 
 The `<TS_HOME>/dist` directory contains all WAR files for the
 {TechnologyShortName} TCK tests that have been compiled and packaged
-using the Reference Implementation for deployment on a
-Servlet-compliant Web container, Java EE 8 RI, using the standard Web
+using the Compatible Implementation for deployment on a
+Servlet-compliant Web container, Jakarta EE 8 CI, using the standard Web
 Archive (WAR) format.
 
-These WAR files contain only Jersey, a Java EE 8 RI -specfic servlet
-adaptor, and are tailored to run against the Reference Implementation.
+These WAR files contain only Jersey, a Jakarta EE 8 CI -specfic servlet
+adaptor, and are tailored to run against the Compatible Implementation.
 These WAR files allow you to deploy (without any additional setup or
-modification) against the Reference Implementation to test the various
+modification) against the Compatible Implementation to test the various
 features and functionality of this implementation.
 
 To deploy the {TechnologyShortName} TCK tests, use either the `deploy`
@@ -434,13 +434,13 @@ under `$TS_HOME/classes`. All test resources packaged in WAR files are
 located under `$TS_HOME/dist`.
 
 If a vendor chooses to deploy WAR files on a Servlet–compliant Web
-container other than Java EE 8 RI , it is necessary to build test WAR
+container other than Jakarta EE 8 CI , it is necessary to build test WAR
 files that contain the VI's servlet class and servlet class property in
 the `web.xml` deployment descriptor, as specified in the {TechnologyShortName}
 specification. The {TechnologyShortName} TCK comes with a
 `web.xml.template` file for each test, which contains all information
 except the servlet class. The {TechnologyShortName} TCK also comes with
-a tool to replace the RI or VI's servlet adaptor class name in the
+a tool to replace the CI or VI's servlet adaptor class name in the
 `web.xml.template`. Refer to link:rebuild.html#GCLIZ[Appendix B,
 "Packaging the Test Applications in Servlet-Compliant WAR Files With
 VI-Specific Information,"] for more information about repackaging the

--- a/user_guides/Template/src/main/jbake/content/install-server.inc
+++ b/user_guides/Template/src/main/jbake/content/install-server.inc
@@ -1,11 +1,11 @@
-.  Install the Java EE 8 RI software (the servlet Web container used
+.  Install the Jakarta EE 8 CI software (the servlet Web container used
 for running the {TechnologyShortName} TCK with the
-{TechnologyShortName} {TechnologyVersion} RI), if it is not already
+{TechnologyShortName} {TechnologyVersion} CI), if it is not already
 installed. +
 Download and install the Servlet Web container with the
-{TechnologyShortName} {TechnologyVersion} RI used for running the
-{TechnologyShortName} TCK {TechnologyVersion}, represented by the Java
-EE 8 RI.
-This software can be obtained from the Java Licensee Engineering Web
+{TechnologyShortName} {TechnologyVersion} CI used for running the
+{TechnologyShortName} TCK {TechnologyVersion}, represented by the Jakarta
+EE 8 CI.
+This software can be obtained from the Eclipse EE4J Github project
 site. Refer to any installation instructions that accompany the software
 for additional information.

--- a/user_guides/Template/src/main/jbake/content/install.adoc
+++ b/user_guides/Template/src/main/jbake/content/install.adoc
@@ -23,12 +23,12 @@ Configuration,"] for instructions on configuring your test environment.
 
 [[GBFUD]][[obtaining-the-reference-implementation]]
 
-3.1 Obtaining the Reference Implementation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+3.1 Obtaining the Compatible Implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can obtain the {TechnologyShortName} Reference Implementation (RI)
-({TechnologyRI}) software from Java Licensee Engineering
-(https://javapartner.oracle.com).
+You can obtain the {TechnologyShortName} Compatible Implementation (CI)
+({TechnologyRI}) software from the Eclipse EE4J GitHub Organization
+(https://github.com/eclipse-ee4j).
 
 [[GBFTS]][[installing-the-software]]
 
@@ -40,7 +40,7 @@ install and set up the following software components:
 
 include::req-software.inc[]
 * Java SE {SEversion}
-* {TechnologyShortName} {TechnologyVersion} RI, which is {TechnologyRI}
+* {TechnologyShortName} {TechnologyVersion} CI, which is {TechnologyRI}
 * {TechnologyShortName} TCK version {TechnologyVersion}, which includes:
 include::tck-packages.inc[]
 * The {TechnologyShortName} {TechnologyVersion} Vendor Implementation (VI)
@@ -56,23 +56,22 @@ additional information.
   a.  Copy or download the {TechnologyShortName} TCK software to your
       local system. +
       You can obtain the {TechnologyShortName} TCK software from the
-      Java Licensee Engineering (https://javapartner.oracle.com) Web
+      Eclipse EE4J GitHub Organization (https://github.com/eclipse-ee4j) project
       site.  The {TechnologyShortName} TCK software is located in the
-      Web site's Download Center area.
+      project site's Download area.
   b.  Use the `unzip` command to extract the bundle in the directory of
       your choice: +
       +unzip {TCKPackageName}+ +
       This creates the TCK directory. The TCK is the test suite home,
       `<TS_HOME>`.
 include::install-server.inc[]
-.  Install the {TechnologyShortName} {TechnologyVersion} Reference
+.  Install the {TechnologyShortName} {TechnologyVersion} Compatible
 Implementation. +
-The Reference Implementation is used to validate your initial
+The Compatible Implementation is used to validate your initial
 configuration and setup of the {TechnologyShortName} TCK
 {TechnologyVersion} tests, which are explained further in
 link:config.html#GBFVV[Chapter 4, "Setup and Configuration."] +
-The {TechnologyShortName} RI can be obtained from Java Licensee Engineering
-(https://javapartner.oracle.com).
+The {TechnologyShortName} CI can be obtained from Eclipse EE4J GitHub Organization (https://github.com/eclipse-ee4j) project site.
 include::install-server-vi.inc[]
-.  Install the {TechnologyShortName} Vendor Implementation (VI) to be tested. +
+.  Install the {TechnologyShortName} VI to be tested. +
 Follow the installation instructions for the particular VI under test.

--- a/user_guides/Template/src/main/jbake/content/install.adoc
+++ b/user_guides/Template/src/main/jbake/content/install.adoc
@@ -26,9 +26,10 @@ Configuration,"] for instructions on configuring your test environment.
 3.1 Obtaining the Compatible Implementation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can obtain the {TechnologyShortName} Compatible Implementation (CI)
-({TechnologyRI}) software from the Eclipse EE4J GitHub Organization
-(https://github.com/eclipse-ee4j).
+Each compatible implementation will provide instructions for obtaining
+their product.
+Eclipse GlassFish is a compatible implementation which may be obtained
+from https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip
 
 [[GBFTS]][[installing-the-software]]
 

--- a/user_guides/Template/src/main/jbake/content/intro.adoc
+++ b/user_guides/Template/src/main/jbake/content/intro.adoc
@@ -43,29 +43,29 @@ other implementations, such as those features that:
 * Mask or abstract hardware or operating system behavior
 
 Compatibility test development for a given feature relies on a complete
-specification and reference implementation for that feature.
+specification and compatible implementation (CI) for that feature.
 Compatibility testing is not primarily concerned with robustness,
-performance, or ease of use.
+performance, nor ease of use.
 
 [[GBFQN]][[why-compatibility-testing-is-important]]
 
 1.1.1 Why Compatibility Testing is Important
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Java platform compatibility is important to different groups involved
-with Java technologies for different reasons:
+Jakarta platform compatibility is important to different groups involved
+with Jakarta technologies for different reasons:
 
-* Compatibility testing ensures that the Java platform does not become
+* Compatibility testing ensures that the Jakarta platform does not become
 fragmented as it is ported to different operating systems and hardware
 environments.
-* Compatibility testing benefits developers working in the Java
+* Compatibility testing benefits developers working in the Jakarta
 programming language, allowing them to write applications once and then
 to deploy them across heterogeneous computing environments without
 porting.
 * Compatibility testing allows application users to obtain applications
 from disparate sources and deploy them with confidence.
-* Conformance testing benefits Java platform implementors by ensuring a
-level playing field for all Java platform ports.
+* Conformance testing benefits Jakarta platform implementors by ensuring a
+level playing field for all Jakarta platform ports.
 
 [[GBFPR]][[tck-compatibility-rules]]
 
@@ -82,11 +82,11 @@ link:rules.html#GBFSN[Chapter 2, "Procedure for Certification."]
 1.1.3 TCK Overview
 ^^^^^^^^^^^^^^^^^^
 
-A TCK is a set of tools and tests used to verify that a licensee's
-implementation of a Java EE technology conforms to the applicable
+A TCK is a set of tools and tests used to verify that a vendor's compatible
+implementation of a Jakarta EE technology conforms to the applicable
 specification. All tests in the TCK are based on the written
-specifications for the Java platform. A TCK tests compatibility of a
-licensee's implementation of the technology to the applicable
+specifications for the Jakarta EE platform. A TCK tests compatibility of a
+vendor's compatible implementation of the technology to the applicable
 specification of the technology. Compatibility testing is a means of
 ensuring correctness, completeness, and consistency across all
 implementations developed by technology licensees.
@@ -104,22 +104,30 @@ List for the TCK you are using.
 
 [[GBFPB]][[java-community-process-jcp-program-and-compatibility-testing]]
 
-1.1.4 Java Community Process (JCP) Program and Compatibility Testing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1.1.4 Jakarta EE Specification Process (JESP) Program and Compatibility Testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Java Community Process (JCP) program is the formalization of the
-open process that has been used since 1995 to develop and revise Java
-technology specifications in cooperation with the international Java
-community. The JCP program specifies that the following three major
-components must be included as deliverables in a final Java technology
+[WARNING]
+====
+TODO
+
+* The following needs to be rewritten to fit the JESP and describe the Eclipse Jakarta EE process
+
+====
+
+The Jakarta EE Specification Process (JESP) program is the formalization of the
+open process that has been used since 2019 to develop and revise Jakarta EE
+technology specifications in cooperation with the international Jakarta EE
+community. The JESP program specifies that the following three major
+components must be included as deliverables in a final Jakarta EE technology
 release under the direction of the responsible Expert Group:
 
 * Technology Specification
-* Reference Implementation
+* Compatible Implementation (CI)
 * Technology Compatibility Kit (TCK)
 
-For further information about the JCP program, go to Java Community
-Process (http://jcp.org/en/home/index).
+For further information about the JESP program, go to Jakarta EE Specification
+Process community page TBD (https://jakarta.ee).
 
 [[GBFQR]][[about-the-tck]]
 
@@ -128,7 +136,7 @@ Process (http://jcp.org/en/home/index).
 
 The {TechnologyShortName} TCK {TechnologyVersion} is designed as a
 portable, configurable, automated test suite for verifying the
-compatibility of a licensee's implementation of the
+compatibility of a vendor's implementation of the
 {TechnologyShortName} {TechnologyVersion} Specification.
 
 [[GBFQV]][[tck-specifications-and-requirements]]
@@ -146,10 +154,10 @@ be found at {JSRURL}.
 * {TechnologyShortName} Version: The {TechnologyShortName} TCK
 {TechnologyVersion} is based on the {TechnologyShortName}
 Specification, Version {TechnologyVersion}.
-* Reference Implementation: The {TechnologyShortName}
-{TechnologyVersion} Reference Implementation ({TechnologyRI}) is
-available from Java Licensee Engineering
-(https://javapartner.oracle.com). See the RI documentation page at
+* Compatible Implementation: The {TechnologyShortName}
+{TechnologyVersion} Compatible Implementation ({TechnologyRI}) is
+available from the Eclipse EE4J Github Organization
+(https://github.com/eclipse-ee4j). See the CI documentation page at
 {TechnologyRIURL} for more information.
 
 See the {TechnologyShortName} TCK Release Notes for more specific
@@ -184,7 +192,7 @@ endif::end-to-end-tests[]
 
 The {TechnologyShortName} TCK tests run on the following platforms:
 
-* Windows 10
+* Microsoft Windows 10
 * Oracle Linux 7.1
 
 [[GBFSA]][[javatest-harness]]
@@ -193,10 +201,10 @@ The {TechnologyShortName} TCK tests run on the following platforms:
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The JavaTest harness version {JavaTestVersion} is a set of tools
-designed to run and manage test suites on different Java platforms. The
-JavaTest harness can be described as both a Java application and a set
+designed to run and manage test suites on different Java and Jakarta EE platforms. The
+JavaTest harness can be described as both a Jakarta (or Java) application and a set
 of compatibility testing tools. It can run tests on different kinds of
-Java platforms and it allows the results to be browsed online within
+Jakarta (or Java) platforms and it allows the results to be browsed online within
 the JavaTest GUI, or offline in the HTML reports that the JavaTest
 harness generates.
 
@@ -225,7 +233,7 @@ The test suite is the collection of tests used by the JavaTest harness
 to test a particular technology implementation. In this case, it is the
 collection of tests used by the {TechnologyShortName} TCK
 {TechnologyVersion} to test a {TechnologyShortName} {TechnologyVersion}
-implementation. The tests are designed to verify that a licensee's
+implementation. The tests are designed to verify that a vendor's
 runtime implementation of the technology complies with the appropriate
 specification. The individual tests correspond to assertions of the
 specification.
@@ -248,7 +256,7 @@ have to be run for the specific version of the TCK being used. Whenever
 tests are run, the JavaTest harness automatically excludes any test on
 the Exclude List from being executed.
 
-A licensee is not required to pass or run any test on the Exclude List.
+A vendor's compatible implementation is not required to pass or run any test on the Exclude List.
 The Exclude List file, +{jtxFileName}+, is included in the
 {TechnologyShortName} TCK.
 
@@ -257,7 +265,7 @@ The Exclude List file, +{jtxFileName}+, is included in the
 =======================================================================
 
 From time to time, updates to the Exclude List are made available on the
-Java Licensee Engineering (https://javapartner.oracle.com) Web site.
+Eclipse EE4J Github Organization (https://github.com/eclipse-ee4j) Web site.
 You should always make sure you are using an up-to-date copy of the
 Exclude List before running the {TechnologyShortName} TCK to verify your
 implementation.
@@ -275,8 +283,8 @@ has been discovered.
 * The test fails due to a bug in the tools (such as the JavaTest
 harness, for example).
 
-In addition, all tests are run against the reference implementations.
-Any tests that fail when run on a reference Java platform are put on the
+In addition, all tests are run against the compatible implementations.
+Any tests that fail when run on a compatible Jakarta platform are put on the
 Exclude List. Any test that is not specification-based, or for which the
 specification is vague, may be excluded. Any test that is found to be
 implementation dependent (based on a particular thread scheduling model,
@@ -286,7 +294,7 @@ based on a particular file system behavior, and so on) may be excluded.
 [NOTE]
 =======================================================================
 
-Licensees are not permitted to alter or modify Exclude Lists. Changes to
+Vendors are not permitted to alter or modify Exclude Lists. Changes to
 an Exclude List can only be made by using the procedure described in
 link:rules.html#CJAJEAEI[Section 2.3.1, "TCK Test Appeals Steps."]
 
@@ -319,7 +327,7 @@ guide.
 on the system hosting the JavaTest harness:
 include::req-software.inc[]
 * Java SE {SEversion}
-* {TechnologyShortName} {TechnologyVersion} RI, which is {TechnologyRI}
+* {TechnologyShortName} {TechnologyVersion} CI, which is {TechnologyRI}
 * {TechnologyShortName} TCK version {TechnologyVersion}, which includes:
 include::tck-packages.inc[]
 * The {TechnologyShortName} {TechnologyVersion} Vendor Implementation (VI) +

--- a/user_guides/Template/src/main/jbake/content/intro.adoc
+++ b/user_guides/Template/src/main/jbake/content/intro.adoc
@@ -201,10 +201,11 @@ The {TechnologyShortName} TCK tests run on the following platforms:
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The JavaTest harness version {JavaTestVersion} is a set of tools
-designed to run and manage test suites on different Java and Jakarta EE platforms. The
-JavaTest harness can be described as both a Jakarta (or Java) application and a set
+designed to run and manage test suites on different Java platforms.
+To JavaTest, Jakarta EE can be considered another platform.
+The JavaTest harness can be described as both a Java application and a set
 of compatibility testing tools. It can run tests on different kinds of
-Jakarta (or Java) platforms and it allows the results to be browsed online within
+Java platforms and it allows the results to be browsed online within
 the JavaTest GUI, or offline in the HTML reports that the JavaTest
 harness generates.
 
@@ -251,10 +252,11 @@ matches with the filters you are using and queues them up for execution.
 ^^^^^^^^^^^^^^^^^^^
 
 Each version of a TCK includes an Exclude List contained in a `.jtx`
-file. This is a list of test file URLs that identify tests which do not
-have to be run for the specific version of the TCK being used. Whenever
-tests are run, the JavaTest harness automatically excludes any test on
-the Exclude List from being executed.
+file. 
+This is a list of test file URLs that identify tests which do not
+have to be run for the specific version of the TCK being used. 
+Whenever tests are run, the JavaTest harness automatically excludes
+any test on the Exclude List from being executed.
 
 A vendor's compatible implementation is not required to pass or run any test on the Exclude List.
 The Exclude List file, +{jtxFileName}+, is included in the
@@ -264,8 +266,10 @@ The Exclude List file, +{jtxFileName}+, is included in the
 [NOTE]
 =======================================================================
 
-From time to time, updates to the Exclude List are made available on the
-Eclipse EE4J Github Organization (https://github.com/eclipse-ee4j) Web site.
+From time to time, updates to the Exclude List are made available.
+The exclude list is included in the Jakarta EE TCK ZIP archive.
+Each time an update is approved and released, the version number 
+will be incremented.
 You should always make sure you are using an up-to-date copy of the
 Exclude List before running the {TechnologyShortName} TCK to verify your
 implementation.
@@ -314,6 +318,15 @@ link:config.html#GBFVV[Chapter 4, "Setup and Configuration."]
 include::intro.inc[]
 
 [[GBFQW]][[getting-started-with-the-tck]]
+
+[WARNING]
+====
+The following only describes setting up the Eclipse GlassFish
+compatible implementation.
+This must be rewritten to describe the general setup, followed by
+specifics for setting up one or more compatible implementations.
+
+====
 
 1.3 Getting Started With the TCK
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/user_guides/Template/src/main/jbake/content/intro.inc
+++ b/user_guides/Template/src/main/jbake/content/intro.inc
@@ -51,7 +51,7 @@ as follows:
 [NOTE]
 =======================================================================
 
-For the JASPIC TCK, more than one provider is registered in the vendor's
+For the Eclipse JASPIC TCK, more than one provider is registered in the vendor's
 message processing runtime.
 
 =======================================================================
@@ -141,6 +141,12 @@ The `provider-configuration.xsd` file is a schema file that resides in
 the same directory as the `ProviderConfiguration.xml` file and describes
 the `ProviderConfiguration.xml` file. This file should not be edited.
 
+[WARNING]
+====
+The following link reference is broken
+
+====
+
 thref4]]
 
 
@@ -168,17 +174,17 @@ Since various SOAP implementations are possible in a vendor's message
 processing runtime, the JASPIC TCK considers the following SOAP
 implementations:
 
-* SOAP implementation in a Java EE environment
-* SOAP implementation in standalone container (non-Java EE)
+* SOAP implementation in a Jakarta EE environment
+* SOAP implementation in standalone container (non-Jakarta EE)
 * Non-container based SOAP implementation
 
 For SOAP profile tests, the client invocations of webservice have been
 abstracted into two different types:
 
-* Invocations of Service in a Java EE environment (for example, using
-JAXWS annotations `@WebServiceRef` for looking up the service and
+* Invocations of Service in a Jakarta EE environment (for example, using
+Eclipse JAXWS annotations `@WebServiceRef` for looking up the service and
 `@WebService` for service definition).
-* Invocations of Service in a standalone (i.e. non-Java EE) environment
+* Invocations of Service in a standalone (i.e. non-Jakarta EE) environment
 (this includes standalone container and non-container based
 implementation). +
 The following are used to get the service reference:
@@ -196,7 +202,13 @@ The following are used to get the service reference:
 The deployment abstraction for handling various SOAP implementations are
 handled in the following ways:
 
-* A JSR 88–compliant deployment is used for Java EE-based
+[WARNING]
+====
+Update the direct links to JSR pages below
+
+====
+
+* A JSR 88–compliant deployment is used for Jakarta EE-based
 implementations. This is differentiated by using a different deliverable
 class,
 `deliverable.class=com.sun.ts.lib.deliverable.jaspic.JaspicJavaEEDeliverable`,
@@ -207,15 +219,15 @@ non-container based implementations), a different deliverable class is
 used,
 `deliverable.class=com.sun.ts.lib.deliverable.jaspic.JaspicDeliverable`.
 Along with this deliverable class an Ant file,
-`TS_HOME/bin/xml/deploy.xml`, is used to deploy in GlassFish Server.
+`TS_HOME/bin/xml/deploy.xml`, is used to deploy in Eclipse GlassFish Server.
 Vendors are expected to implement the `deploy` and `undeploy` targets in
 `deploy.xml` to suite their environment. +
 
 [NOTE]
 =======================================================================
 
-Two deliverable implementations are provided with the GlassFish server.
-One implementation, for non-Java EE servers, turns off auto deployment
+Two deliverable implementations are provided with the Eclipse GlassFish server.
+One implementation, for non-Jakarta EE servers, turns off auto deployment
 and leaves the deployment up to the licensee by way of an Ant target.
 
 =======================================================================
@@ -224,7 +236,13 @@ and leaves the deployment up to the licensee by way of an Ant target.
 `ts.jte` file, `platform.mode`, is used to distinguish the different
 SOAP implementations.
 
-** `platform.mode=javaEE` (for Java EE based implementation)
+[WARNING]
+====
+Change the following mode string?
+
+====
+
+** `platform.mode=javaEE` (for Jakarta EE based implementation)
 
 ** `platform.mode=standalone` +
 
@@ -249,7 +267,7 @@ various artifacts of web services (the WSDL, `ServiceEndpoint`, and
 implementation and their associations). Using other forms of web
 services implementation will lead to separate binding files, web
 services description files (`webservices.xml`) which are different for
-different SOAP implementations, such as a Java EE-based SOAP
+different SOAP implementations, such as a Jakarta EE-based SOAP
 implementation, standalone implementation, and so on.
 
 Since vendors are already expected to generate web service artifacts
@@ -263,7 +281,7 @@ implementation.
 [NOTE]
 ===================================================================
 
-For Java EE-based SOAP implementations, JSR 181 support is required.
+For Jakarta EE-based SOAP implementations, JSR 181 support is required.
 
 ===================================================================
 

--- a/user_guides/Template/src/main/jbake/content/preface.adoc
+++ b/user_guides/Template/src/main/jbake/content/preface.adoc
@@ -20,9 +20,9 @@ Compatibility Kit (TCK) that is used to test the {TechnologyFullName}
 ({TechnologyShortName} {TechnologyVersion}) (JSR {JSR}) technology.
 
 The {TechnologyShortName} TCK is a portable, configurable automated
-test suite for verifying the compatibility of a licensee's
+test suite for verifying the compatibility of a vendor's
 implementation of the {TechnologyShortName} {TechnologyVersion}
-Specification (hereafter referred to as the licensee implementation).
+Specification (hereafter referred to as the vendor implementation or VI).
 The {TechnologyShortName} TCK uses the JavaTest harness version
 {JavaTestVersion} to run the test suite
 
@@ -37,11 +37,18 @@ the authors of this guide.
 
 =======================================================================
 
+[WARNING]
+====
+TODO
 
-Refer to the Java Licensee Engineering
-(https://javapartner.oracle.com) Web site for answers to frequently
-asked questions and send questions you may have to your Java
-Licensee Engineering contact.
+* The following paragraph needs to be rewritten
+
+====
+
+Refer to the Eclipse EE4J Github Organization
+(https://github.com/eclipse-ee4j) Web site for answers to frequently
+asked questions. You may e-mail questions or comments to the 
+specification development e-mail list.
 
 [[TCJRS00034]][[GBFUS]]
 
@@ -50,19 +57,10 @@ Licensee Engineering contact.
 Who Should Use This Book
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This guide is for licensees of the {TechnologyShortName}
+This guide is for vendors that implement the {TechnologyShortName}
 {TechnologyVersion} technology to assist them in running the test suite
 that verifies compatibility of their implementation of the
 {TechnologyShortName} {TechnologyVersion} Specification.
-
-[[sthref2]][[documentation-accessibility]]
-
-Documentation Accessibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For information about Oracle's commitment to accessibility, visit the
-Oracle Accessibility Program website at
-http://www.oracle.com/pls/topic/lookup?ctx=acc&id=docacc.
 
 
 [[TCJRS00035]][[GBFPO]]
@@ -71,6 +69,14 @@ http://www.oracle.com/pls/topic/lookup?ctx=acc&id=docacc.
 [[before-you-read-this-book]]
 Before You Read This Book
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[WARNING]
+====
+TODO
+
+* Fix reference to JSRURL -- everywhere
+
+====
 
 You should be familiar with the {TechnologyShortName}
 {TechnologyVersion} Specification, which can be found at {JSRURL}.

--- a/user_guides/Template/src/main/jbake/content/rebuild.inc
+++ b/user_guides/Template/src/main/jbake/content/rebuild.inc
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////
 NOTE TO WRITERS:
 The following sections should be customized for the technology.
-This text was originally from the JAX-RS TCK.  Most references
+This text was originally from the Eclipse JAX-RS TCK.  Most references
 to JAX-RS have been parameterized to serve as a simple starting
 point for customization.  There are still many details that will
 need to be changed or removed.
@@ -23,7 +23,7 @@ published in a Java SE environment are located under
 `$TS_HOME/classes`.
 
 The {TechnologyShortName} TCK comes with prebuilt test WAR files for
-deployment on Java EE 8 RI , which provides a Servlet–compliant Web
+deployment on Jakarta EE 8 CI , which provides a Servlet–compliant Web
 container. The WAR files are {TechnologyRI}-specific, with {TechnologyRI}'s servlet
 class and {TechnologyRI}'s servlet defined in the `web.xml` deployment
 descriptor. To run the TCK tests against the VI in a Servlet–compliant
@@ -49,9 +49,9 @@ B.1 Overview
 ~~~~~~~~~~~~
 
 The set of prebuilt archives and classes that ship with the
-{TechnologyShortName} TCK were built using the Reference
-Implementation, and must be deployed on Java EE 8 RI and run against
-the {TechnologyRI} RI.
+{TechnologyShortName} TCK were built using the Compatible
+Implementation, and must be deployed on Jakarta EE 8 CI and run against
+the {TechnologyRI} CI.
 
 The prebuilt {TechnologyRI}-specific Servlet–compliant WAR files are located
 under $TS_HOME`/dist`, and have `jersey` as part of their name; for
@@ -147,7 +147,7 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 ----
 
 The {TechnologyShortName} TCK provides a tool,
-`${ts.home}/bin/xml/impl/glassfish/jersey.xml`, for the Java EE 8 RI
+`${ts.home}/bin/xml/impl/glassfish/jersey.xml`, for the Jakarta EE 8 CI
 that you can use as a model to help you create your own VI-specific Web
 test application.
 

--- a/user_guides/Template/src/main/jbake/content/req-software.inc
+++ b/user_guides/Template/src/main/jbake/content/req-software.inc
@@ -1,11 +1,11 @@
 ///////////////////////////////////////////////////////////////////////
 NOTE TO WRITERS:
-This is a list of software required in addition to the TCK and the RI.
-For many Java EE APIs, the Java EE RI will be required, as described below.
+This is a list of software required in addition to the TCK and the CI.
+For many Jakarta EE APIs, the Jakarta EE RI will be required, as described below.
 For standalone technologies, no other software may be required, and the
 below line can be removed.
 
 This is used in intro.adoc in section 1.3 and install.adoc in section 3.2.
 ///////////////////////////////////////////////////////////////////////
 
-* Java EE 8 RI or, at a minimum, a Web server with a Servlet container
+* Jakarta EE 8 CI or, at a minimum, a Web server with a Servlet container

--- a/user_guides/Template/src/main/jbake/content/rules.adoc
+++ b/user_guides/Template/src/main/jbake/content/rules.adoc
@@ -15,6 +15,17 @@ Procedure for Certification
 2 Procedure for Certification
 -----------------------------
 
+[WARNING]
+====
+TODO
+
+* In this section:
+* Replaced Maintenance Lead with "component project team." This probably needs to be revisited 
+* Maintenance Lead seems to refer to the organization that "owns" the Spec. How should this be updates
+* Java Partner Engineering is replaced with EE4J GitHub Organization but that is probably incorrect
+
+====
+
 This chapter describes the compatibility testing procedure and
 compatibility requirements for {TechnologyFullName}.
 This chapter contains the following sections:
@@ -39,7 +50,15 @@ Guide.
 * Ensure that you meet the requirements outlined in
 link:#CJAFGIGG[Compatibility Requirements] below.
 
-* Certify to the Java Partner organization that you have finished
+[WARNING]
+====
+TODO
+
+* Rewrite the following point
+
+====
+
+* Certify to the Eclipse TCK organization that you have finished
 testing and that you meet all of the compatibility requirements.
 
 [[CJAFGIGG]][[compatibility-requirements]]
@@ -63,6 +82,13 @@ and are not intended for any other purpose.
 
 Table 2-1 Definitions 
 
+[WARNING]
+====
+TODO
+
+* Review the following definitions in this table and revise as needed
+
+====
 [width="100%",cols="25%,75%",options="header",]
 |=======================================================================
 |Term |Definition
@@ -92,22 +118,23 @@ specification and which contains configuration information for a set of
 Java classes, archive, or other feature defined in the specification.
 
 |Conformance Tests |All tests in the Test Suite for an indicated
-Technology Under Test, as distributed by the Maintenance Lead, excluding
-those tests on the Exclude List for the Technology Under Test.
+Technology Under Test, as released and distributed by the 
+component project team, excluding those tests on the Exclude List 
+for the Technology Under Test.
 
 |Documented |Made technically accessible and made known to users,
 typically by means such as marketing materials, product documentation,
 usage messages, or developer support programs.
 
-|Exclude List |The most current list of tests, distributed by the
-Maintenance Lead, that are not required to be passed to certify
-conformance. The Maintenance Lead may add to the Exclude List for that
+|Exclude List |The most current list of tests, released and distributed by the
+component project team, that are not required to be passed to certify
+conformance. The component project team may add to the Exclude List for that
 Test Suite as needed at any time, in which case the updated Exclude List
 supplants any previous Exclude Lists for that Test Suite.
 
 |Libraries a|
-The class libraries, as specified through the Java Community Process
-(JCP), for the Technology Under Test.
+The class libraries, as specified through the Jakarta EE Specification 
+Process (JESP), for the Technology Under Test.
 
 The Libraries for {TechnologyFullName} are listed at the end of this chapter.
 
@@ -121,9 +148,9 @@ For example, classes may be required to exist in directories named in a
 CLASSPATH variable, or native libraries may be required to exist in
 directories named in a PATH variable.
 
-|Maintenance Lead |The Java Community Process member responsible for
+|Maintenance Lead |The Jakarta EE Project Team responsible for
 maintaining the Specification, reference implementation, and TCK for the
-Technology. Oracle is the Maintenance Lead for {TechnologyFullName}.
+Technology. Eclipse Jakarta EE Specification Committer Team is Maintenance Lead for {TechnologyFullName}.
 
 |Operating Mode a|
 Any Documented option of a Product that can be changed by a user in
@@ -137,7 +164,7 @@ Note that an Operating Mode may be selected by a command line switch, an
 environment variable, a GUI user interface element, a configuration or
 control file, etc.
 
-|Product |A licensee product in which the Technology Under Test is
+|Product |A vendor's product in which the Technology Under Test is
 implemented or incorporated, and that is subject to compatibility
 testing.
 
@@ -151,7 +178,7 @@ Configuration that links the Product to that encryption package.
 |Rebuildable Tests |Tests that must be built using an
 implementation-specific mechanism. This mechanism must produce
 specification-defined artifacts. Rebuilding and running these tests
-against the Java EE 8 RI verifies that the mechanism generates
+against the Jakarta EE 8 CI verifies that the mechanism generates
 compatible artifacts.
 
 |Resource |A Computational Resource, a Location Resource, or a Security
@@ -169,23 +196,23 @@ to access the files and network resources necessary for use of the
 Product.
 
 |Specifications a|
-The documents produced through the Java Community Process that define a
-particular Version of a Technology.
+The documents produced through the Jakarta EE Specification Process (JESP)
+that define a particular Version of a Technology.
 
 The Specifications for the Technology Under Test are referenced later in
 this chapter.
 
 |Technology |Specifications and a reference implementation produced
-through the Java Community Process.
+through the Jakarta EE Specification Process (JESP).
 
-|Technology Under Test |Specifications and the reference implementation
+|Technology Under Test |Specifications and a compatible implementation
 for {TechnologyFullName} Version {TechnologyVersion}.
 
 |Test Suite |The requirements, tests, and testing tools distributed by
 the Maintenance Lead as applicable to a given Version of the Technology.
 
-|Version |A release of the Technology, as produced through the Java
-Community Process.
+|Version |A release of the Technology, as produced through the Jakarta
+EE Specification Process (JESP).
 |=======================================================================
 
 
@@ -194,6 +221,13 @@ Community Process.
 2.2.2 Rules for {TechnologyFullName} Products
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+[WARNING]
+====
+TODO
+
+* The following rules need to be carefully examined and may need revision.
+
+====
 The following rules apply for each version of an operating system,
 software component, and hardware platform Documented as supporting the
 Product:
@@ -236,8 +270,8 @@ installation. Apart from changing such properties and other allowed
 modifications described in this User's Guide (if any), no source or
 binary code for a Conformance Test may be altered in any way without
 prior written permission. Any such allowed alterations to the
-Conformance Tests would be posted to the Java Licensee Engineering web
-site and apply to all licensees.
+Conformance Tests would be posted to the Eclipse EE4J GitHub Organization web
+site and apply to all vendor compatible implementations.
 
 *{techID}3* The testing tools supplied as part of the Test Suite or as
 updated by the Maintenance Lead must be used to certify compliance.
@@ -246,7 +280,7 @@ updated by the Maintenance Lead must be used to certify compliance.
 modified.
 
 *{techID}5* The Maintenance Lead can define exceptions to these Rules. Such
-exceptions would be made available to and apply to all licensees.
+exceptions would be made available to and apply to all vendor implementations.
 
 *{techID}6* All hardware and software component additions, deletions, and
 modifications to a Documented supporting hardware/software platform,
@@ -372,6 +406,13 @@ https://www.eclipse.org/projects/dev_process/#6_5_Grievance_Handling[Eclipse Dev
 2.4 Specifications for {TechnologyFullName}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+[WARNING]
+====
+TODO
+
+* The following must be updated to the new Jakarta EE TCK process and web-site definitions
+
+====
 The {TechnologyFullName} specification is available on the
 JSR {JSR} Web site at {JSRURL} or on the Java
 Community Process (http://jcp.org/en/home/index) site.

--- a/user_guides/Template/src/main/jbake/content/title.adoc
+++ b/user_guides/Template/src/main/jbake/content/title.adoc
@@ -1,6 +1,6 @@
 type=page
 status=published
-title=Technology Compatibility Kit User's Guide for Technology Licensees
+title=Technology Compatibility Kit User's Guide for Technology Implementors
 next=preface.html
 prev=toc.html
 ~~~~~~
@@ -35,3 +35,7 @@ SPDX-License-Identifier: EPL-2.0
 
 Oracle and Java are registered trademarks of Oracle and/or its
 affiliates. Other names may be trademarks of their respective owners.
+
+References in this document to {LegacyAcronym} refer to the {TechnologyFullName} unless otherwise noted.
+
+References in this document to JAXRS refer to the Jakarta RESTful Web Services unless otherwise noted.

--- a/user_guides/Template/src/main/jbake/content/toc.adoc
+++ b/user_guides/Template/src/main/jbake/content/toc.adoc
@@ -1,11 +1,11 @@
 type=page
 status=published
-title=Technology Compatibility Kit User's Guide for Technology Licensees
+title=Technology Compatibility Kit User's Guide for Technology Implementors
 next=title.html
 ~~~~~~
 include::attributes.conf[]
-Technology Compatibility Kit User's Guide for Technology Licensees
-==================================================================
+Technology Compatibility Kit User's Guide for Technology Implementors
+=====================================================================
 
 [[contents]]
 Contents
@@ -17,7 +17,6 @@ link:preface.html#GBFTI[Preface]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ** link:preface.html#GBFUS[Who Should Use This Book]
-** link:preface.html#sthref2[Documentation Accessibility]
 ** link:preface.html#GBFPO[Before You Read This Book]
 ** link:preface.html#GBFWF[Typographic Conventions]
 ** link:preface.html#FWBSD[Shell Prompts in Command Examples]
@@ -29,7 +28,7 @@ link:intro.html#GBFOW[1 Introduction]
 *** link:intro.html#GBFQN[1.1.1 Why Compatibility Testing is Important]
 *** link:intro.html#GBFPR[1.1.2 TCK Compatibility Rules]
 *** link:intro.html#GBFPW[1.1.3 TCK Overview]
-*** link:intro.html#GBFPB[1.1.4 Java Community Process (JCP) Program and Compatibility Testing]
+*** link:intro.html#GBFPB[1.1.4 Jakarta EE Specification Process (JESP) Program and Compatibility Testing]
 ** link:intro.html#GBFQR[1.2 About the TCK]
 *** link:intro.html#GBFQV[1.2.1 TCK Specifications and Requirements]
 *** link:intro.html#GBFSQ[1.2.2 TCK Components]
@@ -48,15 +47,16 @@ link:rules.html#GBFSN[2 Procedure for Certification]
 *** link:rules.html#definitions[2.2.1 Definitions]
 *** link:rules.html#sthref7[2.2.2 Rules for {TechnologyFullName} Products]
 ** link:rules.html#CJAIIBDJ[2.3 Test Appeals Process]
-*** link:rules.html#CJAJEAEI[2.3.1 TCK Test Appeals Steps]
-*** link:rules.html#sthref8[2.3.2 Test Challenge and Response Forms]
+*** link:rules.html#[2.3.1 Valid Challenges]
+*** link:rules.html#[2.3.2 Invalid Challenges]
+*** link:rules.html#CJAJEAEI[2.3.3 TCK Test Appeals Steps]
 ** link:rules.html#CJAJECIE[2.4 Specifications for {TechnologyFullName}]
 ** link:rules.html#CJABAHGI[2.5 Libraries for {TechnologyFullName}]
 
 link:install.html#GBFTP[3 Installation]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-** link:install.html#GBFUD[3.1 Obtaining the Reference Implementation]
+** link:install.html#GBFUD[3.1 Obtaining the Compatible Implementation]
 ** link:install.html#GBFTS[3.2 Installing the Software]
 
 [[setup-and-configuration]]
@@ -84,7 +84,7 @@ link:using.html#GBFWO[5 Executing Tests]
 *** link:using.html#GBFVT[5.2.1 To Run a Subset of Tests in GUI Mode]
 *** link:using.html#GBFWK[5.2.2 To Run a Subset of Tests in Command-Line Mode]
 *** link:using.html#GBFVL[5.2.3 To Run a Subset of Tests in Batch Mode Based on Prior Result Status]
-** link:using.html#GCLRR[5.3 Running the TCK Against the RI]
+** link:using.html#GCLRR[5.3 Running the TCK Against another CI]
 ** link:using.html#GCLRZ[5.4 Running the TCK Against a Vendor's Implementation]
 ** link:using.html#GBFVK[5.5 Test Reports]
 *** link:using.html#GBFWD[5.5.1 Creating Test Reports]

--- a/user_guides/Template/src/main/jbake/content/using.adoc
+++ b/user_guides/Template/src/main/jbake/content/using.adoc
@@ -24,7 +24,7 @@ This chapter includes the following topics:
 
 * link:#GBFUZ[Starting JavaTest]
 * link:#GBFWM[Running a Subset of the Tests]
-* link:#GCLRR[Running the TCK Against the RI]
+* link:#GCLRR[Running the TCK Against the CI]
 * link:#GCLRZ[Running the TCK Against a Vendor's Implementation]
 * link:#GBFVK[Test Reports]
 
@@ -175,17 +175,17 @@ Note that multiple `priorStatus` values must be separated by commas.
 
 [[GCLRR]][[running-the-tck-against-the-ri]]
 
-5.3 Running the TCK Against the RI
+5.3 Running the TCK Against the CI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This test scenario is ensures that the configuration and deployment of
-all the prebuilt {TechnologyShortName} TCK tests against the Reference
+all the prebuilt {TechnologyShortName} TCK tests against the Compatible
 Implementation are successful, and that the TCK is ready for
-compatibility testing against the Vendor and Reference Implementations.
+compatibility testing against the Vendor and Compatible Implementations.
 
 1.  Verify that you have followed the configuration instructions in
 link:config.html#GBFVU[Section 4.1, "Configuring Your Environment to Run
-the TCK Against the Reference Implementation."]
+the TCK Against the Compatible Implementation."]
 2.  If required, verify that you have completed the steps in
 link:config.html#GCLIW[Section 4.3.2, "Deploying the Prebuilt Archives."]
 3.  Run the tests, as described in link:#GBFUZ[Section 5.1, "Starting

--- a/user_guides/Template/src/main/jbake/content/using.adoc
+++ b/user_guides/Template/src/main/jbake/content/using.adoc
@@ -175,12 +175,12 @@ Note that multiple `priorStatus` values must be separated by commas.
 
 [[GCLRR]][[running-the-tck-against-the-ri]]
 
-5.3 Running the TCK Against the CI
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5.3 Running the TCK Against another CI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This test scenario is ensures that the configuration and deployment of
-all the prebuilt {TechnologyShortName} TCK tests against the Compatible
-Implementation are successful, and that the TCK is ready for
+Some test scenarios are designed to ensure that the configuration and deployment of
+all the prebuilt {TechnologyShortName} TCK tests against one Compatible
+Implementation are successful operating with other compatible implementations, and that the TCK is ready for
 compatibility testing against the Vendor and Compatible Implementations.
 
 1.  Verify that you have followed the configuration instructions in

--- a/user_guides/Template/src/main/jbake/content/using.inc
+++ b/user_guides/Template/src/main/jbake/content/using.inc
@@ -7,7 +7,7 @@ For example, the following is used for the JAX-WS TCK.
 ///////////////////////////////////////////////////////////////////////
 [[GCLRR]][[running-the-jax-ws-tck-against-the-jax-ws-ri]]
 
-5.6 Running the JAX-WS TCK Against the JAX-WS RI
+5.6 Running the JAX-WS TCK Against the JAX-WS CI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This test scenario is ensures that the configuration and deployment of
@@ -31,7 +31,7 @@ if desired, link:#GBFWM[Running a Subset of the Tests].
 
 This test scenario is one of the compatibility test phases that all
 Vendors must pass. This ensures that the prebuilt JAX-WS TCK tests built
-against the JAX-WS RI can be successfully run against the Vendor
+against the JAX-WS CI can be successfully run against the Vendor
 Implementation (VI).
 
 1.  Verify that you have followed the configuration instructions in
@@ -45,7 +45,7 @@ if desired, link:#GBFWM[Running a Subset of the Tests].
 
 [[GCLQV]][[running-the-rebuilt-jax-ws-tck-against-the-jax-ws-ri]]
 
-5.8 Running the Rebuilt JAX-WS TCK Against the JAX-WS RI
+5.8 Running the Rebuilt JAX-WS TCK Against the JAX-WS CI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This test scenario is one of the compatibility test phases that all
@@ -55,7 +55,7 @@ Reference Implementation.
 
 1.  Verify that you have followed the configuration instructions in
 link:config.html#GCLHF[Configuring Your Environment to Rebuild and Run
-the JAX-WS TCK Against the JAX-WS RI].
+the JAX-WS TCK Against the JAX-WS CI].
 2.  Refer to link:rebuild.html#GCLIZ[Appendix B], to learn about
 rebuilding the JAX-WS TCK tests.
 3.  Specify `reverse` for the `keywords` option.


### PR DESCRIPTION
Some basic updates to the Template files:
Simple substitutions for terms: RI -> CI; Java EE-> Jakarta EE, etc.
This it inadequate, but a start.
For some sections that require extensive rework, I have added [WARNING] admonishments.
I expect more iterations on this.
(Not sure if i should have used "draft" PR , or not)