### PR TITLE
JAX-RPC is deprecated in Jakarta EE 9, so remove call to SessionContext#getMessageContext()

### DIFF
--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/bm/allowedmethodstest/TestBeanEJB.java
@@ -507,23 +507,6 @@ public class TestBeanEJB implements SessionBean, TimedObject {
               + e);
     }
 
-    // getMessageContext test
-// TODO: Verify
-// jakarta.ejb.SessionContext#getMessageContext() does not exist in the API anymore
-//    try {
-//      sctx.getMessageContext();
-//      TestUtil.logMsg("Operations test: getMessageContext() - allowed");
-//    } catch (IllegalStateException e) {
-//      methodList[i].setProperty("getMessageContext", "false");
-//      TestUtil.logMsg("Operations test: getMessageContext() - not allowed");
-//    } catch (Exception e) {
-//      TestUtil.printStackTrace(e);
-//      methodList[i].setProperty("getMessageContext", "unexpected");
-//      TestUtil.logMsg(
-//          "Operations test: getMessageContext() - not allowed (Unexpected Exception) - "
-//              + e);
-//    }
-
     // getRollbackOnly test
     try {
       sctx.getRollbackOnly();

--- a/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/bb/session/stateless/cm/allowedmethodstest/TestBeanEJB.java
@@ -566,22 +566,6 @@ public class TestBeanEJB implements SessionBean, TimedObject {
               + e);
     }
 
-    // getMessageContext test
-// TODO: Verify
-// jakarta.ejb.SessionContext#getMessageContext() does not exist in the API anymore    try {
-//      sctx.getMessageContext();
-//      TestUtil.logMsg("Operations test: getMessageContext() - allowed");
-//    } catch (IllegalStateException e) {
-//      methodList[i].setProperty("getMessageContext", "false");
-//      TestUtil.logMsg("Operations test: getMessageContext() - not allowed");
-//    } catch (Exception e) {
-//      TestUtil.printStackTrace(e);
-//      methodList[i].setProperty("getMessageContext", "unexpected");
-//      TestUtil.logMsg(
-//          "Operations test: getMessageContext() - not allowed (Unexpected Exception) - "
-//              + e);
-//    }
-
     // getRollbackOnly test
     try {
       sctx.getRollbackOnly();

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/bm/TestBeanEJB.java
@@ -364,22 +364,6 @@ public class TestBeanEJB implements SessionBean, TimedObject {
               + e);
     }
 
-    // getMessageContext test
-// TODO: Verify
-// jakarta.ejb.SessionContext#getMessageContext() does not exist in the API anymore    try {
-//      sctx.getMessageContext();
-//      TestUtil.logMsg("Operations test: getMessageContext() - allowed");
-//    } catch (IllegalStateException e) {
-//      methodList[i].setProperty("getMessageContext", "false");
-//      TestUtil.logMsg("Operations test: getMessageContext() - not allowed");
-//    } catch (Exception e) {
-//      TestUtil.printStackTrace(e);
-//      methodList[i].setProperty("getMessageContext", "unexpected");
-//      TestUtil.logMsg(
-//          "Operations test: getMessageContext() - not allowed (Unexpected Exception) - "
-//              + e);
-//    }
-
     // getRollbackOnly test
     try {
       sctx.getRollbackOnly();

--- a/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanEJB.java
+++ b/src/com/sun/ts/tests/ejb/ee/webservices/allowedmethodstest/cm/TestBeanEJB.java
@@ -406,23 +406,6 @@ public class TestBeanEJB implements SessionBean, TimedObject {
               + e);
     }
 
-    // getMessageContext test
-// TODO: Verify
-// jakarta.ejb.SessionContext#getMessageContext() does not exist in the API anymore
-//    try {
-//      sctx.getMessageContext();
-//      TestUtil.logMsg("Operations test: getMessageContext() - allowed");
-//    } catch (IllegalStateException e) {
-//      methodList[i].setProperty("getMessageContext", "false");
-//      TestUtil.logMsg("Operations test: getMessageContext() - not allowed");
-//    } catch (Exception e) {
-//      TestUtil.printStackTrace(e);
-//      methodList[i].setProperty("getMessageContext", "unexpected");
-//      TestUtil.logMsg(
-//          "Operations test: getMessageContext() - not allowed (Unexpected Exception) - "
-//             + e);
-//    }
-
     // getRollbackOnly test
     try {
       sctx.getRollbackOnly();

--- a/src/com/sun/ts/tests/ejb30/common/allowed/Operations.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/Operations.java
@@ -53,20 +53,6 @@ public class Operations implements Constants {
     }
   }
 
-// TODO: Verify
-// jakarta.ejb.SessionContext#getMessageContext() does not exist in the API anymore
-  public void runMessageContext(SessionContext sctx, Properties results) {
-//    // getMessageContext test
-//    try {
-//      sctx.getMessageContext();
-//      results.setProperty(getMessageContext, allowed);
-//    } catch (IllegalStateException e) {
-//      results.setProperty(getMessageContext, disallowed);
-//    } catch (Exception e) {
-//      results.setProperty(getMessageContext, e.toString());
-//    }
-  }
-
   public void runRollbackOnly(SessionContext sctx, Properties results) {
     getSetRollbackOnly(sctx, results);
   }
@@ -424,8 +410,6 @@ public class Operations implements Constants {
     runGetEJBLocalObject(sctx, results);
 
     runTimers(sctx, results);
-
-    runMessageContext(sctx, results);
 
     runRollbackOnly(sctx, results);
 


### PR DESCRIPTION


Signed-off-by: Scott Marlow <smarlow@redhat.com>