### PR TITLE
Change JDK javax.security.* classes from jakarta.security, back to javax.security #244

### DIFF
--- a/install/connector/bin/server_policy.append
+++ b/install/connector/bin/server_policy.append
@@ -53,7 +53,7 @@ grant {
      permission javax.security.auth.AuthPermission "modifyPublicCredentials";
      permission javax.security.auth.AuthPermission "modifyPrivateCredentials";
      permission javax.security.auth.AuthPermission  "createLoginContext.fileRealm";
-     permission jakarta.security.auth.PrivateCredentialPermission 
+     permission javax.security.auth.PrivateCredentialPermission 
                 "com.sun.enterprise.security.auth.login.common.PasswordCredential * \"*\"", "read";
      permission org.osgi.framework.AdminPermission "*", "*";
      permission javax.xml.ws.WebServicePermission  "publishEndpoint";

--- a/install/jacc/docs/assertions/spec/JACCSpecAssertions.html
+++ b/install/jacc/docs/assertions/spec/JACCSpecAssertions.html
@@ -150,7 +150,7 @@ applications or instances of an application).
 <TD align="center" valign="center"><a name="JACC:SPEC:14"></a><font size="1PT">JACC:SPEC:14</font></TD><TD align="center" valign="center"><font size="1PT">2</font></TD><TD align="center" valign="center"><font size="1PT">2.1</font></TD><TD align="left" valign="center"><font size="1PT">The security property  policy.provider may be used to replace the default
 java.security.Policy implementation class. Similarly, the security
 property  auth.policy.provider  may be used to replace the default
-jakarta.security.auth.Policy implementation class.
+javax.security.auth.Policy implementation class.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
 </font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">technology</font></TD><TD align="center" valign="center"><font size="1PT">active</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD>
@@ -170,7 +170,7 @@ JRE, then the JRE must be provided with an environment specific Policy
 implementation class. If the JRE is running a J2SE 1.4 security environment, then
 it must be provided with an implementation of the java.security.Policy
 class. If the JRE is running a J2SE 1.3 security environment, it must be provided
