### PR TITLE
batch property name + switch to jakarta package changes

### DIFF
--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryInitProcessor.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryInitProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.chunkartifacts;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemProcessor;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemProcessor;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.InventoryRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryInitReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryInitReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -25,7 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import javax.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.api.chunk.AbstractItemReader;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryInitWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryInitWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -25,7 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
-import javax.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.api.chunk.AbstractItemWriter;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryProcessor.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -23,7 +23,7 @@ import com.ibm.jbatch.tck.artifacts.chunktypes.InventoryRecord;
 
 
 @javax.inject.Named("inventoryProcessor")
-public class InventoryProcessor implements javax.batch.api.chunk.ItemProcessor{
+public class InventoryProcessor implements jakarta.batch.api.chunk.ItemProcessor{
 
 	
 	@Override

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -26,9 +26,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.AbstractItemReader;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryStepListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.logging.Logger;
 
-import javax.batch.api.listener.AbstractStepListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/InventoryWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -25,8 +25,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemWriter;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/NumbersReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/NumbersReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -26,9 +26,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryInitProcessor.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryInitProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.chunkartifacts;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemProcessor;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemProcessor;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryInitReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryInitReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,7 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import javax.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.api.chunk.AbstractItemReader;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryInitWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryInitWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,7 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 
-import javax.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.api.chunk.AbstractItemWriter;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryProcessor.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Properties;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemProcessor;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -27,9 +27,9 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -26,9 +26,9 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemWriter;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/com/ibm/jbatch/tck/artifacts/reusable/CountInvocationsObjectParameterizationStepListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/reusable/CountInvocationsObjectParameterizationStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.listener.AbstractStepListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/reusable/CountInvocationsStepListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/reusable/CountInvocationsStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.listener.AbstractStepListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/reusable/MyBatchletImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/reusable/MyBatchletImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/reusable/MyParallelSubJobsExitStatusBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/reusable/MyParallelSubJobsExitStatusBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/reusable/SimpleJobListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/reusable/SimpleJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.listener.AbstractJobListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.listener.AbstractJobListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/reusable/TransitionTrackerBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/reusable/TransitionTrackerBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("transitionTrackerBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestChunkListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestChunkListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,10 +21,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Map;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.listener.ChunkListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.listener.ChunkListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestJobListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.listener.JobListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.listener.JobListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,7 +21,7 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.io.Serializable;
 
-import javax.batch.api.chunk.ItemReader;
+import jakarta.batch.api.chunk.ItemReader;
 
 @javax.inject.Named("artifactInstanceTestReader")
 public class ArtifactInstanceTestReader implements ItemReader {

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestStepListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,10 +22,10 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.listener.StepListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.listener.StepListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ArtifactInstanceTestWriter.java
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,7 +21,7 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.List;
 
-import javax.batch.api.chunk.ItemWriter;
+import jakarta.batch.api.chunk.ItemWriter;
 
 @javax.inject.Named("artifactInstanceTestWriter")
 public class ArtifactInstanceTestWriter implements ItemWriter {

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/BatchletRestartStateMachineImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/BatchletRestartStateMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Random;
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("batchletRestartStateMachineImpl")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/BatchletUsingStepContextImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/BatchletUsingStepContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,11 +21,11 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyPersistentUserData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ChunkOnErrorCheckpointListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ChunkOnErrorCheckpointListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -20,7 +20,7 @@ import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -38,9 +38,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.AbstractChunkListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.AbstractChunkListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ContextsGetIdJobContextTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ContextsGetIdJobContextTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("contextsGetIdJobContextTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ContextsGetIdStepContextTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ContextsGetIdStepContextTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("contextsGetIdStepContextTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DeciderTestsBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DeciderTestsBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,10 +21,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DeciderTestsDecider.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DeciderTestsDecider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,11 +19,11 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.Decider;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.StepExecution;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.Decider;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.StepExecution;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DeciderTestsJobListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DeciderTestsJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.listener.AbstractJobListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.listener.AbstractJobListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DefaultValueArrayWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DefaultValueArrayWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,10 +23,10 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemWriter;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingArrayItemProcessorImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingArrayItemProcessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemProcessor;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemProcessor;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingArrayItemReaderImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingArrayItemReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingItemProcessorImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingItemProcessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,7 +21,7 @@ import com.sun.ts.lib.util.TestUtil;
 
 
 
-import javax.batch.api.chunk.ItemProcessor;
+import jakarta.batch.api.chunk.ItemProcessor;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingItemReaderImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingItemReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.CheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingItemWriterImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingItemWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.api.chunk.AbstractItemWriter;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.CheckpointData;
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingSimpleArrayWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingSimpleArrayWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,9 +23,9 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemWriter;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingSimpleTimeArrayReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingSimpleTimeArrayReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingSimpleTimeArrayWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/DoSomethingSimpleTimeArrayWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,9 +23,9 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemWriter;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/FailRestartBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/FailRestartBatchlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.Batchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.Batchlet;
 import javax.inject.Inject;
 
 @javax.inject.Named("failRestartBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/FlowTransitionToDecisionTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/FlowTransitionToDecisionTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,7 +19,7 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.AbstractBatchlet;
+import jakarta.batch.api.AbstractBatchlet;
 
 @javax.inject.Named("flowTransitionToDecisionTestBatchlet")
 public class FlowTransitionToDecisionTestBatchlet extends AbstractBatchlet {

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/FlowTransitionToDecisionTestDecider.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/FlowTransitionToDecisionTestDecider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.Decider;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.api.Decider;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/FlowTransitionWithinFlowTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/FlowTransitionWithinFlowTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("flowTransitionWithinFlowTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/InventoryCheckpointAlgorithmNoOverride.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/InventoryCheckpointAlgorithmNoOverride.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,12 +22,12 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractCheckpointAlgorithm;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractCheckpointAlgorithm;
 import javax.inject.Inject;
 
 /*
-* Copyright 2012 International Business Machines Corp.
+* Copyright 2012, 2020 International Business Machines Corp.
 * 
 * See the NOTICE file distributed with this work for additional information
 * regarding copyright ownership. Licensed under the Apache License, 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/InventoryCheckpointAlgorithmOverride150.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/InventoryCheckpointAlgorithmOverride150.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,12 +22,12 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractCheckpointAlgorithm;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractCheckpointAlgorithm;
 import javax.inject.Inject;
 
 /*
-* Copyright 2012 International Business Machines Corp.
+* Copyright 2012, 2020 International Business Machines Corp.
 * 
 * See the NOTICE file distributed with this work for additional information
 * regarding copyright ownership. Licensed under the Apache License, 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/InventoryCheckpointAlgorithmOverride2.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/InventoryCheckpointAlgorithmOverride2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,12 +22,12 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractCheckpointAlgorithm;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractCheckpointAlgorithm;
 import javax.inject.Inject;
 
 /*
-* Copyright 2012 International Business Machines Corp.
+* Copyright 2012, 2020 International Business Machines Corp.
 * 
 * See the NOTICE file distributed with this work for additional information
 * regarding copyright ownership. Licensed under the Apache License, 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/JobAttributesTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/JobAttributesTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
 import javax.inject.Inject;
 
 @javax.inject.Named("jobAttributesTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/JobContextTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/JobContextTestBatchlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.Batchlet;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.Batchlet;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("jobContextTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/JobLevelPropertiesCountBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/JobLevelPropertiesCountBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Iterator;
 import java.util.Properties;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("jobLevelPropertiesCountBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/JobLevelPropertiesPropertyValueBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/JobLevelPropertiesPropertyValueBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Properties;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("jobLevelPropertiesPropertyValueBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/JobLevelPropertiesShouldNotBeAvailableThroughStepContextBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/JobLevelPropertiesShouldNotBeAvailableThroughStepContextBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Properties;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("jobLevelPropertiesShouldNotBeAvailableThroughStepContextBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ListenerOnErrorProcessor.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ListenerOnErrorProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -18,8 +18,8 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemProcessor;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemProcessor;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ListenerOnErrorReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ListenerOnErrorReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.io.Serializable;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemReader;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemReader;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ListenerOnErrorWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ListenerOnErrorWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.List;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemWriter;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemWriter;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MetricsStepListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MetricsStepListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,11 +22,11 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.listener.AbstractStepListener;
-import javax.batch.runtime.Metric;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.batch.runtime.Metric;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("metricsStepListener")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MultipleExitStatusBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MultipleExitStatusBatchlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("multipleExitStatusBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyBatchletWithPropertiesImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyBatchletWithPropertiesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.lang.reflect.Field;
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
 import javax.inject.Inject;
 
 @javax.inject.Named("myBatchletWithPropertiesImpl")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyChunkListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyChunkListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,11 +19,11 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.listener.AbstractChunkListener;
-import javax.batch.api.listener.StepListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.listener.AbstractChunkListener;
+import jakarta.batch.api.listener.StepListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyCustomCheckpointAlgorithm.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyCustomCheckpointAlgorithm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -23,15 +23,15 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractCheckpointAlgorithm;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractCheckpointAlgorithm;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyPersistentRestartUserData;
 
 /*
-* Copyright 2012 International Business Machines Corp.
+* Copyright 2012, 2020 International Business Machines Corp.
 * 
 * See the NOTICE file distributed with this work for additional information
 * regarding copyright ownership. Licensed under the Apache License, 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyCustomCheckpointListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyCustomCheckpointListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -20,7 +20,7 @@ import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -38,9 +38,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.AbstractChunkListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.AbstractChunkListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyItemProcessListenerImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyItemProcessListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.listener.AbstractItemProcessListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.listener.AbstractItemProcessListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyItemReadListenerImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyItemReadListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.listener.AbstractItemReadListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.listener.AbstractItemReadListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyItemWriteListenerImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyItemWriteListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.listener.AbstractItemWriteListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.listener.AbstractItemWriteListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("myItemWriteListenerImpl")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyLongRunningBatchletImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyLongRunningBatchletImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,10 +22,10 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Random;
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.reusable.StopOnBulletinBoardTestData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyMultipleExceptionsRetryReadListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyMultipleExceptionsRetryReadListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.RetryReadListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.RetryReadListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionAnalyzer.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionAnalyzer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -21,10 +21,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.io.Serializable;
 
-import javax.batch.api.partition.AbstractPartitionAnalyzer;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.partition.AbstractPartitionAnalyzer;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.reusable.ExternalizableString;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionCollector.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.io.Externalizable;
 
-import javax.batch.api.partition.PartitionCollector;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.partition.PartitionCollector;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.reusable.ExternalizableString;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionMapper.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Properties;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.partition.PartitionMapper;
-import javax.batch.api.partition.PartitionPlan;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.partition.PartitionMapper;
+import jakarta.batch.api.partition.PartitionPlan;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.specialized.MyPartitionPlan;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionPlan.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionPlan.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,7 +19,7 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.partition.PartitionPlanImpl;
+import jakarta.batch.api.partition.PartitionPlanImpl;
 
 @javax.inject.Named("myPartitionPlan")
 public class MyPartitionPlan extends PartitionPlanImpl {

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionReducer.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionReducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.partition.PartitionReducer;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.partition.PartitionReducer;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("myPartitionReducer")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionedBatchletImpl.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyPartitionedBatchletImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,10 +21,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("myPartitionedBatchletImpl")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyRetryProcessListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyRetryProcessListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.RetryProcessListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.chunk.listener.RetryProcessListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyRetryReadListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyRetryReadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.RetryReadListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.chunk.listener.RetryReadListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyRetryWriteListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyRetryWriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.logging.Logger;
 import java.util.List;
 
-import javax.batch.api.chunk.listener.RetryWriteListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.chunk.listener.RetryWriteListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MySimpleCustomCheckpointAlgorithm.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MySimpleCustomCheckpointAlgorithm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -20,7 +20,7 @@ import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
 /*
-* Copyright 2012 International Business Machines Corp.
+* Copyright 2012, 2020 International Business Machines Corp.
 * 
 * See the NOTICE file distributed with this work for additional information
 * regarding copyright ownership. Licensed under the Apache License, 
@@ -38,7 +38,7 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.AbstractCheckpointAlgorithm;
+import jakarta.batch.api.chunk.AbstractCheckpointAlgorithm;
 
 @javax.inject.Named("mySimpleCustomCheckpointAlgorithm")
 public class MySimpleCustomCheckpointAlgorithm extends AbstractCheckpointAlgorithm {

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipProcessListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipProcessListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipProcessListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipProcessListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipReadListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipReadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipReadListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipReadListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipReaderExceedListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipReaderExceedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipReadListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipReadListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipWriteListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MySkipWriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipWriteListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipWriteListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyTimeCheckpointListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyTimeCheckpointListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -20,7 +20,7 @@ import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -38,10 +38,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.listener.AbstractChunkListener;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.listener.AbstractChunkListener;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/MyUniversalListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/MyUniversalListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,10 +22,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.listener.JobListener;
-import javax.batch.api.listener.StepListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.listener.JobListener;
+import jakarta.batch.api.listener.StepListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("myUniversalListener")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NullChkPtInfoReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NullChkPtInfoReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.ItemReader;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.chunk.ItemReader;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("nullChkPtInfoReader")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NullChkPtInfoWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NullChkPtInfoWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -23,8 +23,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.ItemWriter;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.chunk.ItemWriter;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("nullChkPtInfoWriter")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryProcessListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryProcessListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.RetryProcessListener;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.RetryProcessListener;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryReadListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryReadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.RetryReadListener;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.RetryReadListener;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryWriteListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryWriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.RetryWriteListener;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.RetryWriteListener;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipProcessListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipProcessListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipProcessListener;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipProcessListener;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipReadListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipReadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipReadListener;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipReadListener;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipWriteListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipWriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.api.chunk.listener.SkipWriteListener;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.chunk.listener.SkipWriteListener;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/OverrideOnAttributeValuesUponRestartBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/OverrideOnAttributeValuesUponRestartBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,10 +21,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("overrideOnAttributeValuesUponRestartBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ParsingPartitionAnalyzer.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ParsingPartitionAnalyzer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,10 +19,10 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.partition.AbstractPartitionAnalyzer;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.partition.AbstractPartitionAnalyzer;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SkipProcessor.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SkipProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemProcessor;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemProcessor;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SkipReader.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SkipReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SkipReaderMultipleExceptions.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SkipReaderMultipleExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,8 +22,8 @@ import com.sun.ts.lib.util.TestUtil;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.AbstractItemReader;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.AbstractItemReader;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SkipWriter.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SkipWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemWriter;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemWriter;
 import javax.inject.Inject;
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ArrayIndexCheckpointData;

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SplitFlowTransitionLoopTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SplitFlowTransitionLoopTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("splitFlowTransitionLoopTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SplitTransitionToDecisionTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SplitTransitionToDecisionTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,7 +19,7 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.AbstractBatchlet;
+import jakarta.batch.api.AbstractBatchlet;
 
 @javax.inject.Named("splitTransitionToDecisionTestBatchlet")
 public class SplitTransitionToDecisionTestBatchlet extends AbstractBatchlet {

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SplitTransitionToDecisionTestDecider.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SplitTransitionToDecisionTestDecider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.Decider;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.api.Decider;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/SplitTransitionToStepTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/SplitTransitionToStepTestBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("splitTransitionToStepTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitJobListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.listener.AbstractJobListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.listener.AbstractJobListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitStateMachineVariation1Batchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitStateMachineVariation1Batchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,10 +22,10 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Random;
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("startLimitStateMachineVariation1Batchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitStateMachineVariation2Batchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitStateMachineVariation2Batchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,10 +22,10 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Random;
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("startLimitStateMachineVariation2Batchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitStateMachineVariation3Batchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StartLimitStateMachineVariation3Batchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,10 +21,10 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.api.BatchProperty;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("startLimitStateMachineVariation3Batchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StepContextTestBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StepContextTestBatchlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.Batchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.Batchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("stepContextTestBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StepLevelPropertiesCountBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StepLevelPropertiesCountBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,9 +22,9 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Iterator;
 import java.util.Properties;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("stepLevelPropertiesCountBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StepLevelPropertiesPropertyValueBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StepLevelPropertiesPropertyValueBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Properties;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("stepLevelPropertiesPropertyValueBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/StepLevelPropertiesShouldNotBeAvailableThroughJobContextBatchlet.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/StepLevelPropertiesShouldNotBeAvailableThroughJobContextBatchlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,9 +21,9 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.Properties;
 
-import javax.batch.api.AbstractBatchlet;
-import javax.batch.runtime.context.JobContext;
-import javax.batch.runtime.context.StepContext;
+import jakarta.batch.api.AbstractBatchlet;
+import jakarta.batch.runtime.context.JobContext;
+import jakarta.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("stepLevelPropertiesShouldNotBeAvailableThroughJobContextBatchlet")

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ThreadTrackingJobListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ThreadTrackingJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -21,8 +21,8 @@ import com.sun.ts.lib.util.TestUtil;
 
 import java.util.logging.Logger;
 
-import javax.batch.api.listener.AbstractJobListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.listener.AbstractJobListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/ThreadTrackingStepListener.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/ThreadTrackingStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,8 +19,8 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.listener.AbstractStepListener;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 

--- a/src/com/ibm/jbatch/tck/artifacts/specialized/TransitionDecider.java
+++ b/src/com/ibm/jbatch/tck/artifacts/specialized/TransitionDecider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,
@@ -19,10 +19,10 @@ package com.ibm.jbatch.tck.artifacts.specialized;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.api.BatchProperty;
-import javax.batch.api.Decider;
-import javax.batch.runtime.StepExecution;
-import javax.batch.runtime.context.JobContext;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.Decider;
+import jakarta.batch.runtime.StepExecution;
+import jakarta.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 @javax.inject.Named("transitionDecider")

--- a/src/com/ibm/jbatch/tck/polling/TCKPollingExecutionWaiterFactory.java
+++ b/src/com/ibm/jbatch/tck/polling/TCKPollingExecutionWaiterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,11 +19,11 @@ package com.ibm.jbatch.tck.polling;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.operations.JobOperator;
-import javax.batch.operations.JobSecurityException;
-import javax.batch.operations.NoSuchJobExecutionException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobOperator;
+import jakarta.batch.operations.JobSecurityException;
+import jakarta.batch.operations.NoSuchJobExecutionException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 import java.lang.IllegalStateException;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/com/ibm/jbatch/tck/spi/JobExecutionWaiter.java
+++ b/src/com/ibm/jbatch/tck/spi/JobExecutionWaiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,7 +19,7 @@ package com.ibm.jbatch.tck.spi;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobExecution;
 
 public interface JobExecutionWaiter {
 	JobExecution awaitTermination() throws JobExecutionTimeoutException;

--- a/src/com/ibm/jbatch/tck/spi/JobExecutionWaiterFactory.java
+++ b/src/com/ibm/jbatch/tck/spi/JobExecutionWaiterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,7 +19,7 @@ package com.ibm.jbatch.tck.spi;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.operations.JobOperator;
+import jakarta.batch.operations.JobOperator;
 
 public interface JobExecutionWaiterFactory {
 	public JobExecutionWaiter createWaiter(long executionId, JobOperator jobOp, long sleepTime);

--- a/src/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
+++ b/src/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
@@ -104,8 +104,8 @@ TestUtil.logTrace(METHOD);
 
 			Properties jobParams = new Properties();
 
-			jobParams.put("javax.transaction.global.mode", "true");
-			jobParams.put("javax.transaction.global.timeout", "20");
+			jobParams.put("jakarta.transaction.global.mode", "true");
+			jobParams.put("jakarta.transaction.global.timeout", "20");
 			jobParams.put("init.numbers.quantity", initNumbers.toString());
 			jobParams.put("forced.fail.count.read", forcedFailCountRead.toString());
 			jobParams.put("forced.fail.count.write", forcedFailCountWrite.toString());
@@ -153,8 +153,8 @@ TestUtil.logTrace(METHOD);
 
 			Properties jobParams = new Properties();
 
-			jobParams.put("javax.transaction.global.mode", "true");
-			jobParams.put("javax.transaction.global.timeout", "20");
+			jobParams.put("jakarta.transaction.global.mode", "true");
+			jobParams.put("jakarta.transaction.global.timeout", "20");
 			jobParams.put("init.numbers.quantity", initNumbers.toString());
 			jobParams.put("forced.fail.count.read", forcedFailCountRead.toString());
 			jobParams.put("forced.fail.count.write", forcedFailCountWrite.toString());
@@ -202,8 +202,8 @@ TestUtil.logTrace(METHOD);
 
 			Properties jobParams = new Properties();
 
-			jobParams.put("javax.transaction.global.mode", "true");
-			jobParams.put("javax.transaction.global.timeout", "20");
+			jobParams.put("jakarta.transaction.global.mode", "true");
+			jobParams.put("jakarta.transaction.global.timeout", "20");
 			jobParams.put("init.numbers.quantity", initNumbers.toString());
 			jobParams.put("forced.fail.count.read", forcedFailCountRead.toString());
 			jobParams.put("forced.fail.count.write", forcedFailCountWrite.toString());
@@ -249,13 +249,13 @@ TestUtil.logTrace(METHOD);
 
 			Properties jobParams = new Properties();
 			TestUtil.logMsg("Create job parameters for execution #1:");
-			TestUtil.logMsg("javax.transaction.global.timeout=300");
+			TestUtil.logMsg("jakarta.transaction.global.timeout=300");
 			TestUtil.logMsg("commit.interval="+itemCount.toString());
 			TestUtil.logMsg("init.inventory.quantity="+initInventory.toString());
 			TestUtil.logMsg("forced.fail.count="+forcedFailCount.toString());
 			TestUtil.logMsg("dummy.delay.seconds="+dummyDelay.toString());
 			TestUtil.logMsg("expected.inventory="+expectedInventory.toString());
-			jobParams.put("javax.transaction.global.timeout", "300");
+			jobParams.put("jakarta.transaction.global.timeout", "300");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
 			jobParams.put("forced.fail.count", forcedFailCount.toString());
@@ -304,13 +304,13 @@ TestUtil.logTrace(METHOD);
 			Properties jobParams = new Properties();
 
 			TestUtil.logMsg("Create job parameters for execution #1:");
-			TestUtil.logMsg("javax.transaction.global.timeout=300");
+			TestUtil.logMsg("jakarta.transaction.global.timeout=300");
 			TestUtil.logMsg("commit.interval="+itemCount.toString());
 			TestUtil.logMsg("init.inventory.quantity="+initInventory.toString());
 			TestUtil.logMsg("forced.fail.count="+forcedFailCount.toString());
 			TestUtil.logMsg("dummy.delay.seconds="+dummyDelay.toString());
 			TestUtil.logMsg("expected.inventory="+expectedInventory.toString());
-			jobParams.put("javax.transaction.global.timeout", "300");
+			jobParams.put("jakarta.transaction.global.timeout", "300");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
 			jobParams.put("forced.fail.count", forcedFailCount.toString());
@@ -357,13 +357,13 @@ TestUtil.logTrace(METHOD);
 			Properties jobParams = new Properties();
 
 			TestUtil.logMsg("Create job parameters for execution #1:");
-			TestUtil.logMsg("javax.transaction.global.timeout=300");
+			TestUtil.logMsg("jakarta.transaction.global.timeout=300");
 			TestUtil.logMsg("commit.interval="+itemCount.toString());
 			TestUtil.logMsg("init.inventory.quantity="+initInventory.toString());
 			TestUtil.logMsg("forced.fail.count="+forcedFailCount.toString());
 			TestUtil.logMsg("dummy.delay.seconds="+dummyDelay.toString());
 			TestUtil.logMsg("expected.inventory="+expectedInventory.toString());
-			jobParams.put("javax.transaction.global.timeout", "300");
+			jobParams.put("jakarta.transaction.global.timeout", "300");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
 			jobParams.put("forced.fail.count", forcedFailCount.toString());
@@ -401,7 +401,7 @@ TestUtil.logTrace(METHOD);
 
 	/*
 	 * @testName: testGlobalTranNoDelayLongTimeout
-	 * @assertion: Step-level property of 'javax.transaction.global.timeout' 
+	 * @assertion: Step-level property of 'jakarta.transaction.global.timeout' 
 	 * _Strategy: This test sets a long (180 sec.) checkpoint timeout explicitly in the JSL, and it does not
 	 *                 use any delay or sleep, so it just confirms that the timeout doesn't hit and the chunk completes
 	 *                 normally.
@@ -460,13 +460,13 @@ TestUtil.logTrace(METHOD);
 	 *  (this test name is now a misnomer since we changed the test logic to exclude the "short timeout")
 	 * 
 	 * @testName: testGlobalTranLongDelayMixOfLongTimeoutStepsAndShortTimeoutSteps
-	 * @assertion: Step-level property of 'javax.transaction.global.timeout', including defaults.  Also shows that 
+	 * @assertion: Step-level property of 'jakarta.transaction.global.timeout', including defaults.  Also shows that 
 	 *             job-level property is ignored.
 	 * _Strategy: This test uses three steps that are basically the same, reading and writing from the same tables
 	 *                 (along with some helper steps in between to init the tables).
 	 *                 Two of the steps are configured with long timeouts, and one with a short timeout. 
 	 *                 The long timeouts involve variations:
-	 *                  - step 2 : <property name="javax.transaction.global.timeout" value="0" />
+	 *                  - step 2 : <property name="jakarta.transaction.global.timeout" value="0" />
 	 *                        (shows that '0' means indefinite timeout)
 	 *                  - step 3 : No property specified
 	 *                        (shows that the default is 180 seconds).

--- a/src/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
+++ b/src/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;

--- a/src/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,7 +23,7 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.BatchStatus;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/ChunkTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/ChunkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -24,11 +24,11 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 import java.util.List;
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.JobInstance;
-import javax.batch.runtime.Metric;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobInstance;
+import jakarta.batch.runtime.Metric;
+import jakarta.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyPersistentRestartUserData;
 import com.ibm.jbatch.tck.artifacts.specialized.MyItemProcessListenerImpl;

--- a/src/com/ibm/jbatch/tck/tests/jslxml/ContextAndListenerTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/ContextAndListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/ContextsGetIdTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/ContextsGetIdTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/DeciderTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/DeciderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.operations.JobStartException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/ExecuteTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/ExecuteTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -24,8 +24,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.artifacts.specialized.BatchletUsingStepContextImpl;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;

--- a/src/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,8 +25,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/FlowTransitioningTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/FlowTransitioningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import javax.batch.operations.JobStartException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/JobAttributeRestartTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/JobAttributeRestartTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,12 +25,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import javax.batch.operations.JobRestartException;
-import javax.batch.operations.JobStartException;
-import javax.batch.operations.NoSuchJobException;
-import javax.batch.operations.NoSuchJobExecutionException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobRestartException;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.operations.NoSuchJobException;
+import jakarta.batch.operations.NoSuchJobExecutionException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/JobExecutableSequenceTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/JobExecutableSequenceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import javax.batch.operations.JobStartException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/JobLevelPropertiesTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/JobLevelPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,8 +25,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/JobOperatorTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/JobOperatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -26,15 +26,15 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.operations.JobExecutionAlreadyCompleteException;
-import javax.batch.operations.JobExecutionIsRunningException;
-import javax.batch.operations.JobRestartException;
-import javax.batch.operations.NoSuchJobException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.JobInstance;
-import javax.batch.runtime.Metric;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.operations.JobExecutionAlreadyCompleteException;
+import jakarta.batch.operations.JobExecutionIsRunningException;
+import jakarta.batch.operations.JobRestartException;
+import jakarta.batch.operations.NoSuchJobException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobInstance;
+import jakarta.batch.runtime.Metric;
+import jakarta.batch.runtime.StepExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/MetricsTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/MetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,10 +25,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.Metric;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.Metric;
+import jakarta.batch.runtime.StepExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/ParallelExecutionTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/ParallelExecutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -28,9 +28,9 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.StepExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,7 +25,7 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
 import java.io.File;
 import java.util.Properties;
 
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/RestartNotMostRecentTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/RestartNotMostRecentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
 
-import javax.batch.operations.JobExecutionNotMostRecentException;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobExecutionNotMostRecentException;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/RetryListenerTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/RetryListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/SplitFlowTransitionLoopTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/SplitFlowTransitionLoopTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -23,8 +23,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/SplitTransitioningTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/SplitTransitioningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,9 +25,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import javax.batch.operations.JobStartException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/StartLimitTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/StartLimitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,8 +25,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 import java.util.List;
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.StepExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/StepExecutionTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/StepExecutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -29,10 +29,10 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.Metric;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.Metric;
+import jakarta.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyBatchletImpl;
 import com.ibm.jbatch.tck.artifacts.reusable.MyPersistentUserData;

--- a/src/com/ibm/jbatch/tck/tests/jslxml/StepLevelPropertiesTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/StepLevelPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -25,8 +25,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 

--- a/src/com/ibm/jbatch/tck/tests/jslxml/StopOrFailOnExitStatusWithRestartTests.java
+++ b/src/com/ibm/jbatch/tck/tests/jslxml/StopOrFailOnExitStatusWithRestartTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -24,8 +24,8 @@ import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
 
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/utils/JobOperatorBridge.java
+++ b/src/com/ibm/jbatch/tck/utils/JobOperatorBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2012, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -24,21 +24,21 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.batch.operations.JobExecutionAlreadyCompleteException;
-import javax.batch.operations.JobExecutionIsRunningException;
-import javax.batch.operations.JobExecutionNotMostRecentException;
-import javax.batch.operations.JobExecutionNotRunningException;
-import javax.batch.operations.JobOperator;
-import javax.batch.operations.JobRestartException;
-import javax.batch.operations.JobSecurityException;
-import javax.batch.operations.JobStartException;
-import javax.batch.operations.NoSuchJobException;
-import javax.batch.operations.NoSuchJobExecutionException;
-import javax.batch.operations.NoSuchJobInstanceException;
-import javax.batch.runtime.BatchRuntime;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.JobInstance;
-import javax.batch.runtime.StepExecution;
+import jakarta.batch.operations.JobExecutionAlreadyCompleteException;
+import jakarta.batch.operations.JobExecutionIsRunningException;
+import jakarta.batch.operations.JobExecutionNotMostRecentException;
+import jakarta.batch.operations.JobExecutionNotRunningException;
+import jakarta.batch.operations.JobOperator;
+import jakarta.batch.operations.JobRestartException;
+import jakarta.batch.operations.JobSecurityException;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.operations.NoSuchJobException;
+import jakarta.batch.operations.NoSuchJobExecutionException;
+import jakarta.batch.operations.NoSuchJobInstanceException;
+import jakarta.batch.runtime.BatchRuntime;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobInstance;
+import jakarta.batch.runtime.StepExecution;
 
 
 

--- a/src/com/ibm/jbatch/tck/utils/TCKJobExecution.java
+++ b/src/com/ibm/jbatch/tck/utils/TCKJobExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -19,9 +19,9 @@ package com.ibm.jbatch.tck.utils;
 import com.sun.ts.lib.harness.*;
 import com.sun.ts.lib.util.TestUtil;
 
-import javax.batch.operations.JobSecurityException;
-import javax.batch.operations.NoSuchJobExecutionException;
-import javax.batch.runtime.JobExecution;
+import jakarta.batch.operations.JobSecurityException;
+import jakarta.batch.operations.NoSuchJobExecutionException;
+import jakarta.batch.runtime.JobExecution;
 
 public interface TCKJobExecution extends JobExecution {
 	

--- a/src/com/ibm/jbatch/tck/utils/TCKJobExecutionWrapper.java
+++ b/src/com/ibm/jbatch/tck/utils/TCKJobExecutionWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 International Business Machines Corp.
+ * Copyright 2013, 2020 International Business Machines Corp.
  * 
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License, 
@@ -22,12 +22,12 @@ import com.sun.ts.lib.util.TestUtil;
 import java.util.Date;
 import java.util.Properties;
 
-import javax.batch.operations.JobOperator;
-import javax.batch.operations.JobSecurityException;
-import javax.batch.operations.NoSuchJobExecutionException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.JobInstance;
+import jakarta.batch.operations.JobOperator;
+import jakarta.batch.operations.JobSecurityException;
+import jakarta.batch.operations.NoSuchJobExecutionException;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobInstance;
 
 public class TCKJobExecutionWrapper implements TCKJobExecution {
 


### PR DESCRIPTION
This pr only has three package name changes.  It is the result of applying the following commands:

> find -name "*.java" -type f| xargs sed -i 's/javax\.annotation\.security\./jakarta\.annotation\.security\./g'
> find -name "*.java" -type f| xargs sed -i 's/javax\.annotation\.sql\./jakarta\.annotation\.sql\./g'
> find -name "*.java" -type f| xargs sed -i 's/javax\.batch\./jakarta\.batch\./g'

And committing the changed sources as separate commits.

Is anyone else already doing this?  

Does anyone know which files in the platform TCK need to be updated to bring in the EE 9 SPEC API artifacts?