### PR TITLE
convert javax.servlet => jakarta.servlet in SAAJ

### DIFF
--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/AttachmentPart/AttachmentPartTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/AttachmentPart/AttachmentPartTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Detail/DetailTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Detail/DetailTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import jakarta.activation.DataHandler;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/MessageFactory/MessageFactoryTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/MessageFactory/MessageFactoryTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/MimeHeader/MimeHeaderTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/MimeHeader/MimeHeaderTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/MimeHeaders/MimeHeadersTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/MimeHeaders/MimeHeadersTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Name/NameTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Name/NameTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Node/NodeTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Node/NodeTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SAAJResult/SAAJResultTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SAAJResult/SAAJResultTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPBody/SOAPBodyTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPBody/SOAPBodyTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import jakarta.activation.DataHandler;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnection/GetServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnection/GetServlet.java
@@ -26,8 +26,8 @@ import com.sun.ts.tests.saaj.common.*;
 
 import jakarta.xml.soap.*;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnection/ReceivingServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnection/ReceivingServlet.java
@@ -26,8 +26,8 @@ import com.sun.ts.tests.saaj.common.*;
 
 import jakarta.xml.soap.*;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnection/SOAPConnectionTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnection/SOAPConnectionTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnectionFactory/SOAPConnectionFactoryTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConnectionFactory/SOAPConnectionFactoryTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConstants/SOAPConstantsTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPConstants/SOAPConstantsTestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.*;
 import jakarta.activation.DataHandler;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPElement/SOAPElementTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPElement/SOAPElementTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import jakarta.activation.DataHandler;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPElementFactory/SOAPElementFactoryTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPElementFactory/SOAPElementFactoryTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPEnvelope/SOAPEnvelopeTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPEnvelope/SOAPEnvelopeTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPException/SOAPExceptionTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPException/SOAPExceptionTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import java.net.*;
 import java.io.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPFactory/SOAPFactoryTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPFactory/SOAPFactoryTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import jakarta.activation.DataHandler;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPFault/SOAPFaultTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPFault/SOAPFaultTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPHeader/SOAPHeaderTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPHeader/SOAPHeaderTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.QName;
 import jakarta.activation.DataHandler;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPHeaderElement/SOAPHeaderElementTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPHeaderElement/SOAPHeaderElementTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPMessage/SOAPMessageTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPMessage/SOAPMessageTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.*;
 import javax.xml.transform.stream.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPPart/SOAPPartTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/SOAPPart/SOAPPartTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.DataHandler;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Text/TextTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/api/javax_xml_soap/Text/TextTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import java.net.*;
 import java.io.*;

--- a/src/com/sun/ts/tests/saaj/common/ReceivingSOAP11Servlet.java
+++ b/src/com/sun/ts/tests/saaj/common/ReceivingSOAP11Servlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 
 import jakarta.xml.soap.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 import java.io.*;
 import java.util.*;
 

--- a/src/com/sun/ts/tests/saaj/common/ReceivingSOAP12Servlet.java
+++ b/src/com/sun/ts/tests/saaj/common/ReceivingSOAP12Servlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 
 import jakarta.xml.soap.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 import java.io.*;
 import java.util.*;
 

--- a/src/com/sun/ts/tests/saaj/common/SOAP_Util.java
+++ b/src/com/sun/ts/tests/saaj/common/SOAP_Util.java
@@ -25,8 +25,8 @@ import com.sun.ts.lib.porting.*;
 
 import java.util.*;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 import jakarta.xml.soap.*;
 import java.io.*;
 

--- a/src/com/sun/ts/tests/saaj/ee/RestrictionsAllowables/RestrictionsAllowablesServlet.java
+++ b/src/com/sun/ts/tests/saaj/ee/RestrictionsAllowables/RestrictionsAllowablesServlet.java
@@ -25,8 +25,8 @@ import com.sun.ts.lib.porting.*;
 
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.*;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/ee/SendSyncReqRespMsg/SendingServlet.java
+++ b/src/com/sun/ts/tests/saaj/ee/SendSyncReqRespMsg/SendingServlet.java
@@ -25,8 +25,8 @@ import com.sun.ts.lib.porting.*;
 
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.*;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/ee/SendVariousMimeAttachments/SendingServlet.java
+++ b/src/com/sun/ts/tests/saaj/ee/SendVariousMimeAttachments/SendingServlet.java
@@ -25,8 +25,8 @@ import com.sun.ts.lib.porting.*;
 
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import jakarta.activation.*;
 import java.net.*;

--- a/src/com/sun/ts/tests/saaj/ee/VerifyInformationItems/VerifyInformationItemsTestServlet.java
+++ b/src/com/sun/ts/tests/saaj/ee/VerifyInformationItems/VerifyInformationItemsTestServlet.java
@@ -24,8 +24,8 @@ import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.tests.saaj.common.*;
 
-import javax.servlet.http.*;
-import javax.servlet.*;
+import jakarta.servlet.http.*;
+import jakarta.servlet.*;
 import jakarta.xml.soap.*;
 import javax.xml.namespace.*;
 import jakarta.activation.DataHandler;


### PR DESCRIPTION
This PR is required to get SAAJ TCK working.

I tested master branch of my fork with Tomcat and jakarta.* SAAJ API and RI builds:
[javatest.batch] Number of tests completed:  450 (449 passed, 1 failed, 0 with errors)
[javatest.batch] Number of tests remaining:  0
The only failed test was signature test - that's expected.