-with an implementation of the jakarta.security.auth.Policy class (that is,
+with an implementation of the javax.security.auth.Policy class (that is,
 a JAAS Policy object).
 			</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -259,8 +259,8 @@ when the system property
 jakarta.security.jacc.auth.policy.provider  is defined. That is,
 for each JRE of the application server, the server must construct an instance of the
 class identified by the system property, confirm that the resulting object is an
-instance of jakarta.security.auth.Policy, and set, by calling
-jakarta.security.auth.Policy.setPolicy method, the resulting object
+instance of javax.security.auth.Policy, and set, by calling
+javax.security.auth.Policy.setPolicy method, the resulting object
 as the corresponding Policy object used by the JRE.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -271,9 +271,9 @@ as the corresponding Policy object used by the JRE.
 server must install or bundle, such that it is used by every JRE of the application
 server, a javax.security.auth.SubjectDomainCombiner whose
 combine method returns protection domains constructed using the permission
-collections returned by jakarta.security.auth.Policy.getPermisions.
+collections returned by javax.security.auth.Policy.getPermisions.
 It is recommended that this requirement also be satisfied by J2EE 1.4 application
-servers in the case where jakarta.security.auth.Policy is being used (in
+servers in the case where javax.security.auth.Policy is being used (in
 backward compatibility mode) by the SubjectDomainCombiner.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -1285,7 +1285,7 @@ PermissionCollection implies it. Otherwise, the permission is not granted. This
 technique is supported but not recommended.
 
 -  The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions to determine the
+javax.security.auth.Policy.getPermissions to determine the
 collection of permissions granted independent of AccessControlContext. The
 Subject in the call to getPermissions may be null. The container must call
 the implies method on the returned PermissionCollection using the
@@ -1342,7 +1342,7 @@ been granted to the caller. Otherwise it has not. This technique is supported bu
 not recommended.
 
 The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions with an argument
+javax.security.auth.Policy.getPermissions with an argument
 Subject containing the principals of the caller.The container must call the
 implies method on the returned PermissionCollection using the permission
 being checked as argument. If the PermissionCollection implies the permission
@@ -1387,7 +1387,7 @@ via the java.security.Policy.getPolicy method.
 <TR>
 <TD align="center" valign="center"><a name="JACC:SPEC:107"></a><font size="1PT">JACC:SPEC:107</font></TD><TD align="center" valign="center"><font size="1PT">4</font></TD><TD align="center" valign="center"><font size="1PT">4.11</font></TD><TD align="left" valign="center"><font size="1PT">All of the JRE of a
 J2EE 1.3 application server must perform all of the policy decisions defined by
-this contract by interacting with the jakarta.security.auth.Policy instance
+this contract by interacting with the javax.security.auth.Policy instance
 available in the JRE via the jakarta.security.auth.getPolicy method.
 			</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>

--- a/install/jakartaee/bin/server_policy.append
+++ b/install/jakartaee/bin/server_policy.append
@@ -49,7 +49,7 @@ grant {
      permission javax.security.auth.AuthPermission "modifyPublicCredentials";
      permission javax.security.auth.AuthPermission "modifyPrivateCredentials";
      permission javax.security.auth.AuthPermission  "createLoginContext.fileRealm";
-     permission jakarta.security.auth.PrivateCredentialPermission 
+     permission javax.security.auth.PrivateCredentialPermission 
                 "com.sun.enterprise.security.auth.login.common.PasswordCredential * \"*\"", "read";
      permission org.osgi.framework.AdminPermission "*", "*";
      permission javax.xml.ws.WebServicePermission  "publishEndpoint";

--- a/install/jaspic/bin/server_policy.append
+++ b/install/jaspic/bin/server_policy.append
@@ -38,7 +38,7 @@ grant codebase "file:${com.sun.aas.installRoot}/domains/domain1/applications/-" 
      permission javax.security.auth.AuthPermission "modifyPublicCredentials";
      permission javax.security.auth.AuthPermission "modifyPrivateCredentials";
      permission javax.security.auth.AuthPermission  "createLoginContext.fileRealm";
-     permission jakarta.security.auth.PrivateCredentialPermission 
+     permission javax.security.auth.PrivateCredentialPermission 
                 "com.sun.enterprise.security.auth.login.common.PasswordCredential * \"*\"", "read";
      permission org.osgi.framework.AdminPermission "*", "*";
      permission javax.xml.ws.WebServicePermission  "publishEndpoint";

--- a/internal/docs/jacc/JACCSpecAssertions.html
+++ b/internal/docs/jacc/JACCSpecAssertions.html
@@ -150,7 +150,7 @@ applications or instances of an application).
 <TD align="center" valign="center"><a name="JACC:SPEC:14"></a><font size="1PT">JACC:SPEC:14</font></TD><TD align="center" valign="center"><font size="1PT">2</font></TD><TD align="center" valign="center"><font size="1PT">2.1</font></TD><TD align="left" valign="center"><font size="1PT">The security property  policy.provider may be used to replace the default
 java.security.Policy implementation class. Similarly, the security
 property  auth.policy.provider  may be used to replace the default
-jakarta.security.auth.Policy implementation class.
+javax.security.auth.Policy implementation class.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
 </font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">technology</font></TD><TD align="center" valign="center"><font size="1PT">active</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD>
@@ -170,7 +170,7 @@ JRE, then the JRE must be provided with an environment specific Policy
 implementation class. If the JRE is running a J2SE 1.4 security environment, then
 it must be provided with an implementation of the java.security.Policy
 class. If the JRE is running a J2SE 1.3 security environment, it must be provided
-with an implementation of the jakarta.security.auth.Policy class (that is,
+with an implementation of the javax.security.auth.Policy class (that is,
 a JAAS Policy object).
 			</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -259,8 +259,8 @@ when the system property
 jakarta.security.jacc.auth.policy.provider  is defined. That is,
 for each JRE of the application server, the server must construct an instance of the
 class identified by the system property, confirm that the resulting object is an
-instance of jakarta.security.auth.Policy, and set, by calling
-jakarta.security.auth.Policy.setPolicy method, the resulting object
+instance of javax.security.auth.Policy, and set, by calling
+javax.security.auth.Policy.setPolicy method, the resulting object
 as the corresponding Policy object used by the JRE.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -271,9 +271,9 @@ as the corresponding Policy object used by the JRE.
 server must install or bundle, such that it is used by every JRE of the application
 server, a javax.security.auth.SubjectDomainCombiner whose
 combine method returns protection domains constructed using the permission
-collections returned by jakarta.security.auth.Policy.getPermisions.
+collections returned by javax.security.auth.Policy.getPermisions.
 It is recommended that this requirement also be satisfied by J2EE 1.4 application
-servers in the case where jakarta.security.auth.Policy is being used (in
+servers in the case where javax.security.auth.Policy is being used (in
 backward compatibility mode) by the SubjectDomainCombiner.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -1285,7 +1285,7 @@ PermissionCollection implies it. Otherwise, the permission is not granted. This
 technique is supported but not recommended.
 
 -  The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions to determine the
+javax.security.auth.Policy.getPermissions to determine the
 collection of permissions granted independent of AccessControlContext. The
 Subject in the call to getPermissions may be null. The container must call
 the implies method on the returned PermissionCollection using the
@@ -1342,7 +1342,7 @@ been granted to the caller. Otherwise it has not. This technique is supported bu
 not recommended.
 
 The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions with an argument
+javax.security.auth.Policy.getPermissions with an argument
 Subject containing the principals of the caller.The container must call the
 implies method on the returned PermissionCollection using the permission
 being checked as argument. If the PermissionCollection implies the permission
@@ -1387,7 +1387,7 @@ via the java.security.Policy.getPolicy method.
 <TR>
 <TD align="center" valign="center"><a name="JACC:SPEC:107"></a><font size="1PT">JACC:SPEC:107</font></TD><TD align="center" valign="center"><font size="1PT">4</font></TD><TD align="center" valign="center"><font size="1PT">4.11</font></TD><TD align="left" valign="center"><font size="1PT">All of the JRE of a
 J2EE 1.3 application server must perform all of the policy decisions defined by
-this contract by interacting with the jakarta.security.auth.Policy instance
+this contract by interacting with the javax.security.auth.Policy instance
 available in the JRE via the jakarta.security.auth.getPolicy method.
 			</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>

--- a/internal/docs/jacc/JACCSpecAssertions.xml
+++ b/internal/docs/jacc/JACCSpecAssertions.xml
@@ -218,7 +218,7 @@ applications or instances of an application).
 			<description>The security property  policy.provider may be used to replace the default
 java.security.Policy implementation class. Similarly, the security
 property  auth.policy.provider  may be used to replace the default
-jakarta.security.auth.Policy implementation class.
+javax.security.auth.Policy implementation class.
 			</description>
 			<location chapter = "2" section = "2.1"/>
 			<comment>container</comment>
@@ -240,7 +240,7 @@ JRE, then the JRE must be provided with an environment specific Policy
 implementation class. If the JRE is running a J2SE 1.4 security environment, then
 it must be provided with an implementation of the java.security.Policy
 class. If the JRE is running a J2SE 1.3 security environment, it must be provided
-with an implementation of the jakarta.security.auth.Policy class (that is,
+with an implementation of the javax.security.auth.Policy class (that is,
 a JAAS Policy object).
 			</description>
 			<location chapter = "2" section = "2.5"/>
@@ -336,8 +336,8 @@ when the system property
 jakarta.security.jacc.auth.policy.provider  is defined. That is,
 for each JRE of the application server, the server must construct an instance of the
 class identified by the system property, confirm that the resulting object is an
-instance of jakarta.security.auth.Policy, and set, by calling
-jakarta.security.auth.Policy.setPolicy method, the resulting object
+instance of javax.security.auth.Policy, and set, by calling
+javax.security.auth.Policy.setPolicy method, the resulting object
 as the corresponding Policy object used by the JRE.
 			</description>
 			<location chapter = "2" section = "2.7"/>
@@ -349,9 +349,9 @@ as the corresponding Policy object used by the JRE.
 server must install or bundle, such that it is used by every JRE of the application
 server, a javax.security.auth.SubjectDomainCombiner whose
 combine method returns protection domains constructed using the permission
-collections returned by jakarta.security.auth.Policy.getPermisions.
+collections returned by javax.security.auth.Policy.getPermisions.
 It is recommended that this requirement also be satisfied by J2EE 1.4 application
-servers in the case where jakarta.security.auth.Policy is being used (in
+servers in the case where javax.security.auth.Policy is being used (in
 backward compatibility mode) by the SubjectDomainCombiner.
 			</description>
 			<location chapter = "2" section = "2.7.1"/>                        
@@ -1482,7 +1482,7 @@ PermissionCollection implies it. Otherwise, the permission is not granted. This
 technique is supported but not recommended.
 
 -  The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions to determine the
+javax.security.auth.Policy.getPermissions to determine the
 collection of permissions granted independent of AccessControlContext. The
 Subject in the call to getPermissions may be null. The container must call
 the implies method on the returned PermissionCollection using the
@@ -1540,7 +1540,7 @@ been granted to the caller. Otherwise it has not. This technique is supported bu
 not recommended.
 
 The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions with an argument
+javax.security.auth.Policy.getPermissions with an argument
 Subject containing the principals of the caller.The container must call the
 implies method on the returned PermissionCollection using the permission
 being checked as argument. If the PermissionCollection implies the permission
@@ -1589,7 +1589,7 @@ via the java.security.Policy.getPolicy method.
 			<id>107</id>
 			<description>All of the JRE of a
 J2EE 1.3 application server must perform all of the policy decisions defined by
-this contract by interacting with the jakarta.security.auth.Policy instance
+this contract by interacting with the javax.security.auth.Policy instance
 available in the JRE via the jakarta.security.auth.getPolicy method.
 			</description>
 			<location chapter = "4" section = "4.11"/>

--- a/internal/docs/jacc/jacc_0.3/JACCSpecAssertions_0.3.html
+++ b/internal/docs/jacc/jacc_0.3/JACCSpecAssertions_0.3.html
@@ -100,7 +100,7 @@
 <TD valign="center" align="center"><a name="JACC:SPEC:15"></a><font size="1PT">JACC:SPEC:15</font></TD><TD valign="center" align="center"><font size="1PT">2</font></TD><TD valign="center" align="center"><font size="1PT">2.4</font></TD><TD valign="center" align="left"><font size="1PT">If the container is running a Java 1.3 security environment, then it
    must be provided with the implementation of a class the extends the
    abstract class
-   jakarta.security.auth.Policy. If the container is running a Java 1.4
+   javax.security.auth.Policy. If the container is running a Java 1.4
    security environment, then it must also be provided with the
    implementation of a class that extends the abstract class,
    java.security.Policy.</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD><TD valign="center" align="center"><font size="1PT">
@@ -112,8 +112,8 @@
   jacc.auth.policy.provider  is defined, the application server must
    construct an instance of the class identified by the system 
    property, confirm that the resulting object is an instance of
-   jakarta.security.auth.Policy, and set, using 
-   jakarta.security.auth.Policy.setPolicy(), the resulting
+   javax.security.auth.Policy, and set, using 
+   javax.security.auth.Policy.setPolicy(), the resulting
    object as the corresponding Policy object used by the VM.
 
    If the system property jacc.policy.provider  is defined, an
@@ -203,7 +203,7 @@
 </TR>
 <TR>
 <TD valign="center" align="center"><a name="JACC:SPEC:55"></a><font size="1PT">JACC:SPEC:55</font></TD><TD valign="center" align="center"><font size="1PT">4</font></TD><TD valign="center" align="center"><font size="1PT">4.1</font></TD><TD valign="center" align="left"><font size="1PT">A container must rely on the java.security.Policy and or
-   jakarta.security.auth.Policy objects of the VM (available via
+   javax.security.auth.Policy objects of the VM (available via
    java.security.Policy.getPolicy(), and
    jakarta.security.auth.getPolicy() respectively) for all of the policy
    decisions defined by this contract.</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD><TD valign="center" align="center"><font size="1PT">
@@ -331,12 +331,12 @@
    access exception, the WebUserDataPermission is excluded. Otherwise
    the permission is not excluded.
      
-   A container that relies on a jakarta.security.auth.Policy provider may
+   A container that relies on a javax.security.auth.Policy provider may
    also use the following technique to determine if 
    WebUserDataPermission is excluded.
 
    a)The container shall call 
-   jakarta.security.auth.Policy.getPermissions() to determine
+   javax.security.auth.Policy.getPermissions() to determine
    the collection of permissions granted independent of Subject.
    To do this, the Subject in the call to getPermissions may be null.
    If getPermission returns an empty PermissionCollection, or if the
@@ -363,7 +363,7 @@
    correponding to the caller.
 
    Independent of whether a container employs a
-   jakarta.security.auth.Policy or a J2SE 1.4 java.security.Policy
+   javax.security.auth.Policy or a J2SE 1.4 java.security.Policy
    provider for its authorization decisions it may use one of the
    following techniques to determine if a permission has been granted
    to the caller.
@@ -382,12 +382,12 @@
    access exception, the permission is not granted to the caller.
    Otherwise the permission is granted.
 
-   A container that relies on a jakarta.security.auth.Policy provider may
+   A container that relies on a javax.security.auth.Policy provider may
    also use the following technique to determine if a permission has
    been granted to the caller.
 
    a)The container shall call
-   jakarta.security.auth.Policy.getPermissions() with the
+   javax.security.auth.Policy.getPermissions() with the
    Subject corresponding to the caller. The returned
    PermissionCollection will contain the collection of permissions
    granted to the caller. The container shall call the implies method
@@ -422,12 +422,12 @@
 <TD valign="center" align="center"><a name="JACC:SPEC:77"></a><font size="1PT">JACC:SPEC:77</font></TD><TD valign="center" align="center"><font size="1PT">4</font></TD><TD valign="center" align="center"><font size="1PT">4.7</font></TD><TD valign="center" align="left"><font size="1PT">To be compatible with this contract, a J2EE 1.3 container must
    perform all of its policy decisions as defined by this contract by
    interacting with a concrete implementation of the 
-   jakarta.security.auth.Policy abstract class.
+   javax.security.auth.Policy abstract class.
 
    A J2EE 1.4 container must perform all of its policy decisions as
    defined by this contract by interacting with concrete
    implementations of either or both of the java.security.Policy and
-   jakarta.security.auth.Policy abstract classes.</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD><TD valign="center" align="center"><font size="1PT">
+   javax.security.auth.Policy abstract classes.</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD><TD valign="center" align="center"><font size="1PT">
 <br>
 </font></TD><TD valign="center" align="center"><font size="1PT">false</font></TD><TD valign="center" align="center"><font size="1PT">technology</font></TD><TD valign="center" align="center"><font size="1PT">active</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD>
 </TR>

--- a/internal/docs/jacc/jacc_0.3/JACCSpecAssertions_0.3.xml
+++ b/internal/docs/jacc/jacc_0.3/JACCSpecAssertions_0.3.xml
@@ -219,7 +219,7 @@
 			<description>If the container is running a Java 1.3 security environment, then it
    must be provided with the implementation of a class the extends the
    abstract class
-   jakarta.security.auth.Policy. If the container is running a Java 1.4
+   javax.security.auth.Policy. If the container is running a Java 1.4
    security environment, then it must also be provided with the
    implementation of a class that extends the abstract class,
    java.security.Policy.</description>
@@ -251,8 +251,8 @@
   jacc.auth.policy.provider  is defined, the application server must
    construct an instance of the class identified by the system 
    property, confirm that the resulting object is an instance of
-   jakarta.security.auth.Policy, and set, using 
-   jakarta.security.auth.Policy.setPolicy(), the resulting
+   javax.security.auth.Policy, and set, using 
+   javax.security.auth.Policy.setPolicy(), the resulting
    object as the corresponding Policy object used by the VM.
 
    If the system property jacc.policy.provider  is defined, an
@@ -730,7 +730,7 @@
 		<assertion required = "true" impl-spec = "false" defined-by = "technology" status = "active" testable = "false">
 			<id>50</id>
 			<description>A container must rely on the java.security.Policy and or
-   jakarta.security.auth.Policy objects of the VM (available via
+   javax.security.auth.Policy objects of the VM (available via
    java.security.Policy.getPolicy(), and
    jakarta.security.auth.getPolicy() respectively) for all of the policy
    decisions defined by this contract.</description>
@@ -1004,12 +1004,12 @@ patterns.</description>
    access exception, the WebUserDataPermission is excluded. Otherwise
    the permission is not excluded.
      
-   A container that relies on a jakarta.security.auth.Policy provider may
+   A container that relies on a javax.security.auth.Policy provider may
    also use the following technique to determine if 
    WebUserDataPermission is excluded.
 
    a)The container shall call 
-   jakarta.security.auth.Policy.getPermissions() to determine
+   javax.security.auth.Policy.getPermissions() to determine
    the collection of permissions granted independent of Subject.
    To do this, the Subject in the call to getPermissions may be null.
    If getPermission returns an empty PermissionCollection, or if the
@@ -1037,7 +1037,7 @@ patterns.</description>
    correponding to the caller.
 
    Independent of whether a container employs a
-   jakarta.security.auth.Policy or a J2SE 1.4 java.security.Policy
+   javax.security.auth.Policy or a J2SE 1.4 java.security.Policy
    provider for its authorization decisions it may use one of the
    following techniques to determine if a permission has been granted
    to the caller.
@@ -1056,12 +1056,12 @@ patterns.</description>
    access exception, the permission is not granted to the caller.
    Otherwise the permission is granted.
 
-   A container that relies on a jakarta.security.auth.Policy provider may
+   A container that relies on a javax.security.auth.Policy provider may
    also use the following technique to determine if a permission has
    been granted to the caller.
 
    a)The container shall call
-   jakarta.security.auth.Policy.getPermissions() with the
+   javax.security.auth.Policy.getPermissions() with the
    Subject corresponding to the caller. The returned
    PermissionCollection will contain the collection of permissions
    granted to the caller. The container shall call the implies method
@@ -1097,12 +1097,12 @@ patterns.</description>
 			<description>To be compatible with this contract, a J2EE 1.3 container must
    perform all of its policy decisions as defined by this contract by
    interacting with a concrete implementation of the 
-   jakarta.security.auth.Policy abstract class.
+   javax.security.auth.Policy abstract class.
 
    A J2EE 1.4 container must perform all of its policy decisions as
    defined by this contract by interacting with concrete
    implementations of either or both of the java.security.Policy and
-   jakarta.security.auth.Policy abstract classes.</description>
+   javax.security.auth.Policy abstract classes.</description>
 			<location chapter = "4" section = "4.7"/>
 			<comment>container</comment>
 		</assertion>

--- a/internal/docs/jacc/jacc_1.2/JACCSpecAssertions.html
+++ b/internal/docs/jacc/jacc_1.2/JACCSpecAssertions.html
@@ -104,7 +104,7 @@ applications or instances of an application).
 <TD align="center" valign="center"><a name="JACC:SPEC:14"></a><font size="1PT">JACC:SPEC:14</font></TD><TD align="center" valign="center"><font size="1PT">2</font></TD><TD align="center" valign="center"><font size="1PT">2.1</font></TD><TD align="left" valign="center"><font size="1PT">The security property  policy.provider may be used to replace the default
 java.security.Policy implementation class. Similarly, the security
 property  auth.policy.provider  may be used to replace the default
-jakarta.security.auth.Policy implementation class.
+javax.security.auth.Policy implementation class.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
 </font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">technology</font></TD><TD align="center" valign="center"><font size="1PT">active</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD>
@@ -161,8 +161,8 @@ when the system property
 jakarta.security.jacc.auth.policy.provider  is defined. That is,
 for each JRE of the application server, the server must construct an instance of the
 class identified by the system property, confirm that the resulting object is an
-instance of jakarta.security.auth.Policy, and set, by calling
-jakarta.security.auth.Policy.setPolicy method, the resulting object
+instance of javax.security.auth.Policy, and set, by calling
+javax.security.auth.Policy.setPolicy method, the resulting object
 as the corresponding Policy object used by the JRE.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -173,9 +173,9 @@ as the corresponding Policy object used by the JRE.
 server must install or bundle, such that it is used by every JRE of the application
 server, a javax.security.auth.SubjectDomainCombiner whose
 combine method returns protection domains constructed using the permission
-collections returned by jakarta.security.auth.Policy.getPermisions.
+collections returned by javax.security.auth.Policy.getPermisions.
 It is recommended that this requirement also be satisfied by J2EE 1.4 application
-servers in the case where jakarta.security.auth.Policy is being used (in
+servers in the case where javax.security.auth.Policy is being used (in
 backward compatibility mode) by the SubjectDomainCombiner.
 			</font></TD><TD align="center" valign="center"><font size="1PT">true</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -500,7 +500,7 @@ PermissionCollection implies it. Otherwise, the permission is not granted. This
 technique is supported but not recommended.
 
 -  The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions to determine the
+javax.security.auth.Policy.getPermissions to determine the
 collection of permissions granted independent of AccessControlContext. The
 Subject in the call to getPermissions may be null. The container must call
 the implies method on the returned PermissionCollection using the
@@ -557,7 +557,7 @@ been granted to the caller. Otherwise it has not. This technique is supported bu
 not recommended.
 
 The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions with an argument
+javax.security.auth.Policy.getPermissions with an argument
 Subject containing the principals of the caller.The container must call the
 implies method on the returned PermissionCollection using the permission
 being checked as argument. If the PermissionCollection implies the permission
@@ -582,7 +582,7 @@ via the java.security.Policy.getPolicy method.
 <TR>
 <TD align="center" valign="center"><a name="JACC:SPEC:107"></a><font size="1PT">JACC:SPEC:107</font></TD><TD align="center" valign="center"><font size="1PT">4</font></TD><TD align="center" valign="center"><font size="1PT">4.11</font></TD><TD align="left" valign="center"><font size="1PT">All of the JRE of a
 J2EE 1.3 application server must perform all of the policy decisions defined by
-this contract by interacting with the jakarta.security.auth.Policy instance
+this contract by interacting with the javax.security.auth.Policy instance
 available in the JRE via the jakarta.security.auth.getPolicy method.
 			</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>
@@ -762,7 +762,7 @@ JRE, then the JRE must be provided with an environment specific Policy
 implementation class. If the JRE is running a J2SE 1.4 security environment, then
 it must be provided with an implementation of the java.security.Policy
 class. If the JRE is running a J2SE 1.3 security environment, it must be provided
-with an implementation of the jakarta.security.auth.Policy class (that is,
+with an implementation of the javax.security.auth.Policy class (that is,
 a JAAS Policy object).
 			</font></TD><TD align="center" valign="center"><font size="1PT">false</font></TD><TD align="center" valign="center"><font size="1PT">
 <br>

--- a/internal/docs/jacc/jacc_1.2/assertions.html
+++ b/internal/docs/jacc/jacc_1.2/assertions.html
@@ -104,7 +104,7 @@ applications or instances of an application).
 <TD valign="center" align="center"><a name="JACC:SPEC:14"></a><font size="1PT">JACC:SPEC:14</font></TD><TD valign="center" align="center"><font size="1PT">2</font></TD><TD valign="center" align="center"><font size="1PT">2.1</font></TD><TD valign="center" align="left"><font size="1PT">The security property  policy.provider may be used to replace the default
 java.security.Policy implementation class. Similarly, the security
 property  auth.policy.provider  may be used to replace the default
-jakarta.security.auth.Policy implementation class.
+javax.security.auth.Policy implementation class.
 			</font></TD><TD valign="center" align="center"><font size="1PT">false</font></TD><TD valign="center" align="center"><font size="1PT">
 <br>
 </font></TD><TD valign="center" align="center"><font size="1PT">false</font></TD><TD valign="center" align="center"><font size="1PT">technology</font></TD><TD valign="center" align="center"><font size="1PT">active</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD>
@@ -148,8 +148,8 @@ object as the corresponding Policy object used by the JRE.
 &ldquo;jakarta.security.jacc.auth.policy.provider&rdquo; is defined, an application
 server must use an analogous method to construct an instance of the class
 identified by the system property, confirm that the resulting object is an instance
-of jakarta.security.auth.Policy, and set, by calling
-jakarta.security.auth.Policy.setPolicy, the resulting object as the
+of javax.security.auth.Policy, and set, by calling
+javax.security.auth.Policy.setPolicy, the resulting object as the
 corresponding Policy object used by the JRE.
 			</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD><TD valign="center" align="center"><font size="1PT">
 <br>
@@ -160,9 +160,9 @@ corresponding Policy object used by the JRE.
 server must install or bundle, such that it is used by every JRE of the application
 server, a javax.security.auth.SubjectDomainCombiner whose
 combine method returns protection domains constructed using the permission
-collections returned by jakarta.security.auth.Policy.getPermisions.
+collections returned by javax.security.auth.Policy.getPermisions.
 It is recommended that this requirement also be satisfied by J2EE 1.4 application
-servers in the case where jakarta.security.auth.Policy is being used (in
+servers in the case where javax.security.auth.Policy is being used (in
 backward compatibility mode) by the SubjectDomainCombiner.
 			</font></TD><TD valign="center" align="center"><font size="1PT">true</font></TD><TD valign="center" align="center"><font size="1PT">
 <br>
@@ -472,7 +472,7 @@ PermissionCollection does not imply it. Otherwise, the permission is not
 excluded. This technique is supported but not recommended.
 
 The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions to determine the
+javax.security.auth.Policy.getPermissions to determine the
 collection of permissions granted independent of access control context. The
 Subject argument in the call to getPermissions may be null. The container
 must call the impliesmethod on the returned PermissionCollection using the
@@ -529,7 +529,7 @@ been granted to the caller. Otherwise it has not. This technique is supported bu
 not recommended.
 
 The J2EE 1.3 container calls
-jakarta.security.auth.Policy.getPermissions with an argument
+javax.security.auth.Policy.getPermissions with an argument
 Subject containing the principals of the caller.The container must call the
 implies method on the returned PermissionCollection using the permission
 being checked as argument. If the PermissionCollection implies the permission
@@ -554,7 +554,7 @@ via the java.security.Policy.getPolicy method.
 <TR>
 <TD valign="center" align="center"><a name="JACC:SPEC:107"></a><font size="1PT">JACC:SPEC:107</font></TD><TD valign="center" align="center"><font size="1PT">4</font></TD><TD valign="center" align="center"><font size="1PT">4.11</font></TD><TD valign="center" align="left"><font size="1PT">All of the JRE&rsquo;s of a
 J2EE 1.3 application server must perform all of the policy decisions defined by
-this contract by interacting with the jakarta.security.auth.Policy instance
+this contract by interacting with the javax.security.auth.Policy instance
 available in the JRE via the jakarta.security.auth.getPolicy method.
 			</font></TD><TD valign="center" align="center"><font size="1PT">false</font></TD><TD valign="center" align="center"><font size="1PT">
 <br>
@@ -613,7 +613,7 @@ JRE, then the JRE must be provided with an environment specific Policy
 implementation class. If the JRE is running a J2SE 1.4 security environment, then
 it must be provided with an implementation of the java.security.Policy
 class. If the JRE is running a J2SE 1.3 security environment, it must be provided
-with an implementation of the jakarta.security.auth.Policy class (that is,
+with an implementation of the javax.security.auth.Policy class (that is,
 a JAAS Policy object).
 			</font></TD><TD valign="center" align="center"><font size="1PT">false</font></TD><TD valign="center" align="center"><font size="1PT">
 <br>

--- a/src/com/sun/ts/lib/util/sec/security/provider/PolicyFile.java
+++ b/src/com/sun/ts/lib/util/sec/security/provider/PolicyFile.java
@@ -38,7 +38,7 @@ import com.sun.ts.lib.util.sec.security.auth.PrincipalComparator;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import jakarta.security.auth.PrivateCredentialPermission;
+import javax.security.auth.PrivateCredentialPermission;
 import javax.security.auth.Subject;
 import javax.security.auth.x500.X500Principal;
 import java.io.FilePermission;
@@ -829,7 +829,7 @@ public class PolicyFile extends java.security.Policy {
           // XXX special case PrivateCredentialPermission-SELF
           Permission perm;
           if (pe.permission
-              .equals("jakarta.security.auth.PrivateCredentialPermission")
+              .equals("javax.security.auth.PrivateCredentialPermission")
               && pe.name.endsWith(" self")) {
             pe.name = pe.name.substring(0, pe.name.indexOf("self")) + SELF;
           }


### PR DESCRIPTION
Checked for remaining classes in javax.security.auth and changed those back to javax:
Destroyable
DestroyFailedException
Policy
PrivateCredentialPermission
Refreshable
RefreshFailedException
SubjectDomainCombiner