### PR TITLE
revert jsonb tck version increase, back to 1.0.1

### DIFF
--- a/release/tools/jsonb.xml
+++ b/release/tools/jsonb.xml
@@ -22,7 +22,7 @@
   <import file="../../bin/xml/ts.common.props.xml"/>
   
   <property name="deliverable.version" value="1.0"/>
-  <property name="deliverable.tck.version" value="1.0.2"/>
+  <property name="deliverable.tck.version" value="1.0.1"/>
   <property name="exclude.source.folder" value="com/sun/ts/tests/jsonb/cdi/**"/>
   
   <condition property="exclude.classes" value="">


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
We didn't need to update the jsonb tck version, as we don't have any additional jsonb tck changes yet (version 1.0.1 of jsonb tck contains latest jsonb tck tests).