### PR TITLE
convert Copyright dates to match Eclipse rules eclipse.org/projects/handbook/#ip-copyright-headers

### DIFF
--- a/install/jakartaee/bin/ts.jte.jdk9
+++ b/install/jakartaee/bin/ts.jte.jdk9
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_50/TestBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_50/TestBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat14_50/TestBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat14_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat14_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/compat14_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/casesens/CaseBeanEJB.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean2EJB.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejblink/path/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejbref/casesens/ReferencedBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejbref/casesens/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejbref/casesens/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejbref/casesens/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejbref/casesens/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejbref/casesens/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejbref/scope/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejbref/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/appclient/deploy/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/altDD/PainterBean.java
+++ b/src/com/sun/ts/tests/assembly/altDD/PainterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/altDD/PainterBeanEJB.java
+++ b/src/com/sun/ts/tests/assembly/altDD/PainterBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/altDD/PainterBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/altDD/PainterBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/classpath/ejb/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/classpath/ejb/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/classpath/ejb/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/classpath/ejb/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/ReferencedBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/ReferencedBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/ReferencedBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/ReferencedBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/ReferencedBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_50/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_50/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat14_50/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat14_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat14_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat14_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/standalone/jar/TestBean.java
+++ b/src/com/sun/ts/tests/assembly/standalone/jar/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/standalone/jar/TestBeanHome.java
+++ b/src/com/sun/ts/tests/assembly/standalone/jar/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/BMPExternal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/BMPExternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/BMPExternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/BMPExternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/BMPInternal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/BMPInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/BMPInternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/BMPInternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP11External.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP11External.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP11ExternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP11ExternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP11Internal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP11Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP11InternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP11InternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP20External.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP20External.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP20ExternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP20ExternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP20Internal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP20Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/CMP20InternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/CMP20InternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatefulExternal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatefulExternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatefulExternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatefulExternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatefulInternal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatefulInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatefulInternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatefulInternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatelessExternal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatelessExternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatelessExternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatelessExternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatelessInternal.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatelessInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/refbean/StatelessInternalHome.java
+++ b/src/com/sun/ts/tests/assembly/util/refbean/StatelessInternalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.java
+++ b/src/com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/CoffeeBean.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/CoffeeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/CoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/CoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/DataSourceCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/DataSourceCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/TxCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/TxCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/CompoundPKCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/CompoundPKCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/CompoundPKDSCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/CompoundPKDSCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/FloatPKCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/FloatPKCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/FloatPKDSCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/FloatPKDSCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/LongPKCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/LongPKCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/LongPKDSCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/LongPKDSCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/StringPKCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/StringPKCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/dao/coffee/variants/StringPKDSCoffeeDAO.java
+++ b/src/com/sun/ts/tests/common/dao/coffee/variants/StringPKDSCoffeeDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20Callee.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20Callee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeEJB.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeHome.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeLocal.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeLocalHome.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/CMP20CalleeLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCallee.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCallee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeEJB.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeHome.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeLocal.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeLocalHome.java
+++ b/src/com/sun/ts/tests/common/ejb/calleebeans/StatefulCalleeLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/dba/CompoundDBSupport.java
+++ b/src/com/sun/ts/tests/common/ejb/dba/CompoundDBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/dba/FloatDBSupport.java
+++ b/src/com/sun/ts/tests/common/ejb/dba/FloatDBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/dba/IntegerDBSupport.java
+++ b/src/com/sun/ts/tests/common/ejb/dba/IntegerDBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/dba/LongDBSupport.java
+++ b/src/com/sun/ts/tests/common/ejb/dba/LongDBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/dba/StringDBSupport.java
+++ b/src/com/sun/ts/tests/common/ejb/dba/StringDBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/wrappers/BMPWrapper.java
+++ b/src/com/sun/ts/tests/common/ejb/wrappers/BMPWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/wrappers/CMP11Wrapper.java
+++ b/src/com/sun/ts/tests/common/ejb/wrappers/CMP11Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/wrappers/CMP20Wrapper.java
+++ b/src/com/sun/ts/tests/common/ejb/wrappers/CMP20Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/wrappers/MDBWrapper.java
+++ b/src/com/sun/ts/tests/common/ejb/wrappers/MDBWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/wrappers/StatefulWrapper.java
+++ b/src/com/sun/ts/tests/common/ejb/wrappers/StatefulWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.java
+++ b/src/com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
+++ b/src/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/appmanagedNoTx/AppManagedNoTxVehicleBean.java
+++ b/src/com/sun/ts/tests/common/vehicle/appmanagedNoTx/AppManagedNoTxVehicleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicle.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicleHome.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicleHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicleRemote.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicleRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicleRunner.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejb/EJBVehicleRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejb3share/EJB3ShareBaseBean.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejb3share/EJB3ShareBaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejbembed/EJBEmbedRunner.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejbembed/EJBEmbedRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejbembed/InjectionResolver.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejbembed/InjectionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/ejbliteshare/EJBLiteClientIF.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejbliteshare/EJBLiteClientIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/stateful3/Stateful3VehicleBean.java
+++ b/src/com/sun/ts/tests/common/vehicle/stateful3/Stateful3VehicleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/stateless3/Stateless3VehicleBean.java
+++ b/src/com/sun/ts/tests/common/vehicle/stateless3/Stateless3VehicleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicle.java.src
+++ b/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicle.java.src
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicleHome.java
+++ b/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicleHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicleRemote.java
+++ b/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicleRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicleRunner.java
+++ b/src/com/sun/ts/tests/common/vehicle/wsejb/WSEJBVehicleRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/common/vehicle/wsservlet/WSServletVehicle.java.src
+++ b/src/com/sun/ts/tests/common/vehicle/wsservlet/WSServletVehicle.java.src
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TxECMPBean.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TxECMPBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TxECMPBeanEJB.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TxECMPBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TxECMPBeanHome.java
+++ b/src/com/sun/ts/tests/compat12/ejb/Tx_Single/TxECMPBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/entitycmptest/Client.java
+++ b/src/com/sun/ts/tests/compat12/ejb/entitycmptest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/entitycmptest/TestBean.java
+++ b/src/com/sun/ts/tests/compat12/ejb/entitycmptest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/entitycmptest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/compat12/ejb/entitycmptest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/entitycmptest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/compat12/ejb/entitycmptest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/Account.java
+++ b/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/AccountBean.java
+++ b/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/AccountBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/AccountHome.java
+++ b/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/AccountHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/compat12/ejb/jspejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/Client.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/SecTest.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/SecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/SecTestEJB.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/SecTestHome.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/SecTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/SecTestRoleRef.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/SecTestRoleRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat12/ejb/sec/SecTestRoleRefHome.java
+++ b/src/com/sun/ts/tests/compat12/ejb/sec/SecTestRoleRefHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/AEJB.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/ALocal.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/ALocalHome.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/BEJB.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/BLocal.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/BLocalHome.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/Bean.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/BeanEJB.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/BeanHome.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/oneXmany/Client.java
+++ b/src/com/sun/ts/tests/compat13/ejb/oneXmany/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/Client.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/TestBean.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/TestBeanHome.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/TxCommonBean.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/TxCommonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/TxCommonBeanEJB.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/TxCommonBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/compat13/ejb/tx/TxCommonBeanHome.java
+++ b/src/com/sun/ts/tests/compat13/ejb/tx/TxCommonBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/deployment/Deployment.java
+++ b/src/com/sun/ts/tests/connector/deployment/Deployment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/deployment/DeploymentClient.java
+++ b/src/com/sun/ts/tests/connector/deployment/DeploymentClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/deployment/DeploymentEJB.java
+++ b/src/com/sun/ts/tests/connector/deployment/DeploymentEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/deployment/DeploymentHome.java
+++ b/src/com/sun/ts/tests/connector/deployment/DeploymentHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanA.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanAEJB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanAHome.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanBEJB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanBHome.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/Client.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/TestBean.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/TestBeanHome.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing2/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanA.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanAEJB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanAHome.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanBEJB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanBHome.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/Client.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/TestBean.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/TestBeanHome.java
+++ b/src/com/sun/ts/tests/connector/localTx/transaction/conSharing3/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/mdb/JCAMessageBean.java
+++ b/src/com/sun/ts/tests/connector/mdb/JCAMessageBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/mdb/MessageBean.java
+++ b/src/com/sun/ts/tests/connector/mdb/MessageBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/mdb/MessageBeanOne.java
+++ b/src/com/sun/ts/tests/connector/mdb/MessageBeanOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATest.java
+++ b/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATestClient.java
+++ b/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATestEJB.java
+++ b/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATestHome.java
+++ b/src/com/sun/ts/tests/connector/xa/transaction/jta/JTATestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/allowedmethodstest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/argsemantics/CallerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/argsemantics/CallerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/argsemantics/CallerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/argsemantics/CallerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitybeantest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/entitycontexttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/handletest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/multiclienttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/nonreentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/bmp/reentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/argsemantics/CallerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/argsemantics/CallerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/argsemantics/CallerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/argsemantics/CallerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/complexpktest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitybeantest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/entitycontexttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/handletest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/multiclienttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/nonreentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp/reentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/allowedmethodstest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/argsemantics/CallerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/argsemantics/CallerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/argsemantics/CallerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/argsemantics/CallerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItem.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/LineItemLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/complexpktest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitybeantest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycmptest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPath.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/FastPathLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/entitycontexttest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/handletest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/homemethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/multiclienttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/LoopBackLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/SBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/SBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/SBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/SBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/SBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/SBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/nonreentranttest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/LoopBackLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/SBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/SBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/SBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/SBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/SBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/SBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/reentranttest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/cmp20/unknownpktest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/A.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/AHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/AHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/B.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/BHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/BHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/lrapitest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/entity/util/DBSupport.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/entity/util/DBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/ebaccesstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/MDBClient.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/TestBeanMDB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbqaccesstest/TestBeanMDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/MDBClient.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/TestBeanMDBT.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/mdbtaccesstest/TestBeanMDBT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/sbaccesstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/URLClient.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/localaccess/webaccesstest/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/A.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/AHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/AHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/B.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/BHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/BHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/CEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/CEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/CLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/CLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/CLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/CLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/DEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/DEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/DLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/DLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/DLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/DLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/lrapitest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/argsemantics/CallerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/argsemantics/CallerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/argsemantics/CallerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/argsemantics/CallerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean1/TestBean1.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean1/TestBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean1/TestBean1EJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean1/TestBean1EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean1/TestBean1Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean1/TestBean1Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean2/TestBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean2/TestBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean2/TestBean2EJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean2/TestBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean2/TestBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beanmultijartest/bean2/TestBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean1/TestBean1.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean1/TestBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean1/TestBean1EJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean1/TestBean1EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean1/TestBean1Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean1/TestBean1Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean2/TestBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean2/TestBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean2/TestBean2EJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean2/TestBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean2/TestBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bean2beansinglejartest/bean2/TestBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/bm/allowedmethodstest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanNoTx.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanNoTx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanNoTxEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanNoTxEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanNoTxHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TestBeanNoTxHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TimerEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TimerEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TimerLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TimerLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TimerLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/cm/allowedmethodstest/TimerLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/exceptionerrortest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/handletest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/CallBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/CallBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/CallBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/CallBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/CallBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/CallBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanNoTx.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanNoTx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanNoTxEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanNoTxEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanNoTxHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanNoTxHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanTx.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanTx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanTxEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanTxEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanTxHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessionbeantest/TestBeanTxHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean2EJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/sessioncontexttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/Counter.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/CounterEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/CounterEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/CounterHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateful/statetest/CounterHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/argsemantics/CallerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/argsemantics/CallerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/argsemantics/CallerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/argsemantics/CallerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/Helper.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/HelperEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/HelperEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/HelperHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/HelperHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/ClientBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/ClientBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/ClientBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/ClientBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/ClientBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/ClientBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/LoopBackLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/reentranttest/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/CallBack.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/CallBack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/CallBackEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/CallBackEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/CallBackHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/CallBackHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/sessionbeantest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/Counter.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/CounterEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/CounterEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/CounterHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/statetest/CounterHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/util/DBSupport.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/util/DBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/scope/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejblink/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencingBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencingBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencingBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencingBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/scope/ReferencingBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/ejbref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/scope/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/scope/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/scope/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/scope/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/AllBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/AllBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/AllBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/AllBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/BooleanBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/BooleanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/BooleanBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/BooleanBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ByteBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ByteBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ByteBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ByteBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/CharBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/CharBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/CharBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/CharBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/DoubleBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/DoubleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/DoubleBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/DoubleBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/IntegerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/IntegerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/IntegerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/IntegerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ShortBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ShortBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ShortBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/ShortBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/enventry/single/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style1/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style1/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style1/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style1/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style2/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style2/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style2/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style2/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style3/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style3/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style3/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/method/sec/style3/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/CompoundBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/CompoundBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/CompoundBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/CompoundBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/CompoundBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/CompoundBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/FloatBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/FloatBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/LongBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/LongBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/StringBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/StringBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/pkey/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/QueueBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/QueueBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/QueueBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/QueueBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/TopicBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/TopicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/TopicBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/scope/TopicBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/resref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/single/Single.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/single/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/single/SingleHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/bmp/single/SingleHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/scope/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejblink/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencingBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencingBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencingBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencingBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/scope/ReferencingBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/ejbref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/scope/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/scope/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/scope/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/scope/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/AllBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/AllBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/AllBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/AllBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/BooleanBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/BooleanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/BooleanBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/BooleanBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ByteBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ByteBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ByteBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ByteBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/CharBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/CharBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/CharBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/CharBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/DoubleBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/DoubleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/DoubleBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/DoubleBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/IntegerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/IntegerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/IntegerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/IntegerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ShortBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ShortBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ShortBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/ShortBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/enventry/single/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style1/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style1/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style1/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style1/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style2/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style2/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style2/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style2/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style3/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style3/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style3/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/method/sec/style3/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/CompoundBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/CompoundBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/CompoundBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/CompoundBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/CompoundBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/CompoundBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/FloatBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/FloatBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/LongBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/LongBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/StringBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/StringBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/pkey/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/QueueBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/QueueBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/QueueBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/QueueBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/TopicBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/TopicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/TopicBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/scope/TopicBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/resref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/single/Single.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/single/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/single/SingleHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp11/single/SingleHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/scope/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejblink/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencingBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencingBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencingBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencingBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/scope/ReferencingBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/ejbref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/scope/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/scope/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/scope/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/scope/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/AllBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/AllBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/AllBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/AllBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/BooleanBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/BooleanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/BooleanBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/BooleanBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ByteBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ByteBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ByteBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ByteBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/CharBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/CharBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/CharBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/CharBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/DoubleBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/DoubleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/DoubleBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/DoubleBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/IntegerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/IntegerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/IntegerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/IntegerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ShortBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ShortBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ShortBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/ShortBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/enventry/single/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style1/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style1/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style1/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style1/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style2/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style2/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style2/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style2/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style3/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style3/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style3/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/method/sec/style3/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/CompoundBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/CompoundBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/CompoundBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/CompoundBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/CompoundBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/CompoundBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/FloatBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/FloatBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/LongBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/LongBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/StringBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/StringBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/pkey/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/QueueBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/QueueBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/QueueBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/QueueBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/TopicBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/TopicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/TopicBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/scope/TopicBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/resref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/single/Single.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/single/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/single/SingleHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/entity/cmp20/single/SingleHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencingBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencingBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencingBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencingBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencingBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/AllBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/AllBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/AllBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/AllBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/BooleanBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/BooleanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/BooleanBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/BooleanBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ByteBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ByteBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ByteBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ByteBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/CharBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/CharBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/CharBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/CharBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/DoubleBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/DoubleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/DoubleBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/DoubleBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/IntegerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/IntegerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/IntegerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/IntegerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ShortBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ShortBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ShortBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ShortBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style1/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style1/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style1/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style1/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style2/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style2/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style2/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style2/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style3/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style3/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style3/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/method/sec/style3/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/QueueBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/QueueBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/QueueBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/QueueBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/TopicBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/TopicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/TopicBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/TopicBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/single/Single.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/single/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/single/SingleHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateful/single/SingleHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_13/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_13/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_13/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_13/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat12_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat13_14/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat13_14/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat13_14/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/compat13_14/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2EJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2Home.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencingBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencingBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencingBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencingBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencingBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/CaseBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/CaseBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/CaseBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/CaseBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/AllBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/AllBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/AllBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/AllBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/BooleanBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/BooleanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/BooleanBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/BooleanBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ByteBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ByteBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ByteBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ByteBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/CharBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/CharBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/CharBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/CharBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/DoubleBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/DoubleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/DoubleBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/DoubleBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/FloatBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/FloatBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/FloatBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/FloatBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/IntegerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/IntegerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/IntegerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/IntegerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/LongBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/LongBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/LongBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/LongBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ShortBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ShortBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ShortBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ShortBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/StringBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/StringBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/StringBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/StringBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style1/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style1/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style1/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style1/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style2/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style2/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style2/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style2/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style3/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style3/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style3/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/method/sec/style3/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/QueueBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/QueueBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/QueueBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/QueueBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/TopicBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/TopicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/TopicBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/TopicBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/deploy/session/stateless/single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/equality/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/equality/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/from_clause/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/from_clause/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/null_values/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/null_values/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/order_by/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/order_by/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AddressEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AddressEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AddressLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AddressLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AddressLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AddressLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Alias.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Alias.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/AliasLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CreditCardEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CreditCardEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CreditCardLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CreditCardLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CreditCardLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CreditCardLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Customer.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Customer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/CustomerLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/InfoEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/InfoEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/InfoLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/InfoLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/InfoLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/InfoLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/LineItemEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/LineItemEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/LineItemLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/LineItemLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/LineItemLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/LineItemLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Order.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/OrderLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/PhoneEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/PhoneEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/PhoneLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/PhoneLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/PhoneLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/PhoneLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Product.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/ProductLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Schema.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/SpouseEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/SpouseEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/SpouseLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/SpouseLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/SpouseLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/SpouseLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Util.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/schema/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/select_clause/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/select_clause/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TxCommonBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TxCommonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TxCommonBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TxCommonBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TxCommonBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/tx/TxCommonBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/ejbql/where_clause/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/ejbql/where_clause/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/bi/delete/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXmany/uni/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/manyXone/uni/delete/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/cascadedelete/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/bi/delete/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXmany/uni/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/cascadedelete/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/bi/delete/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/AEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/AEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/ALocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/ALocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/ALocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/ALocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/Bean.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/BeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/oneXone/uni/btob/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/Department.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/Department.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/DepartmentLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/Employee.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/pm/selfXself/EmployeeLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRef.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/SecTestRoleRefLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/lTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/lTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/lTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/common/lTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/lsecp/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/lsecp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/lsecr/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/lsecr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/util/DBSupport.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/util/DBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/bmp/util/DBSupport2.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/bmp/util/DBSupport2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestRoleRef.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestRoleRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestRoleRefHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/SecTestRoleRefHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/common/TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRef.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/SecTestRoleRefLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/lTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/lTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/lTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/common/lTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/lsecp/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/lsecp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/lsecr/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/lsecr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/cmp20/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/cmp20/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/mdb/MDBClient.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/mdb/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/mdb/MsgBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/mdb/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRef.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/SecTestRoleRefLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/lTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/lTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/lTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/common/lTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/lsecp/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/lsecp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/lsecr/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/lsecr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDBClient.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDB_SND_Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDB_SND_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDB_SND_TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDB_SND_TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDB_SND_TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MDB_SND_TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MsgBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/mdb/TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateful/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateful/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRef.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/SecTestRoleRefLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/Test.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/TestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/lTest.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/lTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/lTestHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/common/lTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/lsecp/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/lsecp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/lsecr/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/lsecr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/sec/stateless/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/sec/stateless/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/apitests/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/apitests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/apitests/TimerBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/apitests/TimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/apitests/TimerBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/apitests/TimerBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/apitests/TimerBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/apitests/TimerBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/common/TimerImpl.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/common/TimerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/DAOBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/DAOBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/ProxyBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/ProxyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/ProxyBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/ProxyBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/ProxyBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/ProxyBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/bmp/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/ProxyBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/ProxyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/ProxyBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/ProxyBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/ProxyBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/ProxyBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/entity/cmp20/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/helper/CheckedMethod.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/helper/CheckedMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/helper/CheckedMethodEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/helper/CheckedMethodEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/helper/CheckedMethodHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/helper/CheckedMethodHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/helper/FlagStore.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/helper/FlagStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/helper/FlagStoreEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/helper/FlagStoreEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/helper/FlagStoreHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/helper/FlagStoreHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/mdb/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/mdb/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/mdb/MsgBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/mdb/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/ProxyBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/ProxyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/ProxyBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/ProxyBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/ProxyBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/ProxyBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/bm/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/ProxyBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/ProxyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/ProxyBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/ProxyBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/ProxyBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/ProxyBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/timer/session/stateless/cm/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Multi/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/bm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/S1TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/S1TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/S1TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/S1TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/S1TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Multi/S1TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/bmp/cm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Multi/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/bm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/S1TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/S1TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/S1TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/S1TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/S1TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Multi/S1TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/cmp/cm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Multi/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/bm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entity/pm/cm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/bm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/bmp/cm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/bm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanA.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanAEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanAEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanAHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanAHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanBEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanBEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanBHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanBHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanC.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanCEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanCEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanCHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/BeanCHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Diamond/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/entityLocal/pm/cm/Tx_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxM_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxR_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/TxS_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/bm/Tx_Multi/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxM_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxRN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateful/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxM_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxRN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/bm/Tx_Multi/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxM_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/session/stateless/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxBM_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxM_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxN_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxRN_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxR_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/bm/TxS_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxM_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxRN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateful/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxM_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxRN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/bm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxM_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxNS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxRN_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/TxS_Exceptions/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/sessionLocal/stateless/cm/Tx_SetRollbackOnly/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txECMPbean/TxECMPBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txECMPbean/TxECMPBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txECMPbean/TxECMPBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txECMPbean/TxECMPBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txECMPbean/TxECMPBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txECMPbean/TxECMPBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEPMbean/TxEPMBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEPMbean/TxEPMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEPMbean/TxEPMBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEPMbean/TxEPMBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEPMbean/TxEPMBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEPMbean/TxEPMBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEPMbeanLocal/TxEPMBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEPMbeanLocal/TxEPMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEPMbeanLocal/TxEPMBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEPMbeanLocal/TxEPMBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEPMbeanLocal/TxEPMBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEPMbeanLocal/TxEPMBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEbean/TxEBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEbean/TxEBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEbean/TxEBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEbean/TxEBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEbean/TxEBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEbean/TxEBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEbeanLocal/TxEBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEbeanLocal/TxEBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEbeanLocal/TxEBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEbeanLocal/TxEBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txEbeanLocal/TxEBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txEbeanLocal/TxEBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txbean/TxBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txbean/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txbean/TxBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txbean/TxBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txbean/TxBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txbean/TxBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txbeanLocal/TxBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txbeanLocal/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txbeanLocal/TxBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txbeanLocal/TxBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/tx/txbeanLocal/TxBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/tx/txbeanLocal/TxBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/Client.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBean.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanLocal.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanLocalHome.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/AppResBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/AppResBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/Client.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/common/AppResLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/common/AppResLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/common/AppResRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/common/AppResRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/common/AppResTest.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/common/AppResTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/common/TestServletBase2.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/common/TestServletBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/warejb/AppResBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/warejb/AppResBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/warmbean/AppResBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/warmbean/AppResBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/common/AssemblyBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/common/AssemblyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/common/AssemblyLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/common/AssemblyLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/common/AssemblyRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/common/AssemblyRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/InitOrder2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/InitOrder2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/common/InitOrderBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/common/InitOrderBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/common/InitOrderRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/common/InitOrderRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/AssemblyBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/AssemblyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/AssemblyBean.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/AssemblyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/mbean/appclient/Client.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/mbean/appclient/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/EJBInjectionFilterBase.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/EJBInjectionFilterBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/TestServletBase.java
+++ b/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/TestServletBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatefulDefaultLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatefulDefaultLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatefulLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatefulLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatelessDefaultLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatelessDefaultLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatelessLocal2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatelessLocal2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatelessLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/StatelessLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/common/TestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/common/TestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/mdbclient/MdbTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/mdbclient/MdbTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/statefulclient/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/statefulclient/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/statefulclient/StatefulTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/statefulclient/StatefulTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/statelessclient/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/statelessclient/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/statelessclient/StatelessTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/statelessclient/StatelessTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/webclient/StatelessTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/webclient/StatelessTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/localaccess/webclient/TestServletSuper.java
+++ b/src/com/sun/ts/tests/ejb30/bb/localaccess/webclient/TestServletSuper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/common/ActivationConfigBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/common/ActivationConfigBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/annotated/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/annotated/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/complement/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/complement/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/descriptor/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/descriptor/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/override/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectorauto/override/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectordups/annotated/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectordups/annotated/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectordups/complement/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectordups/complement/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectordups/override/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/queue/selectordups/override/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/annotated/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/annotated/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/complement/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/complement/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/descriptor/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/descriptor/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/override/ActivationConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/activationconfig/topic/selectordupsnondurable/override/ActivationConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/callback/listener/annotated/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/callback/listener/annotated/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/callback/listener/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/callback/listener/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/annotated/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/annotated/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/ejbcreate/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/ejbcreate/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/ejbcreate/CallbackBean0.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/callback/method/ejbcreate/CallbackBean0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/customlistener/MDBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/customlistener/MDBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/DestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/DestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/DestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/DestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/NonListenerDestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/NonListenerDestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/TopicDestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/common/TopicDestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/listener/annotated/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/listener/annotated/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/listener/descriptor/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/listener/descriptor/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/method/annotated/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/method/annotated/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/method/descriptor/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/interceptor/method/descriptor/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/externalizable/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/externalizable/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/externalizable/DestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/externalizable/DestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/serializable/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/serializable/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/serializable/DestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/listenerintf/implementing/serializable/DestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/annotated/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/annotated/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/annotated/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/annotated/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/override/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/override/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/override/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/annotation/appexception/override/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/basic/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/basic/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/basic/RemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/basic/RemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/basic/StatefulRemoteCalculator.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/basic/StatefulRemoteCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/AllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/AllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/CallbackAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/CallbackAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/InjectionAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/InjectionAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/SessionContextAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/SessionContextAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/StatefulBMTOperations.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/bm/allowed/StatefulBMTOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/AnnotatedInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/AnnotatedInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/SessionSynchronizationLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/SessionSynchronizationLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busiface/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/SessionSynchronizationLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/SessionSynchronizationLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/busifacedd/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/StatefulCallbackListener.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/StatefulCallbackListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/StatefulCallbackListener2.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/annotated/StatefulCallbackListener2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/descriptor/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/descriptor/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/listener/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/SessionBeanCallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/annotated/SessionBeanCallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/SessionBeanCallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/callback/method/descriptor/SessionBeanCallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/AllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/AllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/AllowedBeanSessionSynchronizationBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/AllowedBeanSessionSynchronizationBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/CallbackAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/CallbackAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/InjectionAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/InjectionAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/NoTxAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/NoTxAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/SessionContextAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/SessionContextAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/SetRollbackOnlyBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/cm/allowed/SetRollbackOnlyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/AnnotatedSuperClassAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/AnnotatedSuperClassAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/BeanClassLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/BeanClassLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelOverrideAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelOverrideAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/ContainerConcurrencyBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/ContainerConcurrencyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/DefaultConcurrencyBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/DefaultConcurrencyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/NotAllowedConcurrencyBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/NotAllowedConcurrencyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/StatefulConcurrencyBeanBase2.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/StatefulConcurrencyBeanBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/ejblink/one/EjbLink1Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/ejblink/one/EjbLink1Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/ejblink/one/EjbLink2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/ejblink/one/EjbLink2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/ejblink/one/EjbLink3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/ejblink/one/EjbLink3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/annotated/CartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/annotated/CartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/annotated/ShoppingCartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/annotated/ShoppingCartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/descriptor/CartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/descriptor/CartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/descriptor/ShoppingCartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/equals/descriptor/ShoppingCartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/InterceptorInstanceBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/InterceptorInstanceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/InterceptorInstanceIF.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/annotated/InterceptorInstanceIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/descriptor/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/descriptor/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/override/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/override/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/listener/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/annotated/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/annotated/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/descriptor/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/descriptor/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/interceptor/method/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/migration/threetwo/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/migration/threetwo/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/migration/threetwo/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/migration/threetwo/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/migration/threetwo/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/migration/threetwo/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/noattrremotelocal/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/RemoveBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/RemoveBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/RemoveNotRetainBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/RemoveNotRetainBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/StatelessTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/annotated/StatelessTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/common/TestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/common/TestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/complement/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/complement/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/complement/RemoveBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/complement/RemoveBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/complement/RemoveNotRetainBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/complement/RemoveNotRetainBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/RemoveBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/RemoveBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/RemoveNotRetainBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/RemoveNotRetainBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/StatelessTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/descriptor/StatelessTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/RemoveBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/RemoveBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/RemoveNotRetainBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/RemoveNotRetainBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/StatelessTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/remove/override/StatelessTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/AcceptBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/AcceptBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/SessionContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/SessionContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/AcceptBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/AcceptBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/SessionContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/SessionContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/sessioncontext/descriptor/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/annotated/DefaultUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/annotated/DefaultUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/annotated/SecondUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/annotated/SecondUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/timeout/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/annotated/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/annotated/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/annotated/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/annotated/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/override/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/override/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/override/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/appexception/override/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/EnvEntryFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/EnvEntryFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/EnvEntrySetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/EnvEntrySetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/EnvEntryTypeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventry/EnvEntryTypeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrydefault/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrydefault/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrydefault/EnvEntryFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrydefault/EnvEntryFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrydefault/EnvEntrySetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrydefault/EnvEntrySetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrynoat/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrynoat/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrynoat/EnvEntryFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrynoat/EnvEntryFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrynoat/EnvEntrySetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/enventrynoat/EnvEntrySetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/ResourceTypeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/ResourceTypeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceTypeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceTypeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/UserTransactionNegativeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/UserTransactionNegativeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceTypeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceTypeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean5.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/AllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/AllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/CallbackAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/CallbackAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/InjectionAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/InjectionAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/SessionContextAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/bm/allowed/SessionContextAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/AnnotatedInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/AnnotatedInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/TimedObjectLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busiface/TimedObjectLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/TimedObjectLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/busifacedd/TimedObjectLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/defaultinterceptor/descriptor/Callback3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/defaultinterceptor/descriptor/Callback3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/defaultinterceptor/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/defaultinterceptor/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback2BeanSuperSuper.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback2BeanSuperSuper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback3BeanSuperSuper.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback3BeanSuperSuper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback4Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Callback4Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/CallbackBeanSuperSuper.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/CallbackBeanSuperSuper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/inheritance/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/annotated/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/annotated/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/annotated/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/annotated/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/NoAnnotationCallback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/listener/descriptor/NoAnnotationCallback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/EjbCreateCallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/EjbCreateCallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/EjbCreateCallbackBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/EjbCreateCallbackBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/SessionBeanCallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/SessionBeanCallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/Callback2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/Callback2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/CallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/CallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/SessionBeanCallbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/SessionBeanCallbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/threelevels/descriptor/Callback3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/threelevels/descriptor/Callback3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/threelevels/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/threelevels/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/AllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/AllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/CallbackAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/CallbackAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/InjectionAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/InjectionAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/SessionContextAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/cm/allowed/SessionContextAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/one/EjbLink1Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/one/EjbLink1Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/one/EjbLink2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/one/EjbLink2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/one/EjbLink3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/one/EjbLink3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink1Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink1Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink2BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink2BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/EjbLink3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/UnusedEjbLink3Bean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/ejblink/override/UnusedEjbLink3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/annotated/CartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/annotated/CartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/annotated/ShoppingCartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/annotated/ShoppingCartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/descriptor/CartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/descriptor/CartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/descriptor/ShoppingCartBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/equals/descriptor/ShoppingCartBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/invocationcontext/InvocationContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/invocationcontext/InvocationContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/invocationcontext/InvocationContextInterceptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/invocationcontext/InvocationContextInterceptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/annotated/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/annotated/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/descriptor/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/descriptor/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/mixed/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/mixed/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/mixed/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/mixed/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/override/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/override/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/listener/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/annotated/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/annotated/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/descriptor/AroundInvokeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/descriptor/AroundInvokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/interceptor/method/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/threetwo/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/threetwo/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/threetwo/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/threetwo/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/threetwo/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/threetwo/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/annotated/MigrationBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/annotated/MigrationBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/descriptor/MigrationBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/descriptor/MigrationBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/override/MigrationBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/migration/twothree/override/MigrationBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/noattrremotelocal/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/AcceptBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/AcceptBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/SessionContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/SessionContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/AcceptBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/AcceptBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/SessionContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/SessionContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/sessioncontext/descriptor/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/AllowedBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/AllowedBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/CallbackAllowedBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/CallbackAllowedBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/CancelInterceptor.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/CancelInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/InjectiontAllowedBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/InjectiontAllowedBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/MySessionSynchronization.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/MySessionSynchronization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/Operations.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/Operations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/SessionContextAllowedBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/SessionContextAllowedBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulAllowedBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulAllowedBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulCancelInterceptor.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulCancelInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulOperations.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/stateful/TimerEJB.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/stateful/TimerEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/allowed/stateful/TimerLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/stateful/TimerLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/annotation/enventry/EnvEntryBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/enventry/EnvEntryBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/EnvSharingBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/EnvSharingBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/AppExceptionBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/AppExceptionBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/AppExceptionLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/AppExceptionLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/AtCheckedAppException.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/AtCheckedAppException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/AtCheckedRollbackAppException.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/AtCheckedRollbackAppException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/AtUncheckedAppException.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/AtUncheckedAppException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/AtUncheckedRollbackAppException.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/AtUncheckedRollbackAppException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/appexception/RollbackBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/appexception/RollbackBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedBusinessInterface1.java
+++ b/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedBusinessInterface1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedBusinessInterface2.java
+++ b/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedBusinessInterface2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface1.java
+++ b/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface2.java
+++ b/src/com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/busiface/BusinessBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/busiface/BusinessBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/busiface/SessionBeanLocalBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/busiface/SessionBeanLocalBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/callback/Callback2BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/Callback2BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/callback/MDBCallbackBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/MDBCallbackBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/callback/SharedCallbackBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/SharedCallbackBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/covariant/FuzzyLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/covariant/FuzzyLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/covariant/FuzzyRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/covariant/FuzzyRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/covariant/TestServletBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/covariant/TestServletBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/ejblink/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/ejblink/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/equals/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/equals/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/equals/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/equals/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/equals/TestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/equals/TestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/equals/TestBeanForStateful.java
+++ b/src/com/sun/ts/tests/ejb30/common/equals/TestBeanForStateful.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/generics/DateGreetingBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/generics/DateGreetingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/generics/GreetingBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/generics/GreetingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/generics/GreetingBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/generics/GreetingBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/generics/LocalIntGreetingIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/generics/LocalIntGreetingIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/generics/RemoteIntGreetingIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/generics/RemoteIntGreetingIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/helloejbjar/HelloBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/helloejbjar/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/helloejbjar/HelloLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/helloejbjar/HelloLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/helloejbjar/HelloRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/helloejbjar/HelloRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/interceptor/AroundInvokeBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/interceptor/AroundInvokeBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/interceptor/AroundInvokeTestImpl.java
+++ b/src/com/sun/ts/tests/ejb30/common/interceptor/AroundInvokeTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/interceptor/AroundInvokeTestMDBImpl.java
+++ b/src/com/sun/ts/tests/ejb30/common/interceptor/AroundInvokeTestMDBImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/interceptor/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/interceptor/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/invocationcontext/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/invocationcontext/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/DescriptorThreeTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/DescriptorThreeTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/MigrationBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/MigrationBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/MigrationBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/MigrationBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/StatefulThreeTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/StatefulThreeTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/ThreeTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/ThreeTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/ThreeTestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/ThreeTestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoLocalHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoRemoteHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoRemoteHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/threetwo/TwoRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/MigrationBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/MigrationBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/ThreeTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/ThreeTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoLocalHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoRemoteHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoRemoteHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoTestRemoteHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoTestRemoteHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoTestRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/migration/twothree/TwoTestRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/AcceptBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/AcceptBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/SessionContextBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/SessionContextBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/TestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/TestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoLocalHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoLocalHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoRemoteHome.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoRemoteHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/TwoRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/statussingleton/StatusSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/common/statussingleton/StatusSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/NoInterfaceAppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/NoInterfaceAppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/InheritanceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/InheritanceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/NoInterfaceAppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/NoInterfaceAppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/InheritanceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/InheritanceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/NoInterfaceAppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/NoInterfaceAppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/AppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/AppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/NoInterfaceAppExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/NoInterfaceAppExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/async/singleton/descriptor/TimeoutDescriptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/singleton/descriptor/TimeoutDescriptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateful/descriptor/TimeoutDescriptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateful/descriptor/TimeoutDescriptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/common/BasicBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/common/BasicBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/common/BasicBeanHelper.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/common/BasicBeanHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/singleton/BasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/singleton/BasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/singleton/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/singleton/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/singleton/OneInterfaceBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/singleton/OneInterfaceBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/singleton/TwoInterfacesBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/singleton/TwoInterfacesBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateful/BasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateful/BasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateful/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateful/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateful/OneInterfaceBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateful/OneInterfaceBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateful/TwoInterfacesBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateful/TwoInterfacesBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateless/BasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateless/BasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateless/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateless/OneInterfaceBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateless/OneInterfaceBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/basic/stateless/TwoInterfacesBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/basic/stateless/TwoInterfacesBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/EJBContextBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/EJBContextBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/Interceptor1.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/Interceptor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/Util.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/common/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/stateless/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/stateless/EJBContext2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/stateless/EJBContext2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/ejbcontext/stateless/EJBContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/ejbcontext/stateless/EJBContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/common/EnvEntryBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/common/EnvEntryBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/singleton/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/singleton/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/singleton/EnvEntryBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/singleton/EnvEntryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/stateful/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/stateful/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/stateful/EnvEntryBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/stateful/EnvEntryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/stateless/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/enventry/stateless/EnvEntryBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/enventry/stateless/EnvEntryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/business/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/business/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/business/InterceptorBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/business/InterceptorBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/business/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/business/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/HistorySingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/HistorySingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/InterceptorBaseBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/InterceptorBaseBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/InterceptorBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/common/lifecycle/InterceptorBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/InterceptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/InterceptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/InterceptorOverride34Bean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/InterceptorOverride34Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/InterceptorOverrideBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/annotated/InterceptorOverrideBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/business/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/invocationcontext/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/invocationcontext/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/invocationcontext/InvocationContextBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/invocationcontext/InvocationContextBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/invocationcontext/InvocationContextInterceptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/invocationcontext/InvocationContextInterceptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/InterceptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/InterceptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/InterceptorOverride34Bean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/InterceptorOverride34Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/InterceptorOverrideBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/annotated/InterceptorOverrideBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/InterceptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/InterceptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/InterceptorOverride34Bean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/InterceptorOverride34Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/InterceptorOverrideBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/interceptor/singleton/lifecycle/descriptor/InterceptorOverrideBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/annotated/Lookup2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/annotated/Lookup2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/annotated/LookupBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/annotated/LookupBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/common/LookupBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/common/LookupBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/common/LookupBeanPlainBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/common/LookupBeanPlainBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/descriptor/Lookup2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/descriptor/Lookup2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/lookup/descriptor/LookupBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/lookup/descriptor/LookupBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/HasInterfaceSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/HasInterfaceSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/NoInterfaceSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/NoInterfaceSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/NoInterfaceStatefulBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/NoInterfaceStatefulBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/NoInterfaceStatelessBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/annotated/NoInterfaceStatelessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/nointerface/descriptor/HasInterfaceSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/nointerface/descriptor/HasInterfaceSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/LocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/LocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/OneBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/OneBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/ThreeBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/ThreeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/TwoBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/annotated/TwoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/classloader/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/provider/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/provider/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/provider/TSEJBContainerImplBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/provider/TSEJBContainerImplBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/embed/provider/TSEJBContainerProviderImpl.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/embed/provider/TSEJBContainerProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/global/DataSourceBean.java.template
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/global/DataSourceBean.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/Client.java.template
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/Client.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/DataSourceBean.java.template
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/DataSourceBean.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/DataSourceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/DataSourceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor0.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor1.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor2.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor3.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/Interceptor3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/InterceptorBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/InterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/OneBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/OneBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/ThreeBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/ThreeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/TwoBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/enventry/TwoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecyclecdi/OverrideBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecyclecdi/OverrideBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecycleejbcdi/OverrideBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecycleejbcdi/OverrideBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecycleejbcdi/OverrideBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecycleejbcdi/OverrideBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecycleejbcdi/OverrideWithPostConstructBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/mbean/interceptor/lifecycleejbcdi/OverrideWithPostConstructBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/SingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/SingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/StatefulBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/StatefulBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/StatelessBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/StatelessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/TestServletContextListener.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/servletcontextlistener/TestServletContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/OneBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/OneBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/ThreeBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/ThreeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/TwoBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/webinflib/TwoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/common/SingletonInterceptorBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/common/SingletonInterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/bean/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/bean/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/bean/SingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/bean/SingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/common/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/common/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/AnnotatedAccessTimeoutBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/AnnotatedAccessTimeoutBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/ClassLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/ClassLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/ClassLevelCallbackAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/ClassLevelCallbackAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/InheritAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/InheritAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/KeepWaitOrNotAllowedBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/KeepWaitOrNotAllowedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/MethodLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/MethodLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/MethodLevelCallbackAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/MethodLevelCallbackAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/PlainAccessTimeoutBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/PlainAccessTimeoutBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/TimeUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/accesstimeout/TimeUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/annotated/ReadSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/annotated/ReadSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/annotated/SingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/annotated/SingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/InverseLockSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/InverseLockSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/ReadLockBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/ReadLockBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/SingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/concurrency/container/inheritance/SingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/common/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/common/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/common/HistoryBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/common/HistoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/EightBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/EightBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/ElevenBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/ElevenBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/FiveBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/FiveBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/NineBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/NineBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/SevenBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/SevenBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/TenBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/TenBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/ThreeBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/ThreeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/TwoBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/graph/TwoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/ASingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/ASingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/BSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/BSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/CSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/CSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/StatelessBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/StatelessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/XSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/XSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/YSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/YSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/ZSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/ZSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/ASingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/ASingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/BSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/BSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/BeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/BeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/C2SingletonIF.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/C2SingletonIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/CSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/CSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/CSingletonIF.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/CSingletonIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/StatefulBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/bean/StatefulBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/interceptor/ASingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/interceptor/ASingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/interceptor/CSingletonBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/interceptor/CSingletonBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/interceptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/singleton/lifecycle/interceptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/AnnotatedSuperClassAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/AnnotatedSuperClassAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/BeanClassLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/BeanClassLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelOverrideAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/BeanClassMethodLevelOverrideAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClassLevelAnnotatedAccessTimeoutBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClassLevelAnnotatedAccessTimeoutBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/MethodLevelAnnotatedAccessTimeoutBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/MethodLevelAnnotatedAccessTimeoutBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/PlainAccessTimeoutBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/PlainAccessTimeoutBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/BeanClassLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/BeanClassLevelAccessTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/ContainerConcurrencyBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/ContainerConcurrencyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/DefaultConcurrencyBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/DefaultConcurrencyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/NotAllowedConcurrencyBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/NotAllowedConcurrencyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/DayUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/DayUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/DefaultUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/DefaultUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/HourUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/HourUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/MicrosecondUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/MicrosecondUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/MillisecondUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/MillisecondUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/Minus1TimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/Minus1TimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/NanosecondUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/NanosecondUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/SecondUnitBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/SecondUnitBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/ZeroTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/annotated/ZeroTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/timeout/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/bm/singleton/rw/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/bm/singleton/rw/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/bm/singleton/rw/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/bm/singleton/rw/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/bm/singleton/rw/TxBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/bm/singleton/rw/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/common/InheritanceClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/common/InheritanceClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/common/RWTxBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/common/RWTxBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/annotated/LocalSingletonTxBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/annotated/LocalSingletonTxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/ABean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/ABean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/BBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/BBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/CBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/CBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/DBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/DBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/EBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/EBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/FBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/inheritance/FBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/rw/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/rw/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/rw/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/rw/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/rw/TxBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/rw/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/webrw/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/singleton/webrw/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/rw/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/rw/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/rw/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/rw/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/rw/TxBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/rw/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/AnnotatedBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/AnnotatedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/DescriptorBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/DescriptorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/ImplementingBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/ImplementingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/RollbackBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/RollbackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/SessionSyncBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/SessionSyncBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/ABean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/ABean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/BBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/BBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/CBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/CBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/DBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/DBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/EBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/EBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/FBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/inheritance/FBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/rw/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/rw/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/rw/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/rw/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/rw/TxBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/rw/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/webrw/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/tx/cm/stateless/webrw/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/common/SuperclassBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/common/SuperclassBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/common/SuperclassBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/common/SuperclassBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/equals/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/equals/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/equals/SingletonEqualsBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/equals/SingletonEqualsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/equals/StatefulEqualsBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/equals/StatefulEqualsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/equals/StatelessEqualsBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/equals/StatelessEqualsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/AnnotatedInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/AnnotatedInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/LocalAndNoInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/LocalAndNoInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SubclassExtendsBeanBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SubclassExtendsBeanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SubclassExtendsPOJOBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/SubclassExtendsPOJOBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/AnnotatedInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/AnnotatedInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/LocalAndNoInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/LocalAndNoInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SubclassExtendsBeanBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SubclassExtendsBeanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SubclassExtendsPOJOBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/SubclassExtendsPOJOBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/AnnotatedInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/AnnotatedInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/BusinessBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/BusinessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/ExternalizableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/ExternalizableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/LocalAndNoInterfaceBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/LocalAndNoInterfaceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SerializableLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SerializableLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SessionBeanLocalBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SessionBeanLocalBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SubclassExtendsBeanBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SubclassExtendsBeanBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SubclassExtendsPOJOBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/SubclassExtendsPOJOBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/appclientejb/Client.java.template
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/appclientejb/Client.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/appclientejb/DataSourceBean.java.template
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/appclientejb/DataSourceBean.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/twojars/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/twojars/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/twojars/DataSource2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/twojars/DataSource2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/twojars/DataSourceBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/twojars/DataSourceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/twowars/DataSourceBean.java.template
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/twowars/DataSourceBean.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/twowars/TestServlet.java.template
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/twowars/TestServlet.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/datasource/twowars/TestServlet2.java.template
+++ b/src/com/sun/ts/tests/ejb30/misc/datasource/twowars/TestServlet2.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/getresource/warejb/GetResourceBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/getresource/warejb/GetResourceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/getresource/warejb/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/getresource/warejb/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/jndi/earjar/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/jndi/earjar/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/jndi/earjar/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/jndi/earjar/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/jndi/earjar/TestIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/jndi/earjar/TestIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclient2ejbjars/StatelessAnnotationUsedRemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclient2ejbjars/StatelessAnnotationUsedRemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/RemoteCalculatorBean0.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/RemoteCalculatorBean0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/StatefulRemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/StatefulRemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/StatelessRemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/StatelessRemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/appclientejb/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/appclientejb/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/appclientejb/ModuleBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/appclientejb/ModuleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/conflict/Module2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/conflict/Module2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/conflict/ModuleBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/conflict/ModuleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/conflict/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/conflict/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twojars/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twojars/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twojars/Module2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twojars/Module2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twojars/ModuleBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twojars/ModuleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/Module2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/Module2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/ModuleBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/ModuleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/TestServlet2.java
+++ b/src/com/sun/ts/tests/ejb30/misc/moduleName/twowars/TestServlet2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodStatefulBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodStatefulBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodStatelessBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/nomethodbean/NoMethodStatelessBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/nomethodbean/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/nomethodbean/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/sameejbclass/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/sameejbclass/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/FourBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/FourBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/OneBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/OneBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/OneLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/OneLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/OneRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/OneRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/ThreeBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/ThreeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/ThreeLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/ThreeLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/ThreeRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/ThreeRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/TwoBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/TwoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/TwoLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/TwoLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/threebeans/TwoRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/misc/threebeans/TwoRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/xmloverride/ejbref/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/xmloverride/ejbref/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/common/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/common/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/lsecp/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/lsecp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/lsecr/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/lsecr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/lsecr/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/lsecr/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/lsecr/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/lsecr/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/secrunaspropagation/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/secrunaspropagation/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateful/secrunaspropagation/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateful/secrunaspropagation/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/common/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/common/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/common/SecTestRoleRefEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/common/SecTestRoleRefEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/common/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/common/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/common/lTest.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/common/lTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/common/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/common/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/lsecp/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/lsecp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/lsecr/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/lsecr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/lsecr/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/lsecr/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/lsecr/lTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/lsecr/lTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/sec/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/sec/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/secpropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/secpropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/secrunaspropagation/Client.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/secrunaspropagation/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/secrunaspropagation/SecTestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/secrunaspropagation/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/sec/stateless/secrunaspropagation/TestEJB.java
+++ b/src/com/sun/ts/tests/ejb30/sec/stateless/secrunaspropagation/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/LockSingletonTimerBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/LockSingletonTimerBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/ReadSingletonTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/ReadSingletonTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/TimerIF.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/TimerIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/WriteSingletonTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/concurrency/WriteSingletonTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/mdb/TimerBasicBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/mdb/TimerBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/mdb/TimerBasicBeanBase2.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/mdb/TimerBasicBeanBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/sharing/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/sharing/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/sharing/SharingTimerBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/sharing/SharingTimerBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/sharing/SingletonTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/sharing/SingletonTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/sharing/StatelessTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/sharing/StatelessTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/sharing/TimerIF.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/sharing/TimerIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/xa/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/xa/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/xa/SingletonXATimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/xa/SingletonXATimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/xa/StatelessXATimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/xa/StatelessXATimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/basic/xa/XATimerBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/basic/xa/XATimerBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/MethodDispatcher.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/MethodDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/TimeoutStatusBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/TimeoutStatusBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/TimerBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/TimerBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/TimerBeanBaseWithoutTimeOutMethod.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/TimerBeanBaseWithoutTimeOutMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/TimerMessageBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/TimerMessageBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/AroundTimeoutBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/AroundTimeoutBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/AroundTimeoutExceptionBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/AroundTimeoutExceptionBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/AroundTimeoutIF.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/AroundTimeoutIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/Interceptor1.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/Interceptor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/InterceptorBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/InterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/MethodOverrideBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/common/MethodOverrideBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutComplementBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutComplementBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutExceptionBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutExceptionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutOverrideBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/AroundTimeoutOverrideBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/InvocationContextMethodsBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/InvocationContextMethodsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/MethodOverride2Bean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/MethodOverride2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/MethodOverrideBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/annotated/MethodOverrideBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/dual/AroundTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/dual/AroundTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/dual/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/aroundtimeout/singleton/dual/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/common/InterceptorBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/common/InterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/mdb/BusinessTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/mdb/BusinessTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/mdb/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/mdb/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/mdb/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/mdb/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/singleton/BusinessTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/singleton/BusinessTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/singleton/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/singleton/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/stateless/BusinessTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/stateless/BusinessTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/business/stateless/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/business/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/lifecycle/singleton/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/lifecycle/singleton/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/lifecycle/singleton/InterceptorBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/lifecycle/singleton/InterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/interceptor/lifecycle/singleton/LifecycleTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/interceptor/lifecycle/singleton/LifecycleTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/mdb/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/mdb/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/singleton/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/singleton/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/stateless/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/stateless/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/stateless/ScheduleBeanBase2.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/stateless/ScheduleBeanBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/stateless/ScheduleBeanBase3.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/auto/attr/stateless/ScheduleBeanBase3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/common/TimeoutParamIF.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/common/TimeoutParamIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/singleton/SingletonTimerBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/singleton/SingletonTimerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/EmptyParamTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/EmptyParamTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/NoParamTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/NoParamTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/WithParamTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/descriptor/stateless/WithParamTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/expire/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/expire/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/expire/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/expire/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/expression/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/expression/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/expression/annotated/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/expression/annotated/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/expression/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/expression/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/lifecycle/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/lifecycle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/lifecycle/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/lifecycle/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tx/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tx/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ScheduleBMTBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ScheduleBMTBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ScheduleTxBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tx/ScheduleTxBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/txnonpersistent/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/txnonpersistent/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/txnonpersistent/ScheduleBMTBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/txnonpersistent/ScheduleBMTBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/txnonpersistent/ScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/txnonpersistent/ScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tz/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tz/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tz/TZScheduleBareBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tz/TZScheduleBareBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/schedule/tz/TZScheduleBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/schedule/tz/TZScheduleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/timerconfig/Client.java
+++ b/src/com/sun/ts/tests/ejb30/timer/timerconfig/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/timer/timerconfig/TimerConfigBean.java
+++ b/src/com/sun/ts/tests/ejb30/timer/timerconfig/TimerConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/LocalTestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/LocalTestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/LocalTxBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/LocalTxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/LocalTxBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/LocalTxBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/StatefulLocalTxBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/StatefulLocalTxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/StatefulTxBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/StatefulTxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TxBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TxBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TxBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TxBeanBase0.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/cm/TxBeanBase0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/ABeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/ABeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/BBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/BBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/CBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/CBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/DBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/DBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/EBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/EBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/FBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/FBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TestLogic.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TestLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TestServletBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TestServletBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TxBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TxBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TxLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TxLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TxRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/session/inheritance/TxRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/common/web/TxServlet.java
+++ b/src/com/sun/ts/tests/ejb30/tx/common/web/TxServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/mdb/bmt/annotated/DestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/mdb/bmt/annotated/DestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/mdb/notsupported/annotated/DestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/mdb/notsupported/annotated/DestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/mdb/required/annotated/DestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/mdb/required/annotated/DestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateful/cm/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateful/cm/annotated/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateful/cm/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateful/cm/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateful/web/StatefulTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateful/web/StatefulTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/annotated/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/annotated/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/covariant/FuzzyBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/covariant/FuzzyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/descriptor/LocalTxBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/descriptor/LocalTxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/descriptor/TestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/descriptor/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/descriptor/TxBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/descriptor/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/generics/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/generics/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/ABean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/ABean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/BBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/BBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/CBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/CBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/DBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/DBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/EBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/EBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/FBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/inheritance/annotated/FBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/VarargsBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/VarargsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/VarargsLocalIF.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/VarargsLocalIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/VarargsRemoteIF.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/cm/varargs/VarargsRemoteIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/tx/session/stateless/web/StatelessTestBean.java
+++ b/src/com/sun/ts/tests/ejb30/tx/session/stateless/web/StatelessTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/HelloImpl.java
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/HelloImpl.java
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/HelloImpl.java
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/zombie/MessageBean.java
+++ b/src/com/sun/ts/tests/ejb30/zombie/MessageBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/jspejbjdbc/Account.java
+++ b/src/com/sun/ts/tests/integration/entity/jspejbjdbc/Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/jspejbjdbc/AccountBean.java
+++ b/src/com/sun/ts/tests/integration/entity/jspejbjdbc/AccountBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/jspejbjdbc/AccountHome.java
+++ b/src/com/sun/ts/tests/integration/entity/jspejbjdbc/AccountHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/jspejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/integration/entity/jspejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/servletejbjdbc/Account.java
+++ b/src/com/sun/ts/tests/integration/entity/servletejbjdbc/Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/servletejbjdbc/AccountBean.java
+++ b/src/com/sun/ts/tests/integration/entity/servletejbjdbc/AccountBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/servletejbjdbc/AccountHome.java
+++ b/src/com/sun/ts/tests/integration/entity/servletejbjdbc/AccountHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/servletejbjdbc/ServletTest.java
+++ b/src/com/sun/ts/tests/integration/entity/servletejbjdbc/ServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/entity/servletejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/integration/entity/servletejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/sec/propagation/Bean1.java
+++ b/src/com/sun/ts/tests/integration/sec/propagation/Bean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/sec/propagation/Bean1EJB.java
+++ b/src/com/sun/ts/tests/integration/sec/propagation/Bean1EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/sec/propagation/Bean1Home.java
+++ b/src/com/sun/ts/tests/integration/sec/propagation/Bean1Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/sec/propagation/Bean2.java
+++ b/src/com/sun/ts/tests/integration/sec/propagation/Bean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/sec/propagation/Bean2EJB.java
+++ b/src/com/sun/ts/tests/integration/sec/propagation/Bean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/sec/propagation/Bean2Home.java
+++ b/src/com/sun/ts/tests/integration/sec/propagation/Bean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/jspejbjdbc/Teller.java
+++ b/src/com/sun/ts/tests/integration/session/jspejbjdbc/Teller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/jspejbjdbc/TellerBean.java
+++ b/src/com/sun/ts/tests/integration/session/jspejbjdbc/TellerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/jspejbjdbc/TellerHome.java
+++ b/src/com/sun/ts/tests/integration/session/jspejbjdbc/TellerHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/jspejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/integration/session/jspejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/servletejbjdbc/ServletTest.java
+++ b/src/com/sun/ts/tests/integration/session/servletejbjdbc/ServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/servletejbjdbc/Teller.java
+++ b/src/com/sun/ts/tests/integration/session/servletejbjdbc/Teller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/servletejbjdbc/TellerBean.java
+++ b/src/com/sun/ts/tests/integration/session/servletejbjdbc/TellerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/servletejbjdbc/TellerHome.java
+++ b/src/com/sun/ts/tests/integration/session/servletejbjdbc/TellerHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/session/servletejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/integration/session/servletejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/integration/util/DBSupport.java
+++ b/src/com/sun/ts/tests/integration/util/DBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ac_ssl_ssln_upr_noid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ac_ssl_ssln_upr_noid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ac_ssl_ssln_upr_noid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ac_ssl_ssln_upr_noid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ac_ssl_sslr_upn_noid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ac_ssl_sslr_upn_noid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ac_ssl_sslr_upn_noid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ac_ssl_sslr_upn_noid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2AppClient.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2AppClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2Log.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2Session.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2SessionBean.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2SessionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2SessionHome.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2SessionHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2TestLogicImpl.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2TestLogicImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/common/CSIv2TestLogicInterface.java
+++ b/src/com/sun/ts/tests/interop/csiv2/common/CSIv2TestLogicInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_anonid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_anonid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_anonid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_anonid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_ccid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_ccid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_ccid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_ccid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_upid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_upid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_upid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_ssln_upn_upid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_anonid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_anonid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_anonid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_anonid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_ccid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_ccid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_ccid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_ccid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_upid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_upid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_upid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssl_sslr_upn_upid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_anonid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_anonid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_anonid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_anonid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_ccid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_ccid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_ccid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_ccid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_upid/forward/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_upid/forward/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_upid/reverse/Client.java
+++ b/src/com/sun/ts/tests/interop/csiv2/ew_ssln_ssln_upn_upid/reverse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/bmp/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/cmp/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/entity/cmp20/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/entity/cmp20/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean1/TestBean1.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean1/TestBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean1/TestBean1EJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean1/TestBean1EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean1/TestBean1Home.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean1/TestBean1Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean2/TestBean2.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean2/TestBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean2/TestBean2EJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean2/TestBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean2/TestBean2Home.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/bean2beanmultijartest/bean2/TestBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/TestBean.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/exceptionerrortest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/TestBean.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateful/handletest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/Client.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/TestBean.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/ejb/session/stateless/clientviewtest/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/integration/jspejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/interop/integration/jspejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/integration/servletejbjdbc/ServletTest.java
+++ b/src/com/sun/ts/tests/interop/integration/servletejbjdbc/ServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/integration/servletejbjdbc/URLClient.java
+++ b/src/com/sun/ts/tests/interop/integration/servletejbjdbc/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/Client.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestEntityBean.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestEntityBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestEntityBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestEntityBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestEntityBeanHome.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestEntityBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestSessionBean.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestSessionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestSessionBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestSessionBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestSessionBeanHome.java
+++ b/src/com/sun/ts/tests/interop/naming/cosnamingNoSSL/TestSessionBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/rmiiiop/marshaltests/Client.java
+++ b/src/com/sun/ts/tests/interop/rmiiiop/marshaltests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/rmiiiop/objecttests/Client.java
+++ b/src/com/sun/ts/tests/interop/rmiiiop/objecttests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/appclient/bmp/Client.java
+++ b/src/com/sun/ts/tests/interop/security/appclient/bmp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/appclient/cmp/Client.java
+++ b/src/com/sun/ts/tests/interop/security/appclient/cmp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/appclient/stateful/Client.java
+++ b/src/com/sun/ts/tests/interop/security/appclient/stateful/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/appclient/stateless/Client.java
+++ b/src/com/sun/ts/tests/interop/security/appclient/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/bmp/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/bmp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/bmprunas/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/bmprunas/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/cmp/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/cmp/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/cmprunas/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/cmprunas/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/sfrunas/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/sfrunas/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/slrunas/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/slrunas/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/stateful/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/stateful/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/security/ejbclient/stateless/Client.java
+++ b/src/com/sun/ts/tests/interop/security/ejbclient/stateless/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxBM_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxNS_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxN_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/bm/TxRN_GlobalSingle/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxM_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxNS_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxRN_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxR_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/Client.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/TestBean.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/TestBeanHome.java
+++ b/src/com/sun/ts/tests/interop/tx/session/stateful/cm/TxS_Single/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/interop/tx/webclient/jsp/URLClient.java
+++ b/src/com/sun/ts/tests/interop/tx/webclient/jsp/URLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depfactory/depfactoryClient.java
+++ b/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depfactory/depfactoryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depmanager1/depmanagerClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depmanager1/depmanagerClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depmanager2/depmanagerClient2.java
+++ b/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depmanager2/depmanagerClient2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depmanager3/depmanagerClient3.java
+++ b/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/depmanager3/depmanagerClient3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/tmoduleid/tmoduleidClient.java
+++ b/src/com/sun/ts/tests/j2eetools/deploy/platform/ee/tmoduleid/tmoduleidClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/api/mejb1/mejbClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/api/mejb1/mejbClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/api/mejb2/mejbClient2.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/api/mejb2/mejbClient2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/common/BaseMO.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/common/BaseMO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/common/MOUtils.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/common/MOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/appclientmodule/appclientmoduleClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/appclientmodule/appclientmoduleClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/ejb/ejbClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/ejb/ejbClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/ejbmodule/ejbmoduleClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/ejbmodule/ejbmoduleClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/entitybean/entitybeanClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/entitybean/entitybeanClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eeapplication/j2eeapplicationClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eeapplication/j2eeapplicationClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eedeployedobject/j2eedeployedobjectClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eedeployedobject/j2eedeployedobjectClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eedomain/j2eedomainClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eedomain/j2eedomainClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eemodule/j2eemoduleClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eemodule/j2eemoduleClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eeresource/j2eeresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eeresource/j2eeresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eeserver/j2eeserverClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/j2eeserver/j2eeserverClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/javamailresource/javamailresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/javamailresource/javamailresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jcaconnectionfactory/jcaconnectionfactoryClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jcaconnectionfactory/jcaconnectionfactoryClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jcamanagedconnectionfactory/jcamanagedconnectionfactoryClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jcamanagedconnectionfactory/jcamanagedconnectionfactoryClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jcaresource/jcaresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jcaresource/jcaresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jdbcdatasource/jdbcdatasourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jdbcdatasource/jdbcdatasourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jdbcdriver/jdbcdriverClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jdbcdriver/jdbcdriverClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jdbcresource/jdbcresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jdbcresource/jdbcresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jmsresource/jmsresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jmsresource/jmsresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jndiresource/jndiresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jndiresource/jndiresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jtaresource/jtaresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jtaresource/jtaresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/jvm/jvmClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/jvm/jvmClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/messagedrivenbean/messagedrivenbeanClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/messagedrivenbean/messagedrivenbeanClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/resourceadapter/resourceadapterClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/resourceadapter/resourceadapterClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/resourceadaptermodule/resourceadaptermoduleClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/resourceadaptermodule/resourceadaptermoduleClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/rmiiiopresource/rmiiiopresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/rmiiiopresource/rmiiiopresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/servlet/servletClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/servlet/servletClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/sessionbean/sessionbeanClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/sessionbean/sessionbeanClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/statefulsessionbean/statefulsessionbeanClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/statefulsessionbean/statefulsessionbeanClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/statelesssessionbean/statelesssessionbeanClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/statelesssessionbean/statelesssessionbeanClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/urlresource/urlresourceClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/urlresource/urlresourceClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/j2eetools/mgmt/ee/webmodule/webmoduleClient1.java
+++ b/src/com/sun/ts/tests/j2eetools/mgmt/ee/webmodule/webmoduleClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/ejb/mr/Client.java
+++ b/src/com/sun/ts/tests/jacc/ejb/mr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/ejb/mr/InterMediateBean.java
+++ b/src/com/sun/ts/tests/jacc/ejb/mr/InterMediateBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/ejb/mr/TargetBean.java
+++ b/src/com/sun/ts/tests/jacc/ejb/mr/TargetBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/FetchLogClient.java
+++ b/src/com/sun/ts/tests/jacc/util/FetchLogClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCEntity.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCEntityBean.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCEntityBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCEntityHome.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCEntityHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCSession.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCSessionBean.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCSessionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCSessionHome.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCSessionHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCWSSessionBean.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCWSSessionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCWSSessionHome.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCWSSessionHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jacc/util/JACCWSSessionRemote.java
+++ b/src/com/sun/ts/tests/jacc/util/JACCWSSessionRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/MDB_Q_Test.java
+++ b/src/com/sun/ts/tests/jms/commonee/MDB_Q_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/MDB_Q_TestEJB.java
+++ b/src/com/sun/ts/tests/jms/commonee/MDB_Q_TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/MDB_T_Test.java
+++ b/src/com/sun/ts/tests/jms/commonee/MDB_T_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/MDB_T_TestEJB.java
+++ b/src/com/sun/ts/tests/jms/commonee/MDB_T_TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/ParentMsgBean.java
+++ b/src/com/sun/ts/tests/jms/commonee/ParentMsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/ParentMsgBeanNoTx.java
+++ b/src/com/sun/ts/tests/jms/commonee/ParentMsgBeanNoTx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/Tests.java
+++ b/src/com/sun/ts/tests/jms/commonee/Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/TestsEJB.java
+++ b/src/com/sun/ts/tests/jms/commonee/TestsEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/TestsT.java
+++ b/src/com/sun/ts/tests/jms/commonee/TestsT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/commonee/TestsTEJB.java
+++ b/src/com/sun/ts/tests/jms/commonee/TestsTEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/ejb/queueCMTTests/Client.java
+++ b/src/com/sun/ts/tests/jms/ee/ejb/queueCMTTests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/ejb/sessionQtests/Client.java
+++ b/src/com/sun/ts/tests/jms/ee/ejb/sessionQtests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/ejb/sessionTtests/Client.java
+++ b/src/com/sun/ts/tests/jms/ee/ejb/sessionTtests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_exceptQ/MsgBean.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_exceptQ/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_exceptT/MsgBean.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_exceptT/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrQ/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrQ/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrQ/MsgBeanMsgTestHdrQ.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrQ/MsgBeanMsgTestHdrQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrT/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrT/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrT/MsgBeanMsgTestHdrT.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgHdrT/MsgBeanMsgTestHdrT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsQ/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsQ/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsQ/MsgBeanMsgTestPropsQ.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsQ/MsgBeanMsgTestPropsQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsT/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsT/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsT/MsgBeanMsgTestPropsT.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgPropsT/MsgBeanMsgTestPropsT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ1/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ1/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ1/MsgBean.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ1/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ2/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ2/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ2/MsgBeanMsgTestQ2.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ2/MsgBeanMsgTestQ2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ3/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ3/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ3/MsgBeanMsgTestQ3.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesQ3/MsgBeanMsgTestQ3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT1/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT1/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT1/MsgBeanMsgTestT1.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT1/MsgBeanMsgTestT1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT2/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT2/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT2/MsgBeanMsgTestT2.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT2/MsgBeanMsgTestT2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT3/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT3/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT3/MsgBeanMsgTestT3.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_msgTypesT3/MsgBeanMsgTestT3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MDB_AR_Test.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MDB_AR_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MDB_AR_TestEJB.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MDB_AR_TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MsgBeanForQueue.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MsgBeanForQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MsgBeanForTopic.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_rec/MsgBeanForTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MDB_SNDQ_Test.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MDB_SNDQ_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MDB_SNDQ_TestEJB.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MDB_SNDQ_TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MsgBean.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndQ/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToQueue/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToQueue/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToQueue/MsgBean.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToQueue/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToTopic/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToTopic/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToTopic/MsgBeanToTopic.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToTopic/MsgBeanToTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToTopic/MsgBeanTopic.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_sndToTopic/MsgBeanTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_synchrec/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_synchrec/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/mdb_synchrec/MsgBean.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/mdb_synchrec/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/xa/MDBClient.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/xa/MDBClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee/mdb/xa/MsgBeanxa.java
+++ b/src/com/sun/ts/tests/jms/ee/mdb/xa/MsgBeanxa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee20/cditests/mdb/MsgBeanQ.java
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/mdb/MsgBeanQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/descriptor/Stateful3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/descriptor/Stateful3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/descriptor/Stateless3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/descriptor/Stateless3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/exclude/Client.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/exclude/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/exclude/Stateful3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/exclude/Stateful3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/resource_local/Stateless3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/resource_local/Stateless3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/standalone/Client.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/standalone/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/ejb/standalone/Stateful3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/ejb/standalone/Stateful3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/am/Stateful3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/am/Stateful3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/am/Stateless3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/am/Stateless3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/extended/Client.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/extended/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/extended/Stateful3Bean.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/extended/Stateful3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/extended/TellerBean.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/extended/TellerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/ServletTest.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/ServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/TellerBean.java
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/TellerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jta/ee/txpropagationtest/DBSupport.java
+++ b/src/com/sun/ts/tests/jta/ee/txpropagationtest/DBSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jta/ee/txpropagationtest/TxBean.java
+++ b/src/com/sun/ts/tests/jta/ee/txpropagationtest/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jta/ee/txpropagationtest/TxBeanEJB.java
+++ b/src/com/sun/ts/tests/jta/ee/txpropagationtest/TxBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jta/ee/txpropagationtest/TxBeanHome.java
+++ b/src/com/sun/ts/tests/jta/ee/txpropagationtest/TxBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/CallBackBean.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/CallBackBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/CallBackBeanEJB.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/CallBackBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/CallBackBeanHome.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/CallBackBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/Client.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/TestBean.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/TestBeanHome.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/Timer.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/marshaltests/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/objecttests/Client.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/objecttests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/objecttests/HelloRMIIIOPObjectImpl.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/objecttests/HelloRMIIIOPObjectImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/objecttests/TestBean.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/objecttests/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/objecttests/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/objecttests/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/objecttests/TestBeanHome.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/objecttests/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/orbtests/Client.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/orbtests/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/orbtests/HelloRMIIIOPObjectImpl.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/orbtests/HelloRMIIIOPObjectImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/orbtests/ServletTest.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/orbtests/ServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/orbtests/TestBean.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/orbtests/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/orbtests/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/orbtests/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/orbtests/TestBeanHome.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/orbtests/TestBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/rmiiiop/ee/standalone/Client.java
+++ b/src/com/sun/ts/tests/rmiiiop/ee/standalone/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/Hello.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/Hello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/HelloClient.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/HelloClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/HelloEJB.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/HelloEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/HelloHome.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/simpleHello/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean1.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean1EJB.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean1EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean1Home.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean1Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean2.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean2EJB.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean2Home.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TestBean2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/samples/ejb/ee/twobean/TwoBeanClient.java
+++ b/src/com/sun/ts/tests/samples/ejb/ee/twobean/TwoBeanClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/SecTestEJB.java
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/SecTestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/ServletOne.java
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/ServletOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/ServletTwo.java
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/ServletTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/ByeClientBean.java
+++ b/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/ByeClientBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/ByeClientHome.java
+++ b/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/ByeClientHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/ByeClientRemote.java
+++ b/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/ByeClientRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/HelloClientBean.java
+++ b/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/HelloClientBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/HelloClientHome.java
+++ b/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/HelloClientHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/HelloClientRemote.java
+++ b/src/com/sun/ts/tests/webservices/deploy/CompScopedRefs/HelloClientRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/jarDeploy/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/deploy/jarDeploy/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/jarDeploy/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/deploy/jarDeploy/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/jarDeploy/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/deploy/jarDeploy/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/Hello.java
+++ b/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/Hello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/HelloBean2.java
+++ b/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/HelloBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/deploy/multiDeploy/ejb/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/InterModuleEjb.java
+++ b/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/InterModuleEjb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/InterModuleEjbBean.java
+++ b/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/InterModuleEjbBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/InterModuleEjbHome.java
+++ b/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/InterModuleEjbHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/IntraModuleEjb.java
+++ b/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/IntraModuleEjb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/IntraModuleEjbBean.java
+++ b/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/IntraModuleEjbBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/IntraModuleEjbHome.java
+++ b/src/com/sun/ts/tests/webservices/deploy/portcomplink/ejb/IntraModuleEjbHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/existingejb/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/ejb/existingejb/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/existingejb/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/ejb/existingejb/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/existingejb/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/ejb/existingejb/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/marshalltest/MarshallTestBean.java
+++ b/src/com/sun/ts/tests/webservices/ejb/marshalltest/MarshallTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/marshalltest/MarshallTestHome.java
+++ b/src/com/sun/ts/tests/webservices/ejb/marshalltest/MarshallTestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/marshalltest/MarshallTestRemote.java
+++ b/src/com/sun/ts/tests/webservices/ejb/marshalltest/MarshallTestRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/seibasedejb/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/ejb/seibasedejb/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/seibasedejb/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/ejb/seibasedejb/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/seibasedejb/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/ejb/seibasedejb/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/txattributes/ChokeBean.java
+++ b/src/com/sun/ts/tests/webservices/ejb/txattributes/ChokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/txattributes/ChokeHome.java
+++ b/src/com/sun/ts/tests/webservices/ejb/txattributes/ChokeHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/txattributes/ChokeRemote.java
+++ b/src/com/sun/ts/tests/webservices/ejb/txattributes/ChokeRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/txattributes/TxBean.java
+++ b/src/com/sun/ts/tests/webservices/ejb/txattributes/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/txattributes/TxHome.java
+++ b/src/com/sun/ts/tests/webservices/ejb/txattributes/TxHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/ejb/txattributes/TxRemote.java
+++ b/src/com/sun/ts/tests/webservices/ejb/txattributes/TxRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/GenericHandler/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/GenericHandler/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/GenericHandler/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/GenericHandler/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/GenericHandler/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/GenericHandler/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/Handler/Hello2Bean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/Handler/Hello2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/Handler/Hello2Home.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/Handler/Hello2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/Handler/Hello2Remote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/Handler/Hello2Remote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/Handler/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/Handler/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/Handler/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/Handler/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/Handler/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/Handler/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/Hello2Bean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/Hello2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/Hello2Home.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/Hello2Home.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/Hello2Remote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/Hello2Remote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerFlow/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerLifecycle/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerLifecycle/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerLifecycle/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerLifecycle/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerLifecycle/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerLifecycle/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestAuthBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestAuthBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestAuthHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestAuthHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestAuthRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestAuthRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestNoSecBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestNoSecBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestNoSecHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestNoSecHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestNoSecRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestNoSecRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestQueryBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestQueryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestQueryHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestQueryHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestQueryRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestQueryRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestUnAuthBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestUnAuthBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestUnAuthHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestUnAuthHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestUnAuthRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/HandlerSec/TestUnAuthRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/MessageContext/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/MessageContext/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/MessageContext/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/MessageContext/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/MessageContext/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/MessageContext/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/handlerinfo/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/handlerinfo/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/handlerinfo/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/handlerinfo/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/handlerinfo/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/handlerinfo/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/localtx/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/localtx/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/localtx/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/localtx/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/localtx/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/localtx/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/ByeBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/ByeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/ByeHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/ByeHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/ByeRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/ByeRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/HelloHome.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/HelloHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/HelloRemote.java
+++ b/src/com/sun/ts/tests/webservices/handlerEjb/uniqueness/HelloRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloBasicBean.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloBasicHome.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloBasicHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloBasicRemote.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloBasicRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloUnprotectedBean.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloUnprotectedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloUnprotectedHome.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloUnprotectedHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloUnprotectedRemote.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/basicSSL/HelloUnprotectedRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/certificate/HelloCertificateBean.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/certificate/HelloCertificateBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/certificate/HelloCertificateHome.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/certificate/HelloCertificateHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/ejb/certificate/HelloCertificateRemote.java
+++ b/src/com/sun/ts/tests/webservices/sec/ejb/certificate/HelloCertificateRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/sec/war/basicSSL/HelloBasicImpl.java
+++ b/src/com/sun/ts/tests/webservices/sec/war/basicSSL/HelloBasicImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/Simple4/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/Simple4/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/Simple5/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/Simple5/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/Simple6/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/Simple6/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/nested3/StockQuotePortTypeImpl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/nested3/StockQuotePortTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/nested4/StockQuotePortTypeImpl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/nested4/StockQuotePortTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/shared3/SharedTest1Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/shared3/SharedTest1Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/shared3/SharedTest2Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/shared3/SharedTest2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/shared4/SharedTest1Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/shared4/SharedTest1Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/shared4/SharedTest2Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/shared4/SharedTest2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/twin3/ByeBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/twin3/ByeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/twin3/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/twin3/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/twin4/ByeBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/twin4/ByeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/file/twin4/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/file/twin4/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/Simple4/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/Simple4/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/Simple5/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/Simple5/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/Simple6/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/Simple6/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/nested3/StockQuotePortTypeImpl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/nested3/StockQuotePortTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/nested4/StockQuotePortTypeImpl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/nested4/StockQuotePortTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/shared3/SharedTest1Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/shared3/SharedTest1Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/shared3/SharedTest2Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/shared3/SharedTest2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/shared4/SharedTest1Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/shared4/SharedTest1Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/shared4/SharedTest2Impl.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/shared4/SharedTest2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/twin3/ByeBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/twin3/ByeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/twin3/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/twin3/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/twin4/ByeBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/twin4/ByeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices/wsdlImport/http/twin4/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices/wsdlImport/http/twin4/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2002, 2020 International Business Machines Corp. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/webservices12/deploy/jarDeploy/HelloWsBean.java
+++ b/src/com/sun/ts/tests/webservices12/deploy/jarDeploy/HelloWsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/deploy/portcomplink/ejb/InterModuleEjbBean.java
+++ b/src/com/sun/ts/tests/webservices12/deploy/portcomplink/ejb/InterModuleEjbBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/deploy/portcomplink/ejb/IntraModuleEjbBean.java
+++ b/src/com/sun/ts/tests/webservices12/deploy/portcomplink/ejb/IntraModuleEjbBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/HandlerTest/server/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/HandlerTest/server/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbAsyncTest/server/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbAsyncTest/server/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbPkgEPAndClientInSameEarTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbPkgEPAndClientInSameEarTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbPortFieldInjectionTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbPortFieldInjectionTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbPortMethodInjectionTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbPortMethodInjectionTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceProviderTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceProviderTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceRefTest1/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceRefTest1/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceRefTest2/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceRefTest2/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceRefWithNoDDsTest/WSEjbWSRefWithNoDDsTestHelloEJB.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbWebServiceRefWithNoDDsTest/WSEjbWSRefWithNoDDsTestHelloEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/ChokeBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/ChokeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/ChokeHome.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/ChokeHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/ChokeRemote.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/ChokeRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/TxBean.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/TxHome.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/TxHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/TxRemote.java
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/TxRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/basicauth/Hello.java
+++ b/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/basicauth/Hello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/basicauthssl/Hello.java
+++ b/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/basicauthssl/Hello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/clientcert/Hello.java
+++ b/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/clientcert/Hello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/sec/descriptors/ejb/basicSSL/HelloBasicBean.java
+++ b/src/com/sun/ts/tests/webservices12/sec/descriptors/ejb/basicSSL/HelloBasicBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/sec/descriptors/ejb/certificate/HelloCertificateBean.java
+++ b/src/com/sun/ts/tests/webservices12/sec/descriptors/ejb/certificate/HelloCertificateBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/specialcases/services/w2j/doclit/provider/HelloImpl.java
+++ b/src/com/sun/ts/tests/webservices12/specialcases/services/w2j/doclit/provider/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/nested3/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/nested3/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/nested4/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/nested4/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared3/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared3/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared3/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared3/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared4/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared4/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared4/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/shared4/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/simple4/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/simple4/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/simple5/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/simple5/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/simple6/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/simple6/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin3/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin3/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin3/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin3/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin4/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin4/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin4/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/file/twin4/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/nested3/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/nested3/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/nested4/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/nested4/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared3/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared3/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared3/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared3/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared4/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared4/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared4/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/shared4/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/simple4/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/simple4/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/simple5/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/simple5/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/simple6/TestsBean.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/simple6/TestsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin3/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin3/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin3/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin3/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin4/server/TestsBean1.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin4/server/TestsBean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin4/server/TestsBean2.java
+++ b/src/com/sun/ts/tests/webservices12/wsdlImport/http/twin4/server/TestsBean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbPkgInWarUnderWebInfLibTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbPkgInWarUnderWebInfLibTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbPkgInWarUnderWebInfTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbPkgInWarUnderWebInfTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbSingletonTest/HelloBean.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbSingletonTest/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/Client.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/EchoBean.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/EchoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/Client.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/EchoBean.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/EchoBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/Client.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/EjbClient.java
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/EjbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp1/TxBean.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp1/TxBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp1/TxBeanEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp1/TxBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp1/TxBeanHome.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp1/TxBeanHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb1Test.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb1TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb1TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb1TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb1TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb2Test.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb2TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb2TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb2TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp2/Ejb2TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb1Test.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb1TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb1TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb1TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb1TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb2Test.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb2TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb2TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb2TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/resXcomp3/Ejb2TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp1/Ejb1Test.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp1/Ejb1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp1/Ejb1TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp1/Ejb1TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp1/Ejb1TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp1/Ejb1TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb1Test.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb1TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb1TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb1TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb1TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb2Test.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb2TestEJB.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb2TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb2TestHome.java
+++ b/src/com/sun/ts/tests/xa/ee/xresXcomp2/Ejb2TestHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Update the recent EJB change to jakarta.ejb that added incorrect Copyright dates, instead [follow the Eclipse formatting rules for Copyright date](https://www.eclipse.org/projects/handbook/#ip-copyright-headers).

Signed-off-by: Scott Marlow <smarlow@redhat.com>