### PR TITLE
use 9.0 for deliverable.version and 9.0.0 for deliveriable.tck.version, also adjust some zip file names to use 9.0

### DIFF
--- a/release/tools/build-utils.xml
+++ b/release/tools/build-utils.xml
@@ -300,10 +300,10 @@ ${smoke.log.contents}
 		</copy>
 
 		<!-- Create symlinks for latest bundles -->
-		<symlink link="${target}/jakartaeetck_latest.zip" resource="jakartaeetck-8.0_${time.stamp.bundle.string}.zip" overwrite="true"/>
-		<symlink link="${target}/cts-internal_latest.zip" resource="cts-internal-8.0_${time.stamp.bundle.string}.zip" overwrite="true"/>
-		<!-- symlink link="${target}/wls-cts-internal_latest.zip" resource="wls-cts-internal-8.0_${time.stamp.bundle.string}.zip" overwrite="true"/ -->
-		<symlink link="${target}/jakartaee-smoke-8.0_latest.zip" resource="jakartaee-smoke-8.0_${time.stamp.bundle.string}.zip" overwrite="true"/>
+		<symlink link="${target}/jakartaeetck_latest.zip" resource="jakartaeetck-9.0_${time.stamp.bundle.string}.zip" overwrite="true"/>
+		<symlink link="${target}/cts-internal_latest.zip" resource="cts-internal-9.0_${time.stamp.bundle.string}.zip" overwrite="true"/>
+		<!-- symlink link="${target}/wls-cts-internal_latest.zip" resource="wls-cts-internal-9.0_${time.stamp.bundle.string}.zip" overwrite="true"/ -->
+		<symlink link="${target}/jakartaee-smoke-9.0_latest.zip" resource="jakartaee-smoke-9.0_${time.stamp.bundle.string}.zip" overwrite="true"/>
 
 	</target>
 
@@ -314,7 +314,7 @@ ${smoke.log.contents}
 		<symlink action="delete" link="${target}/jakartaeetck_latest.zip"/>
 		<symlink action="delete" link="${target}/cts-internal_latest.zip"/>
 		<!-- symlink action="delete" link="${target}/wls-cts-internal_latest.zip"/ -->
-		<symlink action="delete" link="${target}/jakartaee-smoke-8.0_latest.zip"/>
+		<symlink action="delete" link="${target}/jakartaee-smoke-9.0_latest.zip"/>
 	</target>
 
 

--- a/release/tools/jakartaee-tech-common.xml
+++ b/release/tools/jakartaee-tech-common.xml
@@ -23,8 +23,8 @@
     
     <!--    <property name="test.areas" value="samples"/> -->
 
-    <property name="deliverable.version"           value="8.0"/>
-    <property name="deliverable.tck.version"           value="8.0.2"/>
+    <property name="deliverable.version"           value="9.0"/>
+    <property name="deliverable.tck.version"           value="9.0.0"/>
 
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -29,8 +29,8 @@
     <property name="cts.internal.compat"           value="NULL"/>
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
-    <property name="deliverable.version"           value="8.0"/>
-    <property name="deliverable.tck.version"           value="8.0.2"/>
+    <property name="deliverable.version"           value="9.0"/>
+    <property name="deliverable.tck.version"           value="9.0.0"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxr/api/javax_xml_registry/Connection_asynch/**/*,


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Question, should we also update the standalone TCKs version now?