### PR TITLE
Register consumer before the EventSource is open not to loose the message

### DIFF
--- a/src/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/sseeventsink/JAXRSClient.java
+++ b/src/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/sseeventsink/JAXRSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -311,8 +311,8 @@ public class JAXRSClient extends SSEJAXRSClient {
         .target(getAbsoluteUrl("stage"));
 
     try (SseEventSource source = SseEventSource.target(target).build()) {
-      source.open();
       source.register(holder::add);
+      source.open();
       sleepUntilHolderGetsFilled(holder);
       assertNotNull(holder.get(), "No message received");
       assertTrue(holder.get(0).readData().contains(SSEJAXRSClient.MESSAGE),


### PR DESCRIPTION
Signed-off-by: Jan Supol <jan.supol@oracle.com>