### PR TITLE
removing incorrect NOTICE file from all TCK bundles for the release

### DIFF
--- a/release/tools/caj.xml
+++ b/release/tools/caj.xml
@@ -68,9 +68,10 @@
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
 	  
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+	  <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                 <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
 
 	  <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/concurrency.xml
+++ b/release/tools/concurrency.xml
@@ -79,10 +79,10 @@
 		<fileset dir="${ts.home}/install/${deliverable.name.lower}/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                 <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
 
           <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/connector.xml
+++ b/release/tools/connector.xml
@@ -68,9 +68,10 @@
                      includes="connector.jar,jaxb*" />
         </copy>
 
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 
         <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/el.xml
+++ b/release/tools/el.xml
@@ -45,9 +45,10 @@
 	<copy todir="${deliverable.bundle.dir}/docs" includeEmptyDirs="no">
               <fileset dir="${ts.home}/internal/docs/el" excludes="**svn**" />
         </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 	<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	</copy>
     </target>

--- a/release/tools/jacc.xml
+++ b/release/tools/jacc.xml
@@ -61,10 +61,11 @@
        <copy todir="${deliverable.bundle.dir}/sql" includeEmptyDirs="no">
             <fileset dir="${ts.home}/sql"
                     includes="**/*jacc.sql"/>
-       </copy> 
-       <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
-           <fileset dir="${ts.home}" includes="NOTICE" />
        </copy>
+       <!-- NOTICE will be EPL or EFTL specific: TBD--> 
+       <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+           <fileset dir="${ts.home}" includes="NOTICE" />
+       </copy-->
        <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
 

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -101,9 +101,10 @@
         <fileset dir="${ts.home}/install/${deliverable.name.lower}/other"
             includes="testsuite.jtt, vehicle.properties"/>
         </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 	<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
         </copy>
 	</target>

--- a/release/tools/jaspic.xml
+++ b/release/tools/jaspic.xml
@@ -68,9 +68,10 @@
         <copy todir="${deliverable.bundle.dir}/docs" includeEmptyDirs="no">
               <fileset dir="${ts.home}/install/jaspic/docs" excludes="**svn**" />
 	</copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
               <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 	<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	</copy>
     </target>

--- a/release/tools/jaxr.xml
+++ b/release/tools/jaxr.xml
@@ -60,9 +60,10 @@
               <fileset dir="${ts.home}/install/jaxr/docs" excludes="**svn**" />
 	   </copy>
 
-         <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+         <!-- NOTICE will be EPL or EFTL specific: TBD-->
+         <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-         </copy>
+         </copy-->
 
 	 <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	 </copy>

--- a/release/tools/jaxrpc.xml
+++ b/release/tools/jaxrpc.xml
@@ -48,9 +48,10 @@
 		<fileset dir="${ts.home}/install/${deliverable.name.lower}/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                 <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
       <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
 	  <!-- Copy over jaxrpcdocs -->

--- a/release/tools/jaxrs.xml
+++ b/release/tools/jaxrs.xml
@@ -89,9 +89,10 @@
             <fileset dir="${ts.home}/install/jaxrs/other" 
                      includes="**/*"/>
         </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 	<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
     </target>

--- a/release/tools/jaxws.xml
+++ b/release/tools/jaxws.xml
@@ -85,9 +85,10 @@
 		<fileset dir="${ts.home}/install/${deliverable.name.lower}/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
               <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
 
       <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/jms.xml
+++ b/release/tools/jms.xml
@@ -65,9 +65,10 @@
 		<fileset dir="${ts.home}/install/${deliverable.name.lower}/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
               <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
 
       <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/jpa.xml
+++ b/release/tools/jpa.xml
@@ -82,9 +82,10 @@
         <copy todir="${deliverable.bundle.dir}/docs" includeEmptyDirs="no">
             <fileset dir="${ts.home}/install/jpa/docs" excludes="**svn**, **/*2.1*" />
         </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy> 
+        </copy--> 
         <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>                     
     </target>

--- a/release/tools/jsf.xml
+++ b/release/tools/jsf.xml
@@ -62,9 +62,10 @@
 	    <copy todir="${deliverable.bundle.dir}/docs" includeEmptyDirs="no">
             <fileset dir="${ts.home}/install/jsf/docs" excludes="**svn**" />
 	    </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 	<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}" />
     </target>
     <target name="-create.latest.link"

