### PR TITLE
WebSocket signature update

### DIFF
--- a/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig_2.0_se11
+++ b/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig_2.0_se11
@@ -219,8 +219,8 @@ innr public abstract interface static Binary
 innr public abstract interface static BinaryStream
 innr public abstract interface static Text
 innr public abstract interface static TextStream
-meth public abstract void destroy()
-meth public abstract void init(jakarta.websocket.EndpointConfig)
+meth public void destroy()
+meth public void init(jakarta.websocket.EndpointConfig)
 
 CLSS public abstract interface static jakarta.websocket.Decoder$Binary<%0 extends java.lang.Object>
  outer jakarta.websocket.Decoder
@@ -261,8 +261,8 @@ innr public abstract interface static Binary
 innr public abstract interface static BinaryStream
 innr public abstract interface static Text
 innr public abstract interface static TextStream
-meth public abstract void destroy()
-meth public abstract void init(jakarta.websocket.EndpointConfig)
+meth public void destroy()
+meth public void init(jakarta.websocket.EndpointConfig)
 
 CLSS public abstract interface static jakarta.websocket.Encoder$Binary<%0 extends java.lang.Object>
  outer jakarta.websocket.Encoder

--- a/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig_2.0_se8
+++ b/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig_2.0_se8
@@ -218,8 +218,8 @@ innr public abstract interface static Binary
 innr public abstract interface static BinaryStream
 innr public abstract interface static Text
 innr public abstract interface static TextStream
-meth public abstract void destroy()
-meth public abstract void init(jakarta.websocket.EndpointConfig)
+meth public void destroy()
+meth public void init(jakarta.websocket.EndpointConfig)
 
 CLSS public abstract interface static jakarta.websocket.Decoder$Binary<%0 extends java.lang.Object>
  outer jakarta.websocket.Decoder
@@ -260,8 +260,8 @@ innr public abstract interface static Binary
 innr public abstract interface static BinaryStream
 innr public abstract interface static Text
 innr public abstract interface static TextStream
-meth public abstract void destroy()
-meth public abstract void init(jakarta.websocket.EndpointConfig)
+meth public void destroy()
+meth public void init(jakarta.websocket.EndpointConfig)
 
 CLSS public abstract interface static jakarta.websocket.Encoder$Binary<%0 extends java.lang.Object>
  outer jakarta.websocket.Encoder


### PR DESCRIPTION
The WebSocket team have made a small, backwards compatible change to the WebSocket API to add default methods where appropriate. This PR updates the signature tests for these changes.