### PR TITLE
fix to remove autogenerated .oracle_jre_usage directory in the TCK bundles

### DIFF
--- a/release/tools/caj.xml
+++ b/release/tools/caj.xml
@@ -114,6 +114,9 @@
                        com/sun/ts/tests/signaturetest/caj/*record*"/>
 		</copy>
 		<antcall target="mvn"/>
+		<delete verbose="true">
+          		<fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
 		<!--
 			<antcall target="create.doc.bundle"/>
 		-->

--- a/release/tools/concurrency.xml
+++ b/release/tools/concurrency.xml
@@ -174,6 +174,9 @@
                    com/sun/ts/tests/signaturetest/concurrency/*record*"/>
 		</copy>
 		<antcall target="mvn"/>
+		<delete verbose="true">
+          		<fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/connector.xml
+++ b/release/tools/connector.xml
@@ -211,6 +211,9 @@
                      includes="**/**"/>
         </copy>
 	<antcall target="mvn"/>
+	<delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
         <!--antcall target="javadoc"/-->
         <!--
 		  <antcall target="create.doc.bundle"/>

--- a/release/tools/el.xml
+++ b/release/tools/el.xml
@@ -117,6 +117,9 @@
                      sigtestdev.jar, saxpath.jar"/>
         </delete>
         <antcall target="mvn"/>
+	<delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jacc.xml
+++ b/release/tools/jacc.xml
@@ -195,7 +195,10 @@
             <fileset dir="${ts.home}/install/${deliverable.dir}/docs"
                      includes="**/**"/>
         </copy>
-        <antcall target="mvn"/>        
+        <antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>        
     </target>
     <target name="mvn">
         <exec dir="${ts.home}/user_guides/${deliverable.dir}" executable="mvn"/>

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -145,6 +145,9 @@
 		<antcall target="make.cts.internal.archive"/>
         <antcall target="build.j2eetck"/>
         <antcall target="mvn"/>
+	<delete verbose="true">
+	  <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	</delete>
     </target>
      
     <target name="mvn">

--- a/release/tools/jaspic.xml
+++ b/release/tools/jaspic.xml
@@ -213,6 +213,10 @@
         </copy>
 
         <antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
+
 
         <!--antcall target="javadoc"/-->
         <!--

--- a/release/tools/jaxr.xml
+++ b/release/tools/jaxr.xml
@@ -102,6 +102,9 @@
             **/*log"/>
         </copy>
         <antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jaxrpc.xml
+++ b/release/tools/jaxrpc.xml
@@ -110,6 +110,10 @@ com/sun/ts/lib/implementation/javaee/**/*"
 			excludes="**/*log"/>
 		</copy>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+        	     <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
+
 
 	</target>
 	<target name="mvn">

--- a/release/tools/jaxrs.xml
+++ b/release/tools/jaxrs.xml
@@ -216,6 +216,9 @@
                      includes="*jaxb*"/>
         </delete>
         <antcall target="mvn"/>
+	<delete verbose="true">
+          <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
         <!--
             <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jaxws.xml
+++ b/release/tools/jaxws.xml
@@ -173,6 +173,10 @@
 
 		</copy>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+        	     <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
+
         <!--
 		<antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jms.xml
+++ b/release/tools/jms.xml
@@ -161,6 +161,10 @@
                    com/sun/ts/tests/signaturetest/jms/*record*"/>
 		</copy>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+        	     <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jpa.xml
+++ b/release/tools/jpa.xml
@@ -145,6 +145,10 @@
                      includes="*ReleaseNotes-2.2*.html"/>
         </copy>
         <antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
+
         <!--
             <antcall target="create.doc.bundle"/>
          -->

--- a/release/tools/jsf.xml
+++ b/release/tools/jsf.xml
@@ -205,6 +205,10 @@
         <copy file="${ts.home}/src/com/sun/ts/lib/implementation/sun/common/SunRIURL.java"
               todir="${deliverable.bundle.dir}/src/com/sun/ts/lib/implementation/sun/common"/>
         <antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
+
         <!--
     	   <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jsonb.xml
+++ b/release/tools/jsonb.xml
@@ -139,6 +139,10 @@
 
 		</copy>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+        	     <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jsonp.xml
+++ b/release/tools/jsonp.xml
@@ -128,6 +128,10 @@
 
 		</copy>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+        	     <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
          -->

--- a/release/tools/jsp.xml
+++ b/release/tools/jsp.xml
@@ -177,6 +177,10 @@
                      includes="*jaxb*,apiCheck.jar"/>
         </delete>
 		<antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/jstl.xml
+++ b/release/tools/jstl.xml
@@ -156,6 +156,10 @@
 			<fileset dir="${ts.home}/src/com/sun/ts/lib/porting" includes="TSURLInterface.java, TSURL.java" />
 		</copy>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+        	     <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+	        </delete>
+
         <!--
             <antcall target="create.doc.bundle" />
         -->

--- a/release/tools/jta.xml
+++ b/release/tools/jta.xml
@@ -153,6 +153,10 @@
         <!-- the com/sun/ts/lib/implementation/sun/common file -->
         <copy file="${ts.home}/src/com/sun/ts/lib/implementation/sun/common/SunRIURL.java" todir="${deliverable.bundle.dir}/src/com/sun/ts/lib/implementation/sun/common"/>
 	<antcall target="mvn"/>
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
+
 
     </target>
     <target name="mvn">

--- a/release/tools/saaj.xml
+++ b/release/tools/saaj.xml
@@ -149,7 +149,11 @@
                    com/sun/ts/tests/signaturetest/*record*,
                    com/sun/ts/tests/signaturetest/saaj/*record*"/>
 		</copy>
-    <antcall target="mvn"/>      
+    <antcall target="mvn"/>     
+        <delete verbose="true">
+             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        </delete>
+ 
     <!--    
         <antcall target="create.doc.bundle"/>
     -->

--- a/release/tools/securityapi.xml
+++ b/release/tools/securityapi.xml
@@ -183,6 +183,10 @@
 					 includes="*jaxb*"/>
 		</delete>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+	             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        	</delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/servlet.xml
+++ b/release/tools/servlet.xml
@@ -208,6 +208,10 @@
 					 includes="*jaxb*"/>
 		</delete>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+	             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        	</delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->

--- a/release/tools/websocket.xml
+++ b/release/tools/websocket.xml
@@ -207,6 +207,10 @@
 					 includes="*jaxb*"/>
 		</delete>
 		<antcall target="mvn"/>
+	        <delete verbose="true">
+	             <fileset dir="${deliverable.bundle.dir}" includes="**/?/**" />
+        	</delete>
+
         <!--
 		  <antcall target="create.doc.bundle"/>
         -->


### PR DESCRIPTION

Signed-off-by: alwin.joseph <alwin.joseph@oracle.com>