### PR TITLE
Update download URL for GitHub pages website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ description: [Source code and resources to build and run the Jakarta EE TCK suit
 
 links:
   source: https://github.com/eclipse-ee4j/jakartaee-tck
-  download: http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8/promoted/jakartaeetck-8.0.2.zip
+  download: https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8/promoted/jakartaeetck-8.0.2.zip
   mailinglist: https://accounts.eclipse.org/mailing-list/jakartaee-tck-dev

--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ description: [Source code and resources to build and run the Jakarta EE TCK suit
 
 links:
   source: https://github.com/eclipse-ee4j/jakartaee-tck
-  download: https://download.eclipse.org/ee4j/jakartaee-tck/8.0.1/nightly/javaeetck.zip
+  download: http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee8/promoted/jakartaeetck-8.0.2.zip
   mailinglist: https://accounts.eclipse.org/mailing-list/jakartaee-tck-dev


### PR DESCRIPTION
This PR updates the download URL on this page: https://eclipse-ee4j.github.io/jakartaee-tck/ to point to the latest released 8.0.2 TCK zip, as opposed to and old nightly URL which no longer exists.

Signed-off-by: Jonathan Gallimore <jgallimore@tomitribe.com>