--- a/release/tools/jsonb.xml
+++ b/release/tools/jsonb.xml
@@ -72,9 +72,10 @@
 		<fileset dir="${ts.home}/install/jsonb/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
               <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
 
       <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/jsonp.xml
+++ b/release/tools/jsonp.xml
@@ -64,10 +64,10 @@
 		<fileset dir="${ts.home}/install/${deliverable.name.lower}/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                 <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
           <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
 	</target>

--- a/release/tools/jsp.xml
+++ b/release/tools/jsp.xml
@@ -60,9 +60,10 @@
 		<copy todir="${deliverable.bundle.dir}/docs" includeEmptyDirs="no">
               <fileset dir="${ts.home}/install/jsp/docs" excludes="**svn**" />
 	   </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
             <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
         <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
         </copy>
     </target>

--- a/release/tools/jstl.xml
+++ b/release/tools/jstl.xml
@@ -67,9 +67,10 @@
 		<copy todir="${deliverable.bundle.dir}/docs" includeEmptyDirs="no">
               <fileset dir="${ts.home}/install/jstl/docs" excludes="**svn**" />
 	   </copy>
-           <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+           <!-- NOTICE will be EPL or EFTL specific: TBD-->
+           <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
               <fileset dir="${ts.home}" includes="NOTICE" />
-           </copy>
+           </copy-->
 
 	   <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/jta.xml
+++ b/release/tools/jta.xml
@@ -71,9 +71,10 @@
             <fileset dir="${common.bin.dir}"
                      includes="deploy/**/*"/>
         </copy>
-        <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+        <!-- NOTICE will be EPL or EFTL specific: TBD-->
+        <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
               <fileset dir="${ts.home}" includes="NOTICE" />
-        </copy>
+        </copy-->
 	<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	</copy>
     </target>

--- a/release/tools/saaj.xml
+++ b/release/tools/saaj.xml
@@ -78,10 +78,10 @@
 		<fileset dir="${ts.home}/install/${deliverable.name.lower}/other" 
 			includes="testsuite.jtt, vehicle.properties"/>
 	  </copy>
-
-          <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+          <!-- NOTICE will be EPL or EFTL specific: TBD-->
+          <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                 <fileset dir="${ts.home}" includes="NOTICE" />
-          </copy>
+          </copy-->
 
           <copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>

--- a/release/tools/securityapi.xml
+++ b/release/tools/securityapi.xml
@@ -81,9 +81,10 @@
                         <fileset dir="${ts.home}/install/${deliverable.name.lower}/docs"
                                  includes="assertions/*.html, *-ReleaseNotes.html" />
                 </copy>
-               <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+               <!-- NOTICE will be EPL or EFTL specific: TBD-->
+               <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                    <fileset dir="${ts.home}" includes="NOTICE" />
-               </copy>
+               </copy-->
 		<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
 	</target>

--- a/release/tools/servlet.xml
+++ b/release/tools/servlet.xml
@@ -87,9 +87,10 @@
             <fileset dir="${ts.home}/internal/docs/${deliverable.name.lower}" 
                      includes="ServletJavadocAssertions.html, ServletSpecAssertions.html" />
         </copy>
-               <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+               <!-- NOTICE will be EPL or EFTL specific: TBD-->
+               <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                    <fileset dir="${ts.home}" includes="NOTICE" />
-               </copy>
+               </copy-->
 		<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
 	</target>

--- a/release/tools/websocket.xml
+++ b/release/tools/websocket.xml
@@ -96,9 +96,11 @@
                 <copy todir="${deliverable.bundle.dir}/docs/assertions" includeEmptyDirs="no">
                         <fileset dir="${ts.home}/internal/docs/websocket" includes="WebSocketJavadocAssertions.html" />
                 </copy>
-                <copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
+
+                <!-- NOTICE will be EPL or EFTL specific: TBD-->
+                <!--copy todir="${deliverable.bundle.dir}" includeEmptyDirs="no">
                         <fileset dir="${ts.home}" includes="NOTICE" />
-                </copy>
+                </copy-->
 		<copy tofile="${deliverable.bundle.dir}/LICENSE.md" file="${ts.home}/${licensefile}">
 	  </copy>
 	</target>


### PR DESCRIPTION
removing incorrect NOTICE file from all TCK bundles for the jakartaee8 release.

The NOTICE file need to be EPL or EFTL specific. They will be included after the release.

Signed-off-by: alwin.joseph <alwin.joseph@oracle.com>