### PR TITLE
Fixed jakarta.annotation packages in JAXWS test.

### DIFF
--- a/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase.java
+++ b/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase.java
@@ -34,8 +34,8 @@ import jakarta.xml.ws.WebServiceContext;
 
 import jakarta.activation.DataHandler;
 
-import javax.annotation.PreDestroy;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
 
 import com.sun.ts.tests.jaxws.common.Handler_Util;
 

--- a/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase2.java
+++ b/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase2.java
@@ -35,8 +35,8 @@ import jakarta.xml.ws.WebServiceException;
 
 import jakarta.activation.DataHandler;
 
-import javax.annotation.PreDestroy;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
 
 import com.sun.ts.tests.jaxws.common.Handler_Util;
 

--- a/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase.java
+++ b/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase.java
@@ -32,8 +32,8 @@ import javax.xml.transform.Source;
 import jakarta.xml.bind.JAXBContext;
 import javax.xml.namespace.QName;
 
-import javax.annotation.PreDestroy;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase2.java
+++ b/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase2.java
@@ -32,8 +32,8 @@ import javax.xml.transform.Source;
 import jakarta.xml.bind.JAXBContext;
 import javax.xml.namespace.QName;
 
-import javax.annotation.PreDestroy;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/restful/server/TokensImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/restful/server/TokensImpl.java
@@ -23,7 +23,7 @@ package com.sun.ts.tests.jaxws.ee.j2w.document.literal.restful.server;
 import java.io.ByteArrayInputStream;
 import java.util.StringTokenizer;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import jakarta.xml.ws.Provider;

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/sessionmaintaintest/server/TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/sessionmaintaintest/server/TestImpl.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.jaxws.ee.j2w.document.literal.sessionmaintaintest.serve
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import jakarta.jws.WebMethod;
 import jakarta.jws.WebService;

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/HelloImpl.java
@@ -43,7 +43,7 @@ import java.util.Properties;
 // Service Implementation Class - as outlined in JAX-WS Specification
 
 import jakarta.jws.WebService;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 @WebService(portName = "HelloPort", targetNamespace = "http://dlowhandlertestservice.org/wsdl", serviceName = "DLOWHandlerTestService", wsdlLocation = "WEB-INF/wsdl/WSDLOWHandlerTestService.wsdl", endpointInterface = "com.sun.ts.tests.jaxws.ee.w2j.document.literal.onewayhandlertest.server.Hello")
 

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httpservletmsgctxpropstest/HttpTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httpservletmsgctxpropstest/HttpTestImpl.java
@@ -26,7 +26,7 @@ import com.sun.ts.lib.porting.*;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import jakarta.jws.WebMethod;
 import jakarta.jws.WebService;

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/HelloImpl.java
@@ -43,7 +43,7 @@ import java.util.Properties;
 // Service Implementation Class - as outlined in JAX-WS Specification
 
 import jakarta.jws.WebService;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 @WebService(portName = "HelloPort", targetNamespace = "http://rlowhandlertestservice.org/wsdl", serviceName = "RLOWHandlerTestService", wsdlLocation = "WEB-INF/wsdl/WSRLOWHandlerTestService.wsdl", endpointInterface = "com.sun.ts.tests.jaxws.ee.w2j.rpc.literal.onewayhandlertest.server.Hello")
 

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/annotations/Handler.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/annotations/Handler.java
@@ -25,8 +25,8 @@ import jakarta.xml.ws.soap.*;
 import jakarta.xml.ws.handler.*;
 import jakarta.xml.ws.LogicalMessage;
 
-import javax.annotation.PreDestroy;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
 
 public class Handler
     implements jakarta.xml.ws.handler.LogicalHandler<LogicalMessageContext> {

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/HelloImpl.java
@@ -45,7 +45,7 @@ import java.util.Properties;
 // Service Implementation Class - as outlined in JAX-WS Specification
 
 import jakarta.jws.WebService;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 @WebService(portName = "HelloPort", targetNamespace = "http://dlhandlerservice.org/wsdl", serviceName = "DLHandlerService", wsdlLocation = "WEB-INF/wsdl/DLHandlerService.wsdl", endpointInterface = "com.sun.ts.tests.jaxws.sharedwebservices.dlhandlerservice.Hello")
 

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/hellosecureservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/hellosecureservice/HelloImpl.java
@@ -33,7 +33,7 @@ import java.security.Principal;
 // Service Implementation Class - as outlined in JAX-WS Specification
 
 import jakarta.jws.WebService;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 @WebService(portName = "HelloPort", serviceName = "HelloService", targetNamespace = "http://helloservice.org/wsdl", wsdlLocation = "WEB-INF/wsdl/WSHelloSecureService.wsdl", endpointInterface = "com.sun.ts.tests.jaxws.sharedwebservices.hellosecureservice.Hello")
 

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/HelloImpl.java
@@ -43,7 +43,7 @@ import java.util.Properties;
 // Service Implementation Class - as outlined in JAX-WS Specification
 
 import jakarta.jws.WebService;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 @WebService(portName = "HelloPort", targetNamespace = "http://rlhandlerservice.org/wsdl", serviceName = "RLHandlerService", wsdlLocation = "WEB-INF/wsdl/RLHandlerService.wsdl", endpointInterface = "com.sun.ts.tests.jaxws.sharedwebservices.rlhandlerservice.Hello")
 

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/AddNumbersImpl.java
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.jaxws.wsa.j2w.document.literal.action;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 import jakarta.jws.HandlerChain;
 import jakarta.jws.WebService;
 import jakarta.jws.WebMethod;

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/AddNumbersImpl.java
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.jaxws.wsa.j2w.document.literal.epr;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 import jakarta.jws.HandlerChain;
 import jakarta.jws.WebService;
 import jakarta.xml.ws.WebServiceContext;


### PR DESCRIPTION
This was missing in my previous patch.
[javatest.batch] Test results: passed: 851; failed: 1
The only failing test is signature now.