### PR TITLE
Issue #254 Fix typo in servlet attribute name containing exception type (fix for javax.servlet TCK)

### DIFF
--- a/src/com/sun/ts/tests/servlet/api/javax_servlet/genericservlet/ServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/api/javax_servlet/genericservlet/ServletErrorPage.java
@@ -25,6 +25,7 @@
 package com.sun.ts.tests.servlet.api.javax_servlet.genericservlet;
 
 import javax.servlet.GenericServlet;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -37,17 +38,17 @@ import java.io.PrintWriter;
 
 public class ServletErrorPage extends GenericServlet {
 
-  private static final String STATUS_CODE = "javax.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "javax.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "javax.serlvet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"javax.servlet.error.exception_type";
 
-  private static final String MESSAGE = "javax.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"javax.servlet.error.message";
 
-  private static final String EXCEPTION = "javax.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"javax.servlet.error.exception";
 
-  private static final String REQUEST_URI = "javax.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"javax.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "javax.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"javax.servlet.error.servlet_name";
 
   private static final String EXP_MESSAGE = "error page invoked";
 

--- a/src/com/sun/ts/tests/servlet/api/javax_servlet_http/httpservletresponse/ServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/api/javax_servlet_http/httpservletresponse/ServletErrorPage.java
@@ -23,6 +23,7 @@
  */
 package com.sun.ts.tests.servlet.api.javax_servlet_http.httpservletresponse;
 
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -36,17 +37,17 @@ import java.io.PrintWriter;
 
 public class ServletErrorPage extends HttpServlet {
 
-  private static final String STATUS_CODE = "javax.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "javax.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "javax.serlvet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"javax.servlet.error.exception_type";
 
-  private static final String MESSAGE = "javax.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"javax.servlet.error.message";
 
-  private static final String EXCEPTION = "javax.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"javax.servlet.error.exception";
 
-  private static final String REQUEST_URI = "javax.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"javax.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "javax.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"javax.servlet.error.servlet_name";
 
   private static final String EXP_MESSAGE = "error page invoked";
 

--- a/src/com/sun/ts/tests/servlet/spec/errorpage/SecondServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/spec/errorpage/SecondServletErrorPage.java
@@ -22,6 +22,7 @@ package com.sun.ts.tests.servlet.spec.errorpage;
 
 import com.sun.ts.tests.servlet.common.util.Data;
 
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -35,17 +36,17 @@ import java.io.PrintWriter;
 
 public class SecondServletErrorPage extends HttpServlet {
 
-  private static final String STATUS_CODE = "javax.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "javax.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "javax.serlvet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"javax.servlet.error.exception_type";
 
-  private static final String MESSAGE = "javax.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"javax.servlet.error.message";
 
-  private static final String EXCEPTION = "javax.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"javax.servlet.error.exception";
 
-  private static final String REQUEST_URI = "javax.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"javax.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "javax.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"javax.servlet.error.servlet_name";
 
   private static final String EXP_MESSAGE = "error page invoked";
 
@@ -60,7 +61,8 @@ public class SecondServletErrorPage extends HttpServlet {
     pw.println("Servlet Name: " + req.getAttribute(SERVLET_NAME));
     pw.println("Request URI: " + req.getAttribute(REQUEST_URI));
     pw.println("Status Code: " + req.getAttribute(STATUS_CODE));
-    pw.println("Exception Type: " + req.getAttribute(EXCEPTION_TYPE));
+    // with the cast we even enforce it's a Class type
+    pw.println("Exception Type: " + ((Class)req.getAttribute(EXCEPTION_TYPE)).getName());
     pw.println("Exception: " + req.getAttribute(EXCEPTION));
     pw.print("Message: ");
     if (((String) req.getAttribute(MESSAGE)).indexOf(EXP_MESSAGE) > -1) {

--- a/src/com/sun/ts/tests/servlet/spec/errorpage/ServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/spec/errorpage/ServletErrorPage.java
@@ -22,6 +22,7 @@ package com.sun.ts.tests.servlet.spec.errorpage;
 
 import com.sun.ts.tests.servlet.common.util.Data;
 
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -35,17 +36,17 @@ import java.io.PrintWriter;
 
 public class ServletErrorPage extends HttpServlet {
 
-  private static final String STATUS_CODE = "javax.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "javax.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "javax.serlvet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"javax.servlet.error.exception_type";
 
-  private static final String MESSAGE = "javax.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"javax.servlet.error.message";
 
-  private static final String EXCEPTION = "javax.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"javax.servlet.error.exception";
 
-  private static final String REQUEST_URI = "javax.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"javax.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "javax.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"javax.servlet.error.servlet_name";
 
   private static final String EXP_MESSAGE = "error page invoked";
 
@@ -60,7 +61,8 @@ public class ServletErrorPage extends HttpServlet {
     pw.println("Servlet Name: " + req.getAttribute(SERVLET_NAME));
     pw.println("Request URI: " + req.getAttribute(REQUEST_URI));
     pw.println("Status Code: " + req.getAttribute(STATUS_CODE));
-    pw.println("Exception Type: " + req.getAttribute(EXCEPTION_TYPE));
+    // with the cast we even enforce it's a Class type
+    pw.println("Exception Type: " + ((Class)req.getAttribute(EXCEPTION_TYPE)).getName());
     pw.println("Exception: " + req.getAttribute(EXCEPTION));
     pw.print("Message: ");
     if (((String) req.getAttribute(MESSAGE)).indexOf(EXP_MESSAGE) > -1) {

--- a/src/com/sun/ts/tests/servlet/spec/errorpage/URLClient.java
+++ b/src/com/sun/ts/tests/servlet/spec/errorpage/URLClient.java
@@ -72,7 +72,7 @@ public class URLClient extends AbstractUrlClient {
     TEST_PROPS.setProperty(APITEST, "servletErrorPageTest");
     TEST_PROPS.setProperty(STATUS_CODE, INTERNAL_SERVER_ERROR);
     TEST_PROPS.setProperty(SEARCH_STRING,
-        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: null|Exception: java.lang.IllegalStateException: error page invoked|Message: error page invoked");
+        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: java.lang.IllegalStateException|Exception: java.lang.IllegalStateException: error page invoked|Message: error page invoked");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, Data.FAILED);
     invoke();
 
@@ -120,7 +120,7 @@ public class URLClient extends AbstractUrlClient {
     TEST_PROPS.setProperty(APITEST, "heirarchyErrorMatchTest");
     TEST_PROPS.setProperty(STATUS_CODE, INTERNAL_SERVER_ERROR);
     TEST_PROPS.setProperty(SEARCH_STRING,
-        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: null|Exception: java.lang.IllegalThreadStateException: error page invoked|Message: error page invoked");
+        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: java.lang.IllegalThreadStateException|Exception: java.lang.IllegalThreadStateException: error page invoked|Message: error page invoked");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, Data.FAILED);
     invoke();
   }
@@ -146,7 +146,7 @@ public class URLClient extends AbstractUrlClient {
     TEST_PROPS.setProperty(SEARCH_STRING, "Second ErrorPage|"
         + "Servlet Name: WrappedException|"
         + "Request URI: /servlet_spec_errorpage_web/WrappedException|Status Code: 500|"
-        + "Exception Type: null|"
+        + "Exception Type: com.sun.ts.tests.servlet.spec.errorpage.TestException|"
         + "Exception: com.sun.ts.tests.servlet.spec.errorpage.TestException: error page invoked|Message: error page invoked");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, Data.FAILED);
     TEST_PROPS.setProperty(REQUEST,


### PR DESCRIPTION
Currently the tests are using a constant with a typo `javax.serlvet.error.exception_type` note the `serlvet`  https://github.com/eclipse-ee4j/jakartaee-tck/pull/258/commits/b7360eee2dc21fa33a7a692bf44916cecdfb7990#diff-f09eab37c700ed051ff72ff5e9a13963L42 so the test assert the attribute with the typo in the name returns Null https://github.com/eclipse-ee4j/jakartaee-tck/pull/258/commits/b7360eee2dc21fa33a7a692bf44916cecdfb7990#diff-050a4404eb79e87a2927e2e5f722de06L75 whereas as the specs says this attribute should contains the class of the exception in the format `java.lang.Class`. 
So I changed the  constant to use constants from the servlet api jar class `RequestDispatcher` and I fix the assert as well to contains the class in the toString format.