### PR TITLE
Increase memory size for Jenkins JNLP process from default, up to 2176MB (2GB + 128MB)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,9 @@ spec:
     env:
       - name: JNLP_PROTOCOL_OPTS
         value: "-XshowSettings:vm -Xmx2048m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
+    resources:
+      limits:
+        memory: 2176Mi
   - name: jakartaeetck-ci
     image: jakartaee/cts-base:0.1
     command:


### PR DESCRIPTION
Experiment to set the memory size for the Jenkins JNLP process to be a little larger than the max Java heap size specified (-Xmx2048m).  This may help us avoid git failures that we see sometimes.

Changed JNLP config from:
```
  - name: jnlp
    env:
      - name: JNLP_PROTOCOL_OPTS
        value: "-XshowSettings:vm -Xmx2048m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
```

To:
```
  - name: jnlp
    env:
      - name: JNLP_PROTOCOL_OPTS
        value: "-XshowSettings:vm -Xmx2048m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
    resources:
      limits:
        memory: 2176Mi
```

Signed-off-by: Scott Marlow <smarlow@redhat.com>