### PR TITLE
fix to exclude auto-generated /?/.oracle_jre_usage dir from bundles

### DIFF
--- a/release/tools/build.xml
+++ b/release/tools/build.xml
@@ -266,6 +266,8 @@
     	  <exec executable="zip" dir="${bundle.dir}" failonerror="true">
             <arg line="-rq"/>
             <arg line="${zip.file} ${zip.name}"/>
+	    <arg line="-x"/>
+	    <arg line="**/\?**"/>
         </exec>
         <exec executable="zip" dir="${bundle.dir}" failonerror="true">
             <arg line="-T"/>


### PR DESCRIPTION
Signed-off-by: alwin.joseph <alwin.joseph@oracle.com>