### PR TITLE
Replaced javax.persistence with jakarta.persistence in JPA TCK config

### DIFF
--- a/install/jpa/bin/initdb.xml
+++ b/install/jpa/bin/initdb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/install/jpa/bin/initdb.xml
+++ b/install/jpa/bin/initdb.xml
@@ -55,10 +55,10 @@
         <if>
             <istrue value="${cmpNeeded}"/>
         <then>
-            <sql driver="${javax.persistence.jdbc.driver}"
-                 url="${javax.persistence.jdbc.url}"
-                 userid="${javax.persistence.jdbc.user}"
-                 password="${javax.persistence.jdbc.password}"
+            <sql driver="${jakarta.persistence.jdbc.driver}"
+                 url="${jakarta.persistence.jdbc.url}"
+                 userid="${jakarta.persistence.jdbc.user}"
+                 password="${jakarta.persistence.jdbc.password}"
                  classpath="${jdbc.driver.classes}"
                  delimiter="${db.delimiter}"
                  autocommit="true"
@@ -127,10 +127,10 @@
         <if>
             <equals arg1="${jdbc.db}" arg2="derby"/>
         <then>
-            <sql driver="${javax.persistence.jdbc.driver}"
-                 url="${javax.persistence.jdbc.url}"
-                 userid="${javax.persistence.jdbc.user}"
-                 password="${javax.persistence.jdbc.password}"
+            <sql driver="${jakarta.persistence.jdbc.driver}"
+                 url="${jakarta.persistence.jdbc.url}"
+                 userid="${jakarta.persistence.jdbc.user}"
+                 password="${jakarta.persistence.jdbc.password}"
                  classpath="${jdbc.driver.classes}"
                  autocommit="true"
                  onerror="continue" >

--- a/install/jpa/bin/ts.jte
+++ b/install/jpa/bin/ts.jte
@@ -70,11 +70,11 @@ jdbc.db=
 ## initdb.xml file uses them to create the jpa-provider.properties file.
 ##
 ###############################################################
-javax.persistence.provider=org.eclipse.persistence.jpa.PersistenceProvider
-javax.persistence.jdbc.driver=
-javax.persistence.jdbc.url=
-javax.persistence.jdbc.user=
-javax.persistence.jdbc.password=
+jakarta.persistence.provider=org.eclipse.persistence.jpa.PersistenceProvider
+jakarta.persistence.jdbc.driver=
+jakarta.persistence.jdbc.url=
+jakarta.persistence.jdbc.user=
+jakarta.persistence.jdbc.password=
 
 ###############################################################
 # @jpa.provider.implementation.specific.properties

--- a/install/jpa/bin/ts.jte
+++ b/install/jpa/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
This was missing in my previous PR.
Changes were verified by https://ci.eclipse.org/eclipselink/job/eclipselink-tck-run/ job.
