### PR TITLE
Fix unreliable timeout tests (issue #260)

### DIFF
--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -1150,9 +1150,11 @@ class TCKConfigurator extends Configurator {
   void TCKConfigurator() {
   }
 
+  @Override
   public void beforeRequest(Map<String, List<String>> headers) {
   }
 
+  @Override
   public void afterResponse(HandshakeResponse hr) {
   }
 }

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -21,7 +21,6 @@
 package com.sun.ts.tests.websocket.api.jakarta.websocket.clientendpointconfig;
 
 import com.sun.javatest.Status;
-import com.sun.ts.lib.harness.EETest.Fault;
 import com.sun.ts.lib.harness.ServiceEETest;
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.websocket.common.TCKExtension;

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -1146,9 +1146,6 @@ public class WSClient extends ServiceEETest {
 
 class TCKConfigurator extends Configurator {
 
-  void TCKConfigurator() {
-  }
-
   @Override
   public void beforeRequest(Map<String, List<String>> headers) {
   }

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -203,7 +203,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -284,7 +284,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -380,7 +380,7 @@ public class WSClient extends ServiceEETest {
     boolean passed = true;
     StringBuffer log = new StringBuffer();
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
@@ -442,7 +442,7 @@ public class WSClient extends ServiceEETest {
     boolean passed = true;
     StringBuffer log = new StringBuffer();
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -509,7 +509,7 @@ public class WSClient extends ServiceEETest {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -533,7 +533,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -664,13 +664,13 @@ public class WSClient extends ServiceEETest {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.BooleanEncoder.class);
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -694,7 +694,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -963,13 +963,13 @@ public class WSClient extends ServiceEETest {
     List<String> expected_subprotocols = Arrays.asList("JSON", "XML", "XMPP",
         "Hessian", "Quake", "PUB/SUB", "Query");
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.BooleanEncoder.class);
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -995,7 +995,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -41,6 +41,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ws_wait; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
   }
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/closereason/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/closereason/WSClient.java
@@ -69,6 +69,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
   }
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/closereason/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/closereason/WSClient.java
@@ -21,7 +21,6 @@
 package com.sun.ts.tests.websocket.api.jakarta.websocket.closereason;
 
 import com.sun.javatest.Status;
-import com.sun.ts.lib.harness.EETest.Fault;
 import com.sun.ts.lib.harness.ServiceEETest;
 import java.io.PrintWriter;
 import java.util.Properties;

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/closereason/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/closereason/WSClient.java
@@ -132,7 +132,6 @@ public class WSClient extends ServiceEETest {
     boolean passed = true;
 
     int size = codes_number.length;
-    CloseReason closereason;
 
     for (int i = 0; i < size; i++) {
       if (!CloseReason.CloseCodes.valueOf(codes_string[i]).equals(codes[i])) {
@@ -230,7 +229,6 @@ public class WSClient extends ServiceEETest {
     boolean passed = true;
 
     int size = codes_number.length;
-    CloseReason closereason;
     CloseCode tmp;
 
     for (int i = 0; i < size; i++) {

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/decodeexception/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/decodeexception/WSClient.java
@@ -48,6 +48,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ws_wait; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
     try {
       TestUtil.init(p);

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/deploymentException/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/deploymentException/WSClient.java
@@ -38,6 +38,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ws_wait; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
   }
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/deploymentException/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/deploymentException/WSClient.java
@@ -21,7 +21,6 @@
 package com.sun.ts.tests.websocket.api.jakarta.websocket.deploymentException;
 
 import com.sun.javatest.Status;
-import com.sun.ts.lib.harness.EETest.Fault;
 import com.sun.ts.lib.harness.ServiceEETest;
 import java.io.PrintWriter;
 import java.util.Properties;

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/deploymentException/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/deploymentException/WSClient.java
@@ -52,6 +52,7 @@ public class WSClient extends ServiceEETest {
   public void constructorTest() throws Fault {
     String reason = "TCK: testing the DeploymentException(String)";
 
+    @SuppressWarnings("unused")
     DeploymentException dex = new DeploymentException(reason);
 
   }
@@ -66,6 +67,7 @@ public class WSClient extends ServiceEETest {
   public void constructorTest1() throws Fault {
     String reason = "TCK: testing the DeploymentException(String)";
 
+    @SuppressWarnings("unused")
     DeploymentException dex = new DeploymentException(reason,
         new Throwable("TCK_Test"));
   }

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/encodeexception/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/encodeexception/WSClient.java
@@ -39,6 +39,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ws_wait; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
   }
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/encodeexception/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/encodeexception/WSClient.java
@@ -21,7 +21,6 @@
 package com.sun.ts.tests.websocket.api.jakarta.websocket.encodeexception;
 
 import com.sun.javatest.Status;
-import com.sun.ts.lib.harness.EETest.Fault;
 import com.sun.ts.lib.harness.ServiceEETest;
 import com.sun.ts.lib.util.TestUtil;
 import java.io.PrintWriter;

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/server/serverendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/server/serverendpointconfig/WSClient.java
@@ -21,7 +21,6 @@
 package com.sun.ts.tests.websocket.api.jakarta.websocket.server.serverendpointconfig;
 
 import com.sun.javatest.Status;
-import com.sun.ts.lib.harness.EETest.Fault;
 import com.sun.ts.lib.harness.ServiceEETest;
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.websocket.common.TCKExtension;

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/server/serverendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/server/serverendpointconfig/WSClient.java
@@ -211,7 +211,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -295,7 +295,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -391,7 +391,7 @@ public class WSClient extends ServiceEETest {
     boolean passed = true;
     StringBuffer log = new StringBuffer();
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
@@ -456,7 +456,7 @@ public class WSClient extends ServiceEETest {
     boolean passed = true;
     StringBuffer log = new StringBuffer();
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -526,7 +526,7 @@ public class WSClient extends ServiceEETest {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -550,7 +550,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -682,13 +682,13 @@ public class WSClient extends ServiceEETest {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.BooleanEncoder.class);
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -712,7 +712,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -1063,13 +1063,13 @@ public class WSClient extends ServiceEETest {
     List<String> expected_subprotocols = Arrays.asList("JSON", "XML", "XMPP",
         "Hessian", "Quake", "PUB/SUB", "Query");
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.BooleanEncoder.class);
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -1095,7 +1095,7 @@ public class WSClient extends ServiceEETest {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/server/serverendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/server/serverendpointconfig/WSClient.java
@@ -46,6 +46,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ws_wait; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
   }
 

--- a/src/com/sun/ts/tests/websocket/api/jakarta/websocket/websocketcontainer/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/api/jakarta/websocket/websocketcontainer/WSClient.java
@@ -44,6 +44,7 @@ public class WSClient extends ServiceEETest {
   /*
    * @class.setup_props: webServerHost; webServerPort; ts_home;
    */
+  @SuppressWarnings("unused")
   public void setup(String[] args, Properties p) throws Fault {
   }
 

--- a/src/com/sun/ts/tests/websocket/common/client/ApacheRequestAdapter.java
+++ b/src/com/sun/ts/tests/websocket/common/client/ApacheRequestAdapter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,6 +34,7 @@ public class ApacheRequestAdapter extends HttpRequest {
    * 
    * @return String request path
    */
+  @Override
   public String getRequestPath() {
     return super.getRequestPath();
   }

--- a/src/com/sun/ts/tests/websocket/common/client/ClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/common/client/ClientEndpoint.java
@@ -203,7 +203,7 @@ public abstract class ClientEndpoint<T extends Object> extends Endpoint
     return ClientEndpointData.sb;
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({ "unchecked", "unused" })
   public T getLastMessage(Class<T> messageType) {
     return (T) ClientEndpointData.lastMessage;
   }

--- a/src/com/sun/ts/tests/websocket/common/client/EndpointCallback.java
+++ b/src/com/sun/ts/tests/websocket/common/client/EndpointCallback.java
@@ -37,15 +37,19 @@ import jakarta.websocket.Session;
  */
 public class EndpointCallback {
 
+  @SuppressWarnings("unused")
   public void onError(Session session, Throwable t) {
   }
 
+  @SuppressWarnings("unused")
   public void onMessage(Object o) {
   }
 
+  @SuppressWarnings("unused")
   public void onOpen(Session session, EndpointConfig config) {
   }
 
+  @SuppressWarnings("unused")
   public void onClose(Session session, CloseReason closeReason) {
   }
 

--- a/src/com/sun/ts/tests/websocket/common/client/WebSocketCommonClient.java
+++ b/src/com/sun/ts/tests/websocket/common/client/WebSocketCommonClient.java
@@ -636,7 +636,7 @@ public abstract class WebSocketCommonClient extends ServiceEETest {
         "[WebSocketCommonClient] 'ws_wait' (in seconds) ts.jte must be set greater than 0");
 
     TestUtil.logMsg("[WebSocketCommonClient] Test setup OK");
-    TEST_PROPS = new Hashtable<Property, String>();
+    TEST_PROPS = new Hashtable<>();
   }
 
   // ///////////////////////////// Utility methods
@@ -996,7 +996,7 @@ public abstract class WebSocketCommonClient extends ServiceEETest {
   protected static//
   Map<String, List<String>> basicAuthenticationAsHeaderMap(String userName,
       String password) {
-    Map<String, List<String>> headers = new HashMap<String, List<String>>();
+    Map<String, List<String>> headers = new HashMap<>();
     String toEncode = new StringBuilder().append(userName).append(':')
         .append(password).toString();
     String base64 = new BASE64Encoder().encode(toEncode.getBytes());

--- a/src/com/sun/ts/tests/websocket/common/client/WebSocketTestCase.java
+++ b/src/com/sun/ts/tests/websocket/common/client/WebSocketTestCase.java
@@ -501,7 +501,7 @@ public class WebSocketTestCase extends WebTestCase {
     return ClientEndpoint.getMessageBuilder().toString();
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({ "unchecked", "unused" })
   protected <T> T getLastResponse(Class<T> type) {
     return (T) ClientEndpointData.lastMessage;
   }

--- a/src/com/sun/ts/tests/websocket/common/client/WebSocketTestCase.java
+++ b/src/com/sun/ts/tests/websocket/common/client/WebSocketTestCase.java
@@ -143,8 +143,8 @@ public class WebSocketTestCase extends WebTestCase {
     this.client = client;
     clientEndpointConfig = ClientEndpointConfig.Builder.create().build();
     strategy = ValidationFactory.getInstance(TOKENIZED_STRATEGY);
-    configurators = new LinkedList<ClientEndpointConfig.Configurator>();
-    slaveClientCallbacks = new LinkedList<EndpointCallback>();
+    configurators = new LinkedList<>();
+    slaveClientCallbacks = new LinkedList<>();
     ClientEndpointData.resetData();
     logTrace("A new test case has been created");
   }

--- a/src/com/sun/ts/tests/websocket/common/impl/ClientConfigurator.java
+++ b/src/com/sun/ts/tests/websocket/common/impl/ClientConfigurator.java
@@ -31,9 +31,9 @@ import com.sun.ts.tests.websocket.common.util.StringUtil;
 
 public class ClientConfigurator extends Configurator {
 
-  private Map<String, List<String>> requestMap = new TreeMap<String, List<String>>();
+  private Map<String, List<String>> requestMap = new TreeMap<>();
 
-  private Map<String, List<String>> responseMap = new TreeMap<String, List<String>>();
+  private Map<String, List<String>> responseMap = new TreeMap<>();
 
   private boolean hasBeenAfterResponse = false;
 

--- a/src/com/sun/ts/tests/websocket/common/impl/ExtensionImpl.java
+++ b/src/com/sun/ts/tests/websocket/common/impl/ExtensionImpl.java
@@ -32,7 +32,7 @@ import jakarta.websocket.Extension;
  */
 public class ExtensionImpl implements Extension, Comparable<Extension> {
 
-  protected List<Parameter> list = new ArrayList<Parameter>();
+  protected List<Parameter> list = new ArrayList<>();
 
   protected String name;
 
@@ -128,7 +128,7 @@ public class ExtensionImpl implements Extension, Comparable<Extension> {
    */
   public List<ExtensionParameterImpl> getExtensionParameters(
       Extension extension) {
-    List<ExtensionParameterImpl> params = new ArrayList<ExtensionParameterImpl>();
+    List<ExtensionParameterImpl> params = new ArrayList<>();
     for (Parameter item : extension.getParameters())
       params.add(new ExtensionParameterImpl(item, caseSensitive));
     Collections.sort(params);
@@ -143,7 +143,7 @@ public class ExtensionImpl implements Extension, Comparable<Extension> {
    */
   public static List<ExtensionImpl> transformToImpl(
       List<? extends Extension> extensions) {
-    List<ExtensionImpl> list = new ArrayList<ExtensionImpl>();
+    List<ExtensionImpl> list = new ArrayList<>();
     if (extensions != null)
       for (Extension ex : extensions)
         list.add(new ExtensionImpl(ex));

--- a/src/com/sun/ts/tests/websocket/common/util/SessionUtil.java
+++ b/src/com/sun/ts/tests/websocket/common/util/SessionUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.ts.tests.websocket.common.util;
+
+import java.util.concurrent.TimeUnit;
+
+import jakarta.websocket.Session;
+
+public class SessionUtil {
+
+  private SessionUtil() {
+  }
+
+  public static void waitUntilClosed(Session session, long timeout, TimeUnit unit) {
+    long timeoutMillis = unit.toMillis(timeout);
+    while (session.isOpen() && timeoutMillis > 0) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        // Clear the interrupt flag
+        Thread.interrupted();
+        // Exit the loop
+        break;
+      }
+      timeoutMillis -= 100;
+    }
+  }
+}

--- a/src/com/sun/ts/tests/websocket/common/util/StringUtil.java
+++ b/src/com/sun/ts/tests/websocket/common/util/StringUtil.java
@@ -146,8 +146,8 @@ public class StringUtil {
    */
   public static <T> boolean //
       contains(List<T> where, List<T> what, Comparator<? super T> comparator) {
-    where = new ArrayList<T>(where); // new collection not to affect
-    what = new ArrayList<T>(what); // the original by sorting
+    where = new ArrayList<>(where); // new collection not to affect
+    what = new ArrayList<>(what); // the original by sorting
     Collections.sort(what, comparator);
     Collections.sort(where, comparator);
     Iterator<T> j = where.iterator();
@@ -175,8 +175,8 @@ public class StringUtil {
    */
   public static <T extends Comparable<? super T>> //
   boolean contains(List<T> where, List<T> what) {
-    where = new ArrayList<T>(where); // new collection not to affect
-    what = new ArrayList<T>(what); // the original by sorting
+    where = new ArrayList<>(where); // new collection not to affect
+    what = new ArrayList<>(what); // the original by sorting
     Collections.sort(what);
     Collections.sort(where);
     return containsInOrder(where, what);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCCloseClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCCloseClientEndpoint.java
@@ -42,16 +42,19 @@ public class WSCCloseClientEndpoint extends AnnotatedClientEndpoint<String> {
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
@@ -59,6 +62,7 @@ public class WSCCloseClientEndpoint extends AnnotatedClientEndpoint<String> {
     countDown.countDown();
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCConfiguratedClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCConfiguratedClientEndpoint.java
@@ -37,21 +37,25 @@ public class WSCConfiguratedClientEndpoint
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCErrorClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCErrorClientEndpoint.java
@@ -40,6 +40,7 @@ public class WSCErrorClientEndpoint extends AnnotatedClientEndpoint<String> {
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
@@ -52,16 +53,19 @@ public class WSCErrorClientEndpoint extends AnnotatedClientEndpoint<String> {
     }
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String msg = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCMatchedSubprotocolClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCMatchedSubprotocolClientEndpoint.java
@@ -39,21 +39,25 @@ public class WSCMatchedSubprotocolClientEndpoint
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCUnmatchedSubprotocolClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpoint/WSCUnmatchedSubprotocolClientEndpoint.java
@@ -39,21 +39,25 @@ public class WSCUnmatchedSubprotocolClientEndpoint
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -42,7 +42,7 @@ public class WSClient extends WebSocketCommonClient {
 
   private static StringBuffer receivedMessageString = new StringBuffer();
 
-  static CountDownLatch messageLatch;
+  static volatile CountDownLatch messageLatch;
 
   public static void main(String[] args) {
     WSClient theTests = new WSClient();
@@ -73,22 +73,21 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(10);
-
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "Extension size=0|"
@@ -141,23 +140,22 @@ public class WSClient extends WebSocketCommonClient {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
     try {
-      messageLatch = new CountDownLatch(10);
-
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .preferredSubprotocols(expected_subprotocols).build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "Extension size=0|"
@@ -233,23 +231,22 @@ public class WSClient extends WebSocketCommonClient {
     extensions.add(new TCKExtension("ext2", extension2));
 
     try {
-      messageLatch = new CountDownLatch(10);
-
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .extensions(extensions).build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKTestServer received String:Dummy String Test",
@@ -334,23 +331,23 @@ public class WSClient extends WebSocketCommonClient {
     extensions.add(new TCKExtension("ext2", extension2));
 
     try {
-      messageLatch = new CountDownLatch(10);
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .preferredSubprotocols(expected_subprotocols).extensions(extensions)
           .build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKTestServer received String:Dummy String Test",
@@ -433,23 +430,23 @@ public class WSClient extends WebSocketCommonClient {
         .add(com.sun.ts.tests.websocket.common.util.BooleanEncoder.class);
 
     try {
-      messageLatch = new CountDownLatch(15);
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .encoders(expected_encoders).build();
 
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "EndpointConfig.getEncoders() returned encoders size=2|"
@@ -494,23 +491,22 @@ public class WSClient extends WebSocketCommonClient {
         .add(com.sun.ts.tests.websocket.common.util.BooleanDecoder.class);
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .decoders(expected_decoders).build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "EndpointConfig.getDecoders() returned decoders size=|"
@@ -581,24 +577,23 @@ public class WSClient extends WebSocketCommonClient {
     extensions.add(new TCKExtension("ext2", extension2));
 
     try {
-      messageLatch = new CountDownLatch(20);
-
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .preferredSubprotocols(expected_subprotocols).extensions(extensions)
           .decoders(expected_decoders).build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "EndpointConfig.getDecoders() returned decoders size=|"
@@ -716,24 +711,23 @@ public class WSClient extends WebSocketCommonClient {
     extensions.add(new TCKExtension("ext2", extension2));
 
     try {
-      messageLatch = new CountDownLatch(20);
-
       ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
           .preferredSubprotocols(expected_subprotocols).extensions(extensions)
           .decoders(expected_decoders).encoders(expected_encoders).build();
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           cec, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(5);
       session.getBasicRemote().sendText("Dummy String Test");
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "EndpointConfig.getEncoders() returned encoders size=2|"

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -229,7 +229,7 @@ public class WSClient extends WebSocketCommonClient {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -330,7 +330,7 @@ public class WSClient extends WebSocketCommonClient {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -427,7 +427,7 @@ public class WSClient extends WebSocketCommonClient {
   public void encodersTest() throws Fault {
     boolean passed = true;
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
@@ -488,7 +488,7 @@ public class WSClient extends WebSocketCommonClient {
   public void decodersTest() throws Fault {
     boolean passed = true;
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -553,7 +553,7 @@ public class WSClient extends WebSocketCommonClient {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
@@ -577,7 +577,7 @@ public class WSClient extends WebSocketCommonClient {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 
@@ -682,13 +682,13 @@ public class WSClient extends WebSocketCommonClient {
     List<String> expected_subprotocols = Arrays.asList("MBWS", "MBLWS", "soap",
         "WAMP", "v10.stomp", "v11.stomp", "v12.stomp");
 
-    List<Class<? extends Decoder>> expected_decoders = new ArrayList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> expected_decoders = new ArrayList<>();
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.ByteDecoder.class);
     expected_decoders
         .add(com.sun.ts.tests.websocket.common.util.BooleanDecoder.class);
 
-    List<Class<? extends Encoder>> expected_encoders = new ArrayList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> expected_encoders = new ArrayList<>();
     expected_encoders
         .add(com.sun.ts.tests.websocket.common.util.ErrorEncoder.class);
     expected_encoders
@@ -712,7 +712,7 @@ public class WSClient extends WebSocketCommonClient {
       }
     };
 
-    ArrayList<Extension> extensions = new ArrayList<Extension>();
+    ArrayList<Extension> extensions = new ArrayList<>();
     extensions.add(new TCKExtension("ext1", extension1));
     extensions.add(new TCKExtension("ext2", extension2));
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -869,9 +869,6 @@ public class WSClient extends WebSocketCommonClient {
 
   class TCKConfigurator extends ClientEndpointConfig.Configurator {
 
-    void TCKConfigurator() {
-    }
-
     @Override
     public void beforeRequest(Map<String, List<String>> headers) {
     }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -801,6 +801,7 @@ public class WSClient extends WebSocketCommonClient {
     }
   }
 
+  @Override
   public void cleanup() throws Fault {
     super.cleanup();
   }
@@ -846,6 +847,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+        @Override
         public void onMessage(ByteBuffer data) {
           byte[] data1 = new byte[data.remaining()];
           data.get(data1);
@@ -871,9 +873,11 @@ public class WSClient extends WebSocketCommonClient {
     void TCKConfigurator() {
     }
 
+    @Override
     public void beforeRequest(Map<String, List<String>> headers) {
     }
 
+    @Override
     public void afterResponse(HandshakeResponse hr) {
     }
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -21,7 +21,6 @@
 package com.sun.ts.tests.websocket.ee.jakarta.websocket.clientendpointconfig;
 
 import com.sun.javatest.Status;
-import com.sun.ts.lib.harness.EETest.Fault;
 import com.sun.ts.tests.websocket.common.TCKExtension;
 import com.sun.ts.tests.websocket.common.client.WebSocketCommonClient;
 import com.sun.ts.tests.websocket.common.util.MessageValidator;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSTestServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSTestServer.java
@@ -129,7 +129,7 @@ public class WSTestServer {
   }
 
   @OnClose
-  public void onClose(Session session) {
+  public void onClose() {
     System.out.println("==From onClose==");
   }
 }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointonmessage/WSDefaultMaxLengthClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointonmessage/WSDefaultMaxLengthClientEndpoint.java
@@ -40,6 +40,7 @@ public class WSDefaultMaxLengthClientEndpoint
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo) {
     try {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryDecoder.java
@@ -38,21 +38,25 @@ public class WSCEndpointWithBinaryDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryDecoders.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryDecoders.java
@@ -39,21 +39,25 @@ public class WSCEndpointWithBinaryDecoders
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryEncoder.java
@@ -37,21 +37,25 @@ public class WSCEndpointWithBinaryEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryStreamDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryStreamDecoder.java
@@ -38,21 +38,25 @@ public class WSCEndpointWithBinaryStreamDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithBinaryStreamEncoder.java
@@ -37,21 +37,25 @@ public class WSCEndpointWithBinaryStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextDecoder.java
@@ -38,21 +38,25 @@ public class WSCEndpointWithTextDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextDecoders.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextDecoders.java
@@ -39,21 +39,25 @@ public class WSCEndpointWithTextDecoders
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextEncoder.java
@@ -37,21 +37,25 @@ public class WSCEndpointWithTextEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextStreamDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextStreamDecoder.java
@@ -38,21 +38,25 @@ public class WSCEndpointWithTextStreamDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/coder/WSCEndpointWithTextStreamEncoder.java
@@ -37,21 +37,25 @@ public class WSCEndpointWithTextStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/containerprovider/metainf/TCKClassLoader.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/containerprovider/metainf/TCKClassLoader.java
@@ -70,7 +70,7 @@ public class TCKClassLoader extends ClassLoader {
   }
 
   private static Enumeration<URL> filter(Enumeration<URL> orig) {
-    List<URL> list = new LinkedList<URL>();
+    List<URL> list = new LinkedList<>();
     while (orig.hasMoreElements()) {
       URL url = orig.nextElement();
       String file = url.getFile();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/containerprovider/metainf/WSCServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/containerprovider/metainf/WSCServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/srv")
 public class WSCServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String onMessage(String data) {
     LibrariedQuestionaire lq = new LibrariedQuestionaire();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/containerprovider/vi/WSCServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/containerprovider/vi/WSCServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/srv")
 public class WSCServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public boolean onMessage(String data) {
     WebSocketContainer container = ContainerProvider.getWebSocketContainer();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/client/WSCCloseClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/client/WSCCloseClientEndpoint.java
@@ -48,6 +48,7 @@ public class WSCCloseClientEndpoint extends StringClientEndpoint {
     countDown.countDown();
   }
 
+  @Override
   public void onError(Session session, Throwable t) {
     super.onError(session, t);
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/client/WSCErrorClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/client/WSCErrorClientEndpoint.java
@@ -47,6 +47,7 @@ public class WSCErrorClientEndpoint extends StringClientEndpoint {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/server/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/server/AppConfig.java
@@ -35,7 +35,7 @@ public class AppConfig implements ServerApplicationConfig {
     ServerEndpointConfig errorConfig = ServerEndpointConfig.Builder
         .create(WSCErrorServerEndpoint.class, "/error").build();
 
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(closeConfig);
     set.add(errorConfig);
     return set;
@@ -43,7 +43,7 @@ public class AppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSCMsgServer.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/server/WSCErrorServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/server/WSCErrorServerEndpoint.java
@@ -46,6 +46,7 @@ public class WSCErrorServerEndpoint extends Endpoint
     this.session = session;
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/server/WSCMsgServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/endpoint/server/WSCMsgServer.java
@@ -35,7 +35,7 @@ public class WSCMsgServer {
   static String message = EMPTY;
 
   @OnMessage
-  public String onMessage(String msg, Session session) {
+  public String onMessage(String msg) {
     if (MESSAGES[0].equals(msg)) {
       setLastMessage(EMPTY);
     }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/AppConfig.java
@@ -33,7 +33,7 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(new BinaryDecoderEndpointConfig());
     set.add(new BinaryEncoderEndpointConfig());
     set.add(new BinaryStreamDecoderEndpointConfig());
@@ -49,7 +49,7 @@ public class AppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSCLoggerServer.class);
     set.add(WSCSimpleBinaryEchoServer.class);
     set.add(WSCSimpleEchoServer.class);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryDecoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryDecoderEndpointConfig.java
@@ -70,7 +70,7 @@ public class BinaryDecoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
     Class<? extends Decoder> clz = InitDestroyBinaryDecoder.class;
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryEncoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryEncoderEndpointConfig.java
@@ -65,7 +65,7 @@ public class BinaryEncoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Encoder>> getEncoders() {
     Class<? extends Encoder> clz = InitDestroyBinaryEncoder.class;
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryStreamDecoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryStreamDecoderEndpointConfig.java
@@ -70,7 +70,7 @@ public class BinaryStreamDecoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
     Class<? extends Decoder> clz = InitDestroyBinaryStreamDecoder.class;
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryStreamEncoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/BinaryStreamEncoderEndpointConfig.java
@@ -65,7 +65,7 @@ public class BinaryStreamEncoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Encoder>> getEncoders() {
     Class<? extends Encoder> clz = InitDestroyBinaryStreamEncoder.class;
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextDecoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextDecoderEndpointConfig.java
@@ -70,7 +70,7 @@ public class TextDecoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
     Class<? extends Decoder> clz = InitDestroyTextDecoder.class;
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextEncoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextEncoderEndpointConfig.java
@@ -65,7 +65,7 @@ public class TextEncoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Encoder>> getEncoders() {
     Class<? extends Encoder> clz = InitDestroyTextEncoder.class;
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextStreamDecoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextStreamDecoderEndpointConfig.java
@@ -70,7 +70,7 @@ public class TextStreamDecoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
     Class<? extends Decoder> clz = InitDestroyTextStreamDecoder.class;
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextStreamEncoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/TextStreamEncoderEndpointConfig.java
@@ -65,7 +65,7 @@ public class TextStreamEncoderEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Encoder>> getEncoders() {
     Class<? extends Encoder> clz = InitDestroyTextStreamEncoder.class;
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(clz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WSProgramaticClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WSProgramaticClient.java
@@ -74,6 +74,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void textEncoderInitDestroyTest() throws Fault {
     super.textEncoderInitDestroyTest();
   }
@@ -93,6 +94,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void textStreamEncoderInitDestroyTest() throws Fault {
     super.textStreamEncoderInitDestroyTest();
   }
@@ -112,6 +114,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void binaryEncoderInitDestroyTest() throws Fault {
     super.binaryEncoderInitDestroyTest();
   }
@@ -131,6 +134,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void binaryStreamEncoderInitDestroyTest() throws Fault {
     super.binaryStreamEncoderInitDestroyTest();
   }
@@ -153,6 +157,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode, willdecode
    */
+  @Override
   public void textDecoderInitDestroyTest() throws Fault {
     super.textDecoderInitDestroyTest();
   }
@@ -173,6 +178,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode
    */
+  @Override
   public void textStreamDecoderInitDestroyTest() throws Fault {
     super.textStreamDecoderInitDestroyTest();
   }
@@ -193,6 +199,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode, willDecode
    */
+  @Override
   public void binaryDecoderInitDestroyTest() throws Fault {
     super.binaryDecoderInitDestroyTest();
   }
@@ -213,6 +220,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode
    */
+  @Override
   public void binaryStreamDecoderInitDestroyTest() throws Fault {
     super.binaryStreamDecoderInitDestroyTest();
   }
@@ -229,6 +237,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void textEncoderEncodeTest() throws Fault {
     super.textEncoderEncodeTest();
   }
@@ -243,6 +252,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void textStreamEncoderEncodeTest() throws Fault {
     super.textStreamEncoderEncodeTest();
   }
@@ -257,6 +267,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void binaryEncoderEncodeTest() throws Fault {
     super.binaryEncoderEncodeTest();
   }
@@ -271,6 +282,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void binaryStreamEncoderEncodeTest() throws Fault {
     super.binaryStreamEncoderEncodeTest();
   }
@@ -289,6 +301,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void textDecoderDecodeTest() throws Fault {
     super.textDecoderDecodeTest();
   }
@@ -304,6 +317,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void textStreamDecoderDecodeTest() throws Fault {
     super.textStreamDecoderDecodeTest();
   }
@@ -320,6 +334,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void binaryDecoderDecodeTest() throws Fault {
     super.binaryDecoderDecodeTest();
   }
@@ -335,6 +350,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void binaryStreamDecoderDecodeTest() throws Fault {
     super.binaryStreamDecoderDecodeTest();
   }
@@ -348,6 +364,7 @@ public class WSProgramaticClient extends WSClient {
    * @test_Strategy: test binary decoder with willDecode returning false will
    * not be used
    */
+  @Override
   public void binaryDecoderWillDecodeTest() throws Fault {
     super.binaryDecoderWillDecodeTest();
   }
@@ -361,6 +378,7 @@ public class WSProgramaticClient extends WSClient {
    * @test_Strategy: test text decoder with willDecode returning false will not
    * be used
    */
+  @Override
   public void textDecoderWillDecodeTest() throws Fault {
     super.textDecoderWillDecodeTest();
   }
@@ -382,6 +400,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void textEncoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyTextEncoder.class);
@@ -405,6 +424,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void textStreamEncoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyTextStreamEncoder.class);
@@ -428,6 +448,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void binaryEncoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyBinaryEncoder.class);
@@ -451,6 +472,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * encode
    */
+  @Override
   public void binaryStreamEncoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyBinaryStreamEncoder.class);
@@ -477,6 +499,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode, willdecode
    */
+  @Override
   public void textDecoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setClientEndpointInstance(new StringBeanClientEndpoint());
@@ -502,6 +525,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode
    */
+  @Override
   public void textStreamDecoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setClientEndpointInstance(new StringBeanClientEndpoint());
@@ -527,6 +551,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode, willDecode
    */
+  @Override
   public void binaryDecoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setClientEndpointInstance(new StringBeanClientEndpoint());
@@ -552,6 +577,7 @@ public class WSProgramaticClient extends WSClient {
    *
    * decode
    */
+  @Override
   public void binaryStreamDecoderInitDestroyOnClientTest() throws Fault {
     clientClear();
     setClientEndpointInstance(new StringBeanClientEndpoint());
@@ -573,6 +599,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void textEncoderEncodeOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyTextEncoder.class);
@@ -590,6 +617,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void textStreamEncoderEncodeOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyTextStreamEncoder.class);
@@ -607,6 +635,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void binaryEncoderEncodeOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyBinaryEncoder.class);
@@ -624,6 +653,7 @@ public class WSProgramaticClient extends WSClient {
    * The implementation must attempt to encode application objects of matching
    * parametrized type as the encoder when they are attempted to be sent
    */
+  @Override
   public void binaryStreamEncoderEncodeOnClientTest() throws Fault {
     clientClear();
     setEncoder(InitDestroyBinaryStreamEncoder.class);
@@ -645,6 +675,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void textDecoderDecodeOnClientTest() throws Fault {
     clientClear();
     setDecoder(InitDestroyTextDecoder.class);
@@ -665,6 +696,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void textStreamDecoderDecodeOnClientTest() throws Fault {
     clientClear();
     setDecoder(InitDestroyTextStreamDecoder.class);
@@ -685,6 +717,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void binaryDecoderDecodeOnClientTest() throws Fault {
     clientClear();
     setDecoder(InitDestroyBinaryDecoder.class);
@@ -705,6 +738,7 @@ public class WSProgramaticClient extends WSClient {
    * decoder in the list appropriate to the native websocket message type and
    * pass the message in decoded object form to the websocket endpoint
    */
+  @Override
   public void binaryStreamDecoderDecodeOnClientTest() throws Fault {
     clientClear();
     setDecoder(InitDestroyBinaryStreamDecoder.class);
@@ -722,6 +756,7 @@ public class WSProgramaticClient extends WSClient {
    * @test_Strategy: test binary decoder with willDecode returning false will
    * not be used
    */
+  @Override
   public void binaryDecoderWillDecodeOnClientTest() throws Fault {
     clientClear();
     setClientEndpointInstance(new StringBeanClientEndpoint());
@@ -743,6 +778,7 @@ public class WSProgramaticClient extends WSClient {
    * @test_Strategy: test text decoder with willDecode returning false will not
    * be used
    */
+  @Override
   public void textDecoderWillDecodeOnClientTest() throws Fault {
     clientClear();
     setClientEndpointInstance(new StringBeanClientEndpoint());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WSProgramaticClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WSProgramaticClient.java
@@ -795,7 +795,7 @@ public class WSProgramaticClient extends WSClient {
 
   @SafeVarargs
   private final void setEncoder(Class<? extends Encoder>... encoders) {
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     for (Class<? extends Encoder> encoder : encoders)
       list.add(encoder);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
@@ -805,7 +805,7 @@ public class WSProgramaticClient extends WSClient {
 
   @SafeVarargs
   private final void setDecoder(Class<? extends Decoder>... decoders) {
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     for (Class<? extends Decoder> decoder : decoders)
       list.add(decoder);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WillDecodeBinaryDecoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WillDecodeBinaryDecoderEndpointConfig.java
@@ -71,7 +71,7 @@ public class WillDecodeBinaryDecoderEndpointConfig
 
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(WillDecodeFirstBinaryDecoder.class);
     list.add(WillDecodeSecondBinaryDecoder.class);
     return list;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WillDecodeTextDecoderEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/programaticcoder/WillDecodeTextDecoderEndpointConfig.java
@@ -71,7 +71,7 @@ public class WillDecodeTextDecoderEndpointConfig
 
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(WillDecodeFirstTextDecoder.class);
     list.add(WillDecodeSecondTextDecoder.class);
     return list;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/async/ThrowingStringBean.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/async/ThrowingStringBean.java
@@ -23,6 +23,7 @@ public class ThrowingStringBean {
     throw new IllegalStateException(ERROR);
   }
 
+  @SuppressWarnings("unused")
   public void set(String bean) {
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/async/WSCOtherSideServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/async/WSCOtherSideServer.java
@@ -37,14 +37,14 @@ public class WSCOtherSideServer {
   }
 
   @OnMessage
-  public String onMessage(String msg, Session session) {
+  public String onMessage(String msg) {
     return msg;
   }
 
   @OnMessage
-  public String onMessage(ByteBuffer buffer, Session session) {
+  public String onMessage(ByteBuffer buffer) {
     String msg = IOUtil.byteBufferToString(buffer);
-    return onMessage(msg, session);
+    return onMessage(msg);
   }
 
   @OnError

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/async/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/async/WSClient.java
@@ -1120,7 +1120,7 @@ public class WSClient extends WebSocketCommonClient {
     setClientCallback(callback);
 
     // Add StringBean encoder just for sendObject methods
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(StringBeanTextEncoder.class);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
         .encoders(list).build();
@@ -1158,7 +1158,7 @@ public class WSClient extends WebSocketCommonClient {
     setClientCallback(callback);
 
     // Add StringBean encoder just for sendObject methods
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(ThrowingStringBeanEncoder.class);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
         .encoders(list).build();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/basic/WSCOtherSideServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/basic/WSCOtherSideServer.java
@@ -37,14 +37,14 @@ public class WSCOtherSideServer {
   }
 
   @OnMessage
-  public String onMessage(String msg, Session session) {
+  public String onMessage(String msg) {
     return msg;
   }
 
   @OnMessage
-  public String onMessage(ByteBuffer buffer, Session session) {
+  public String onMessage(ByteBuffer buffer) {
     String msg = IOUtil.byteBufferToString(buffer);
-    return onMessage(msg, session);
+    return onMessage(msg);
   }
 
   @OnError

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/basic/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/basic/WSClient.java
@@ -889,7 +889,7 @@ public class WSClient extends WebSocketCommonClient {
     setClientCallback(callback);
 
     // Add StringBean encoder just for sendObject methods
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(StringBeanTextEncoder.class);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
         .encoders(list).build();
@@ -969,7 +969,7 @@ public class WSClient extends WebSocketCommonClient {
       }
     };
     // Add ThrowingEncoder encoder just for sendObject methods
-    List<Class<? extends Encoder>> list = new LinkedList<Class<? extends Encoder>>();
+    List<Class<? extends Encoder>> list = new LinkedList<>();
     list.add(ThrowingEncoder.class);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
         .encoders(list).build();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/CoderSuperClass.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/CoderSuperClass.java
@@ -28,6 +28,7 @@ public abstract class CoderSuperClass {
 
   public static final boolean BOOL = false;
 
+  @SuppressWarnings("unused")
   public void init(EndpointConfig config) {
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCBinaryClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCBinaryClientEndpoint.java
@@ -33,21 +33,25 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
     BinaryCoderLong.class, BinaryCoderFloat.class, BinaryCoderShort.class })
 public class WSCBinaryClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCBinaryStreamClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCBinaryStreamClientEndpoint.java
@@ -36,21 +36,25 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class WSCBinaryStreamClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCTextClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCTextClientEndpoint.java
@@ -33,21 +33,25 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
     TextCoderLong.class, TextCoderFloat.class, TextCoderShort.class })
 public class WSCTextClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCTextStreamClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/WSCTextStreamClientEndpoint.java
@@ -35,21 +35,25 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
     TextStreamCoderShort.class })
 public class WSCTextStreamClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCBinaryServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCBinaryServer.java
@@ -41,12 +41,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     BinaryCoderShort.class })
 public class WSCBinaryServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session) throws IOException,
       EncodeException, InterruptedException, ExecutionException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCBinaryStreamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCBinaryStreamServer.java
@@ -42,12 +42,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     BinaryStreamCoderFloat.class, BinaryStreamCoderShort.class })
 public class WSCBinaryStreamServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session) throws IOException,
       EncodeException, InterruptedException, ExecutionException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCTextServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCTextServer.java
@@ -41,12 +41,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     TextCoderShort.class })
 public class WSCTextServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session) throws IOException,
       EncodeException, InterruptedException, ExecutionException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCTextStreamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/async/WSCTextStreamServer.java
@@ -42,12 +42,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     TextStreamCoderShort.class })
 public class WSCTextStreamServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session) throws IOException,
       EncodeException, InterruptedException, ExecutionException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCBinaryServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCBinaryServer.java
@@ -40,12 +40,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     BinaryCoderShort.class })
 public class WSCBinaryServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCBinaryStreamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCBinaryStreamServer.java
@@ -41,12 +41,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     BinaryStreamCoderFloat.class, BinaryStreamCoderShort.class })
 public class WSCBinaryStreamServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCTextServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCTextServer.java
@@ -40,12 +40,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     TextCoderShort.class })
 public class WSCTextServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCTextStreamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/asyncwithhandler/WSCTextStreamServer.java
@@ -41,12 +41,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     TextStreamCoderShort.class })
 public class WSCTextStreamServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCBinaryServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCBinaryServer.java
@@ -40,12 +40,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     BinaryCoderShort.class })
 public class WSCBinaryServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCBinaryStreamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCBinaryStreamServer.java
@@ -41,12 +41,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     BinaryStreamCoderFloat.class, BinaryStreamCoderShort.class })
 public class WSCBinaryStreamServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCTextServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCTextServer.java
@@ -40,12 +40,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     TextCoderShort.class })
 public class WSCTextServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCTextStreamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/remoteendpoint/usercoder/basic/WSCTextStreamServer.java
@@ -41,12 +41,14 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.remoteendpoint.usercoder.
     TextStreamCoderShort.class })
 public class WSCTextStreamServer extends WSCCommonServer {
 
+  @Override
   @OnMessage
   public void onMessage(String msg, Session session)
       throws IOException, EncodeException {
     super.onMessage(msg, session);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfig/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfig/AppConfig.java
@@ -29,14 +29,14 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(new UsedServerEndpointConfig());
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSUsedServer.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfig/OtherAppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfig/OtherAppConfig.java
@@ -34,7 +34,7 @@ public class OtherAppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSOtherUsedServer.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfig/UsedServerEndpointConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfig/UsedServerEndpointConfig.java
@@ -70,7 +70,7 @@ public class UsedServerEndpointConfig implements ServerEndpointConfig {
   @Override
   public List<Class<? extends Decoder>> getDecoders() {
     Class<? extends Decoder> clazz = StringBeanTextDecoder.class;
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     list.add(clazz);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfiginlib/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfiginlib/AppConfig.java
@@ -32,14 +32,14 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(new UsedServerEndpointConfig());
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSUsedServer.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfiginlib/OtherAppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfiginlib/OtherAppConfig.java
@@ -36,7 +36,7 @@ public class OtherAppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSOtherUsedServer.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfiginlib/WSLibClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverapplicationconfiginlib/WSLibClient.java
@@ -51,6 +51,7 @@ public class WSLibClient extends WSClient {
    * to this method is the set obtained by scanning the archive containing the
    * implementation of this interface.
    */
+  @Override
   public void usedServerTest() throws Fault {
     super.usedServerTest();
   }
@@ -67,6 +68,7 @@ public class WSLibClient extends WSClient {
    * Therefore, this set passed in contains all the annotated endpoint classes
    * in the JAR or WAR file containing the implementation of this interface.
    */
+  @Override
   public void unusedServerTest() throws Fault {
     super.unusedServerTest();
   }
@@ -81,6 +83,7 @@ public class WSLibClient extends WSClient {
    * @test_Strategy: Test all
    * ServerApplicationConfig#getAnnotatedEndpointClasses methods are really used
    */
+  @Override
   public void otherUsedServerTest() throws Fault {
     super.otherUsedServerTest();
   }
@@ -101,6 +104,7 @@ public class WSLibClient extends WSClient {
    * passed in may be used the build the set of ServerEndpointConfig instances
    * to return to the container for deployment.
    */
+  @Override
   public void configuredServerTest() throws Fault {
     super.configuredServerTest();
   }
@@ -114,6 +118,7 @@ public class WSLibClient extends WSClient {
    * 
    * @test_Strategy: Test the incorrect ServerEndpointConfig is NOT used
    */
+  @Override
   public void unusedConfiguredServerTest() throws Fault {
     super.unusedConfiguredServerTest();
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/CountingConfigurator.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/CountingConfigurator.java
@@ -28,9 +28,6 @@ public class CountingConfigurator extends Configurator {
     COUNTER.incrementAndGet();
   }
 
-  public CountingConfigurator(boolean b) {
-  }
-
   public int getCounterValue() {
     return COUNTER.intValue();
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSConfiguredServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSConfiguredServer.java
@@ -56,6 +56,7 @@ public class WSConfiguredServer extends WSAbstractServer {
     return "{" + subprotocols + "}";
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSCountConfiguratorInstancesFirstServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSCountConfiguratorInstancesFirstServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint(value = "/countone", configurator = CountingConfigurator.class)
 public class WSCountConfiguratorInstancesFirstServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String getCountingConfiguratorValue(String entity) {
     Annotation ann = getClass().getAnnotations()[0];

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSCountConfiguratorInstancesSecondServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSCountConfiguratorInstancesSecondServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint(value = "/counttwo", configurator = CountingConfigurator.class)
 public class WSCountConfiguratorInstancesSecondServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String getCountingConfiguratorValue(String op) {
     Annotation ann = getClass().getAnnotations()[0];

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSDecodedServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSDecodedServer.java
@@ -63,6 +63,7 @@ public class WSDecodedServer extends WSAbstractServer {
     return "{" + subprotocols + "}";
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSDefaultServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSDefaultServer.java
@@ -56,6 +56,7 @@ public class WSDefaultServer extends WSAbstractServer {
     return "{" + subprotocols + "}";
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSEncodedServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSEncodedServer.java
@@ -63,6 +63,7 @@ public class WSEncodedServer extends WSAbstractServer {
     return "{" + subprotocols + "}";
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSSubprotocoledServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpoint/WSSubprotocoledServer.java
@@ -57,6 +57,7 @@ public class WSSubprotocoledServer extends WSAbstractServer {
     return "{" + subprotocols + "}";
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) throws IOException {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/AppConfig.java
@@ -29,7 +29,7 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(new SubprotocolsServerEndpointConfig());
     set.add(new ConfiguratorServerEndpointConfig());
     set.add(new ExtensionsServerEndpointConfig());
@@ -38,7 +38,7 @@ public class AppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSAnnotatedSubprotocolsServer.class);
     set.add(WSAnnotatedConfiguratorServer.class);
     return set;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/builder/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/builder/AppConfig.java
@@ -114,7 +114,7 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(getSubprotocolsConfig());
     set.add(getConfiguratorConfig());
     set.add(getExtensionsConfig());
@@ -125,7 +125,7 @@ public class AppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     return set;
   }
 }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/AppConfig.java
@@ -32,7 +32,7 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     set.add(new ExtensionsServerEndpointConfig());
     set.add(new SubprotocolsServerEndpointConfig());
     return set;
@@ -40,7 +40,7 @@ public class AppConfig implements ServerApplicationConfig {
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSCGetEndpointInstanceServer.class);
     set.add(WSCOriginServer.class);
     set.add(WSCOriginServerReturningFalse.class);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/WSCExtensionsServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/WSCExtensionsServer.java
@@ -107,7 +107,7 @@ public class WSCExtensionsServer extends Endpoint
     Extension.Parameter secondParam = ExtensionsServerEndpointConfig.PARAMETER[1];
     ExtensionImpl extension = new ExtensionImpl(
         ExtensionsServerEndpointConfig.EXT_NAMES[0], firstParam, secondParam);
-    List<ExtensionImpl> list = new ArrayList<ExtensionImpl>();
+    List<ExtensionImpl> list = new ArrayList<>();
     list.add(extension);
     return list;
   }
@@ -117,7 +117,7 @@ public class WSCExtensionsServer extends Endpoint
     Extension.Parameter secondParam = ExtensionsServerEndpointConfig.PARAMETER[1];
     ExtensionImpl extension = new ExtensionImpl(
         ExtensionsServerEndpointConfig.EXT_NAMES[1], firstParam, secondParam);
-    List<ExtensionImpl> list = new ArrayList<ExtensionImpl>();
+    List<ExtensionImpl> list = new ArrayList<>();
     list.add(extension);
     list.add(getRequestedExtension().iterator().next());
     return list;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/WSCGetEndpointInstanceServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/WSCGetEndpointInstanceServer.java
@@ -39,6 +39,7 @@ public class WSCGetEndpointInstanceServer {
 
   String additionalInformation;
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String onMessage(String msg) {
     String instance = GetEndpointInstanceConfigurator.getInstanceName();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/WSCModifyHandshakeServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/configurator/WSCModifyHandshakeServer.java
@@ -50,7 +50,7 @@ public class WSCModifyHandshakeServer {
   }
 
   @OnOpen
-  public void onOpen(Session session, EndpointConfig config) {
+  public void onOpen(EndpointConfig config) {
     this.config = (ServerEndpointConfig) config;
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
@@ -102,7 +102,6 @@ public class WSClient extends WebSocketCommonClient {
    * @test_Strategy:
    */
   public void isOpenTest1() throws Fault {
-    String testName = "isOpenTest";
     String search = "TCKTestServer opened|"
         + "session from Server is open=TRUE";
 
@@ -1520,7 +1519,6 @@ public class WSClient extends WebSocketCommonClient {
    * @test_Strategy:
    */
   public void getPathParametersTest() throws Fault {
-    String testName = "getPathParametersTest";
     String message = "invoke test";
     boolean passed = true;
     String param1 = "test1";
@@ -1954,6 +1952,7 @@ public class WSClient extends WebSocketCommonClient {
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append("TCKCloseEndpoint OnClose");
       receivedMessageString.append("Pass_On_To_Error=");
+      @SuppressWarnings("unused")
       int i = 1 / 0;
     }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
@@ -1735,6 +1735,7 @@ public class WSClient extends WebSocketCommonClient {
       receivedMessageString.append("TCKBasicEndpoint OnOpen");
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           receivedMessageString.append(message);
           messageLatch.countDown();
@@ -1743,6 +1744,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+        @Override
         public void onMessage(ByteBuffer data) {
           byte[] data1 = new byte[data.remaining()];
           data.get(data1);
@@ -1755,6 +1757,7 @@ public class WSClient extends WebSocketCommonClient {
 
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append(
           "TCKBasicEndpoint OnClose CloseCode=" + closeReason.getCloseCode());
@@ -1796,6 +1799,7 @@ public class WSClient extends WebSocketCommonClient {
       try {
         session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+          @Override
           public void onMessage(String message) {
             getMessageBuilder()
                 .append("========Second TextMessageHander received=")
@@ -1867,6 +1871,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           receivedMessageString.append(message);
           messageLatch.countDown();
@@ -1874,6 +1879,7 @@ public class WSClient extends WebSocketCommonClient {
       });
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append("onClose");
     }
@@ -1886,6 +1892,7 @@ public class WSClient extends WebSocketCommonClient {
       receivedMessageString.append("TCKCloseEndpoint OnOpen");
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           receivedMessageString.append(message);
           messageLatch.countDown();
@@ -1894,6 +1901,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+        @Override
         public void onMessage(ByteBuffer data) {
           String message_string = IOUtil.byteBufferToString(data);
 
@@ -1905,12 +1913,14 @@ public class WSClient extends WebSocketCommonClient {
       });
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append("TCKCloseEndpoint OnClose");
       receivedMessageString.append("Pass_On_To_Error=");
       int i = 1 / 0;
     }
 
+    @Override
     public void onError(Session session, Throwable t) {
       receivedMessageString.append("TCKCloseEndpoint OnError");
       receivedMessageString.append(t.getMessage());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
@@ -22,6 +22,8 @@ import com.sun.ts.tests.websocket.common.client.EndpointCallback;
 import com.sun.ts.tests.websocket.common.client.WebSocketCommonClient;
 import com.sun.ts.tests.websocket.common.util.IOUtil;
 import com.sun.ts.tests.websocket.common.util.MessageValidator;
+import com.sun.ts.tests.websocket.common.util.SessionUtil;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -43,7 +45,7 @@ public class WSClient extends WebSocketCommonClient {
 
   private static StringBuffer receivedMessageString = new StringBuffer();
 
-  static CountDownLatch messageLatch;
+  static volatile CountDownLatch messageLatch;
 
   public static void main(String[] args) {
     new WSClient().run(args);
@@ -193,20 +195,22 @@ public class WSClient extends WebSocketCommonClient {
     String message_sent_string = "BasicStringMessageHandler added";
 
     try {
-      messageLatch = new CountDownLatch(30);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       final Session session = clientContainer
           .connectToServer(TCKBasicEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
       Set<MessageHandler> msgHanders = session.getMessageHandlers();
       receivedMessageString
           .append("Start with MessageHandler=" + msgHanders.size());
+
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText(message_sent_string);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -214,6 +218,7 @@ public class WSClient extends WebSocketCommonClient {
           .allocate(message_sent_bytebuffer.getBytes().length);
       data.put(message_sent_bytebuffer.getBytes());
       data.flip();
+      messageLatch = new CountDownLatch(3);
       session.getBasicRemote().sendBinary(data);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -266,7 +271,6 @@ public class WSClient extends WebSocketCommonClient {
     final String message_reader_msghandler = "BasicReaderMessageHander received=";
 
     try {
-      messageLatch = new CountDownLatch(50);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
@@ -288,13 +292,14 @@ public class WSClient extends WebSocketCommonClient {
             int i = r.read(buffer);
             receivedMessageString.append("========" + message_reader_msghandler
                 + new String(buffer, 0, i));
+            messageLatch.countDown();
           } catch (IOException e) {
             e.printStackTrace();
           }
         }
       });
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(2);
       Writer writer = session.getBasicRemote().getSendWriter();
       writer.append(message_sent_reader);
       writer.close();
@@ -319,6 +324,7 @@ public class WSClient extends WebSocketCommonClient {
           .allocate((message_sent_bytebuffer).getBytes().length);
       data.put((message_sent_bytebuffer).getBytes());
       data.flip();
+      messageLatch = new CountDownLatch(3);
       session.getBasicRemote().sendBinary(data);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       Set<MessageHandler> msgHanders_3 = session.getMessageHandlers();
@@ -370,21 +376,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "TCKTestServer opened|"
@@ -426,19 +430,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.getBasicRemote().sendText("testName=" + testName);
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKTestServer opened|" + "session from Server is open=TRUE|"
@@ -479,20 +483,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.getBasicRemote().sendText("testName=" + testName);
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "TCKTestServer opened|"
@@ -531,19 +534,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer opened|"
@@ -585,19 +588,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer opened|"
@@ -639,20 +645,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer opened|"
@@ -691,21 +699,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer1"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer1 opened|"
@@ -747,19 +753,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer1"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer1 opened|"
@@ -801,20 +810,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer1"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer1 opened|"
@@ -853,21 +864,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer2"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer2 opened|"
@@ -909,19 +918,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer2"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer2 opened|"
@@ -963,20 +975,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer2"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer2 opened|"
@@ -1018,26 +1032,24 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKCloseEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKCloseEndpoint OnOpen|" + "TCKTestServer opened|"
               + "TCKCloseEndpoint OnClose|" + "TCKCloseEndpoint OnError",
           receivedMessageString.toString());
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       if (session.isOpen()) {
         passed = false;
@@ -1065,7 +1077,6 @@ public class WSClient extends WebSocketCommonClient {
    */
   public void getContainerTest() throws Fault {
     boolean passed = true;
-    messageLatch = new CountDownLatch(15);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1073,11 +1084,12 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
       WebSocketContainer tmp = session.getContainer();
 
       if (clientContainer != tmp) {
@@ -1112,7 +1124,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getId1Test() throws Fault {
     boolean passed = true;
     String testName = "getId1Test";
-    messageLatch = new CountDownLatch(5);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1120,15 +1131,17 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       String tmp = session.getId();
 
       receivedMessageString.append("getId returned from client side" + tmp);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1167,21 +1180,21 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       receivedMessageString
           .append("getMaxBinaryMessageBufferSize returned default value ="
               + session.getMaxBinaryMessageBufferSize());
       session.setMaxBinaryMessageBufferSize(size);
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int tmp = session.getMaxBinaryMessageBufferSize();
       if (tmp == size) {
@@ -1219,8 +1232,6 @@ public class WSClient extends WebSocketCommonClient {
    */
   public void setMaxTextMessageBufferSizeTest() throws Fault {
     int size = 987654321;
-    messageLatch = new CountDownLatch(1); // not to throw NPE in
-                                          // TCKBasicEndpoint
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1228,9 +1239,11 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       System.out.println("getMaxTextMessageBufferSize returned default value ="
           + session.getMaxTextMessageBufferSize());
@@ -1313,7 +1326,6 @@ public class WSClient extends WebSocketCommonClient {
     String testName = "setTimeout1Test";
     boolean passed = true;
     long tt = _ws_wait * 4 * 1000L;
-    messageLatch = new CountDownLatch(10);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1321,17 +1333,23 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?timeout=" + _ws_wait));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       System.out
           .println("getMaxIdleTimeout returned default value on client side ="
               + session.getMaxIdleTimeout());
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.setMaxIdleTimeout(tt);
+
+      // Wait for 2 messages but not third (which should be sent after timeout)
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
-      Thread.sleep(_ws_wait * 8000);
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait * 8, TimeUnit.SECONDS);
       if (session.isOpen()) {
         passed = false;
         receivedMessageString.append("Session is still open after timeout");
@@ -1380,7 +1398,6 @@ public class WSClient extends WebSocketCommonClient {
   public void setTimeout2Test() throws Fault {
     String testName = "setTimeout2Test";
     boolean passed = true;
-    messageLatch = new CountDownLatch(5);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1388,16 +1405,23 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?timeout=" + _ws_wait));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       System.out
           .println("getMaxIdleTimeout returned default value on client side ="
               + session.getMaxIdleTimeout());
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      // Session timeout is set on server
+      // Wait for 2 messages but not third (which should be sent after timeout)
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
-      Thread.sleep(_ws_wait * 8000);
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait * 8, TimeUnit.SECONDS);
       if (session.isOpen()) {
         passed = false;
         receivedMessageString.append("Session is still open after timeout");
@@ -1448,7 +1472,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getQueryStringTest() throws Fault {
     String testName = "getQueryStringTest";
     boolean passed = true;
-    messageLatch = new CountDownLatch(5);
     String querystring = "test1=value1&test2=value2&test3=value3";
 
     try {
@@ -1457,11 +1480,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?" + querystring));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1498,7 +1523,6 @@ public class WSClient extends WebSocketCommonClient {
     String testName = "getPathParametersTest";
     String message = "invoke test";
     boolean passed = true;
-    messageLatch = new CountDownLatch(5);
     String param1 = "test1";
     String param2 = "test2=xyz";
 
@@ -1508,11 +1532,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(1);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServerPathParam/" + param1 + "/" + param2));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText(message);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1553,7 +1579,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getRequestURITest() throws Fault {
     String testName = "getRequestURITest";
     boolean passed = true;
-    messageLatch = new CountDownLatch(6);
     String querystring = "test1=value1&test2=value2&test3=value3";
 
     try {
@@ -1562,11 +1587,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?" + querystring));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1637,7 +1664,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getOpenSessionsTest() throws Fault {
     boolean passed = true;
     String testName = "getOpenSessionsTest";
-    messageLatch = new CountDownLatch(30);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1645,44 +1671,55 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer
           .connectToServer(TCKOpenSessionEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os = getOpenSessions(receivedMessageString.toString());
 
+      messageLatch = new CountDownLatch(2);
       Session session1 = clientContainer
           .connectToServer(TCKOpenSessionEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session1.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os1 = getOpenSessions(receivedMessageString.toString());
 
+      messageLatch = new CountDownLatch(2);
       Session session2 = clientContainer
           .connectToServer(TCKOpenSessionEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session2.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os2 = getOpenSessions(receivedMessageString.toString());
 
       session.close();
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(4);
       session1.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os3 = getOpenSessions(receivedMessageString.toString());
 
       session1.close();
+      SessionUtil.waitUntilClosed(session1, _ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(4);
       session2.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java
@@ -1963,6 +1963,7 @@ public class WSClient extends WebSocketCommonClient {
     }
   }
 
+  @SuppressWarnings("unused")
   private int getOpenSessions(String message) {
     int start = receivedMessageString.lastIndexOf("getOpenSessions=");
     int stop = receivedMessageString

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSCloseTestServer1.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSCloseTestServer1.java
@@ -88,7 +88,7 @@ public class WSCloseTestServer1 {
   }
 
   @OnClose
-  public void onClose3(CloseReason closeReason) {
+  public void onClose3() {
     System.out.println("==From WSCloseTestServer1 onClose(CloseReason)==");
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSCloseTestServer2.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSCloseTestServer2.java
@@ -88,7 +88,7 @@ public class WSCloseTestServer2 {
   }
 
   @OnClose
-  public void onClose3(Session session, CloseReason closeReason) {
+  public void onClose3(Session session) {
     System.out
         .println("==From WSCloseTestServer2 onClose(Session, CloseReason)==");
     try {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSTestServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSTestServer.java
@@ -309,10 +309,7 @@ public class WSTestServer {
   public void setMaxBinaryMessageBufferSizeTest2(ByteBuffer message_b,
       Session session) {
     System.out.println("In setMaxBinaryMessageBufferSizeTest2");
-    int size = 64;
     String message = "Binary Message over size 64=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    String message1 = message.substring(0, size - 1);
-    String message2 = message.substring(size, 90 - 1);
 
     ByteBuffer data = ByteBuffer
         .wrap(("========TCKTestServer received ByteBuffer: ").getBytes());
@@ -333,10 +330,7 @@ public class WSTestServer {
   public void setMaxTextMessageBufferSize2Test(String message_r,
       Session session) {
     System.out.println("In setMaxTextMessageBufferSize2Test");
-    int size = 64;
     String message = "String Message over size 64=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    String message1 = message.substring(0, size - 1);
-    String message2 = message.substring(size, 90 - 1);
 
     try {
       session.getBasicRemote()

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSTestServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSTestServer.java
@@ -172,6 +172,7 @@ public class WSTestServer {
     }
   }
 
+  @SuppressWarnings("unused")
   public void close1Test(String message, Session session) {
     try {
       session.close();
@@ -180,6 +181,7 @@ public class WSTestServer {
     }
   }
 
+  @SuppressWarnings("unused")
   public void close2Test(String message, Session session) {
     try {
       session.close(new CloseReason(CloseReason.CloseCodes.TOO_BIG,
@@ -327,6 +329,7 @@ public class WSTestServer {
     }
   }
 
+  @SuppressWarnings("unused")
   public void setMaxTextMessageBufferSize2Test(String message_r,
       Session session) {
     System.out.println("In setMaxTextMessageBufferSize2Test");

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/AnnotatedBinaryClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/AnnotatedBinaryClient.java
@@ -38,6 +38,7 @@ public class AnnotatedBinaryClient extends AnnotatedClientEndpoint<String> {
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     session.addMessageHandler(InputStream.class,

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/AnnotatedThrowingClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/AnnotatedThrowingClient.java
@@ -45,6 +45,7 @@ public class AnnotatedThrowingClient extends AnnotatedClientEndpoint<String> {
     this.typeEnum = typeEnum;
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     switch (typeEnum) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/MixedProgramaticEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/MixedProgramaticEndpoint.java
@@ -51,7 +51,7 @@ public class MixedProgramaticEndpoint extends ClientEndpoint<String> {
   public void onOpen(Session session, EndpointConfig config) {
     switch (type) {
     case LINKEDLIST_HASHSET_TEXT:
-      LinkedList<HashSet<String>> list = new LinkedList<HashSet<String>>();
+      LinkedList<HashSet<String>> list = new LinkedList<>();
 
       Class<LinkedList<HashSet<String>>> clzLLHS = (Class<LinkedList<HashSet<String>>>) list
           .getClass();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/WSCClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/client/WSCClient.java
@@ -464,7 +464,7 @@ public class WSCClient extends WebSocketCommonClient {
     MixedProgramaticEndpoint endpoint = new MixedProgramaticEndpoint(type,
         this.entity);
     setClientEndpointInstance(endpoint);
-    List<Class<? extends Decoder>> list = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> list = new LinkedList<>();
     if (decoderClass != null)
       list.add(decoderClass);
     ClientEndpointConfig config = ClientEndpointConfig.Builder.create()

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/common/LinkedListHashSetTextDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/common/LinkedListHashSetTextDecoder.java
@@ -38,9 +38,9 @@ public class LinkedListHashSetTextDecoder
   @Override
   public LinkedList<HashSet<String>> decode(String arg0)
       throws DecodeException {
-    HashSet<String> set = new HashSet<String>();
+    HashSet<String> set = new HashSet<>();
     set.add(arg0);
-    LinkedList<HashSet<String>> list = new LinkedList<HashSet<String>>();
+    LinkedList<HashSet<String>> list = new LinkedList<>();
     list.add(set);
     return list;
   }

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/server/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/server/AppConfig.java
@@ -40,7 +40,7 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     addServerEndpoint(set, LinkedListHashSetTextDecoder.class,
         TypeEnum.LINKEDLIST_HASHSET_TEXT);
     addServerEndpoint(set, StringListTextDecoder.class, TypeEnum.LIST_TEXT);
@@ -66,7 +66,7 @@ public class AppConfig implements ServerApplicationConfig {
   private Set<ServerEndpointConfig> addServerEndpoint(
       Set<ServerEndpointConfig> set, Class<? extends Decoder> decoder,
       final TypeEnum typeEnum) {
-    List<Class<? extends Decoder>> decoders = new LinkedList<Class<? extends Decoder>>();
+    List<Class<? extends Decoder>> decoders = new LinkedList<>();
     decoders.add(decoder);
     ServerEndpointConfig.Configurator configurator = new ServerEndpointConfig.Configurator() {
       @SuppressWarnings("unchecked")

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/server/WSCServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/session11/server/WSCServerEndpoint.java
@@ -47,7 +47,7 @@ public class WSCServerEndpoint extends Endpoint {
   public void onOpen(Session session, EndpointConfig config) {
     switch (typeEnum) {
     case LINKEDLIST_HASHSET_TEXT:
-      LinkedList<HashSet<String>> list = new LinkedList<HashSet<String>>();
+      LinkedList<HashSet<String>> list = new LinkedList<>();
       Class<LinkedList<HashSet<String>>> clzLLHS = (Class<LinkedList<HashSet<String>>>) list
           .getClass();
       session.addMessageHandler(clzLLHS,

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/sessionexception/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/sessionexception/WSClient.java
@@ -152,6 +152,7 @@ public class WSClient extends WebSocketCommonClient {
     public void onOpen(Session session, EndpointConfig config) {
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           messageLatch.countDown();
           receivedMessageString.append(message);
@@ -159,6 +160,7 @@ public class WSClient extends WebSocketCommonClient {
       });
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append("CloseCode=" + closeReason.getCloseCode());
       receivedMessageString

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCBinaryDecoderServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCBinaryDecoderServer.java
@@ -33,7 +33,7 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.throwingcoder.ThrowingTex
 public class WSCBinaryDecoderServer {
 
   @OnMessage
-  public String echo(StringBean bean, Session session) {
+  public String echo(StringBean bean) {
     return bean.get();
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCBinaryStreamDecoderServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCBinaryStreamDecoderServer.java
@@ -33,7 +33,7 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.throwingcoder.ThrowingTex
 public class WSCBinaryStreamDecoderServer {
 
   @OnMessage
-  public String echo(StringBean bean, Session session) {
+  public String echo(StringBean bean) {
     return bean.get();
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryDecoder.java
@@ -40,21 +40,25 @@ public class WSCClientEndpointWithBinaryDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryEncoder.java
@@ -39,21 +39,25 @@ public class WSCClientEndpointWithBinaryEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);// should throw on SendMessageCallback
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryStreamDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryStreamDecoder.java
@@ -40,21 +40,25 @@ public class WSCClientEndpointWithBinaryStreamDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithBinaryStreamEncoder.java
@@ -39,21 +39,25 @@ public class WSCClientEndpointWithBinaryStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // should throw on SendMessageCallback
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOBinaryStreamDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOBinaryStreamDecoder.java
@@ -40,21 +40,25 @@ public class WSCClientEndpointWithIOBinaryStreamDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOBinaryStreamEncoder.java
@@ -39,21 +39,25 @@ public class WSCClientEndpointWithIOBinaryStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // should throw on SendMessageCallback
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOTextStreamDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOTextStreamDecoder.java
@@ -40,21 +40,25 @@ public class WSCClientEndpointWithIOTextStreamDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithIOTextStreamEncoder.java
@@ -39,21 +39,25 @@ public class WSCClientEndpointWithIOTextStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // should throw on SendMessageCallback
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextDecoder.java
@@ -40,21 +40,25 @@ public class WSCClientEndpointWithTextDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextEncoder.java
@@ -39,21 +39,25 @@ public class WSCClientEndpointWithTextEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // should throw on SendMessageCallback
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextStreamDecoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextStreamDecoder.java
@@ -40,21 +40,25 @@ public class WSCClientEndpointWithTextStreamDecoder
     super(new StringBeanClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(StringBean msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCClientEndpointWithTextStreamEncoder.java
@@ -39,21 +39,25 @@ public class WSCClientEndpointWithTextStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // should throw on SendMessageCallback
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCIOBinaryStreamDecoderServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCIOBinaryStreamDecoderServer.java
@@ -33,7 +33,7 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.throwingcoder.ThrowingTex
 public class WSCIOBinaryStreamDecoderServer {
 
   @OnMessage
-  public String echo(StringBean bean, Session session) {
+  public String echo(StringBean bean) {
     return bean.get();
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCIOTextStreamDecoderServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCIOTextStreamDecoderServer.java
@@ -33,7 +33,7 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.throwingcoder.ThrowingTex
 public class WSCIOTextStreamDecoderServer {
 
   @OnMessage
-  public String echo(StringBean bean, Session session) {
+  public String echo(StringBean bean) {
     return bean.get();
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryEncoder.java
@@ -40,6 +40,7 @@ public class WSCReturningClientEndpointWithBinaryEncoder
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public StringBean onMessage(String msg, Session session) {
     return new StringBean(msg);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryEncoder.java
@@ -45,16 +45,19 @@ public class WSCReturningClientEndpointWithBinaryEncoder
     return new StringBean(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // throwing encoder is not used here!
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryStreamEncoder.java
@@ -45,16 +45,19 @@ public class WSCReturningClientEndpointWithBinaryStreamEncoder
     return new StringBean(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // throwing encoder is not used here!
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithBinaryStreamEncoder.java
@@ -40,6 +40,7 @@ public class WSCReturningClientEndpointWithBinaryStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public StringBean onMessage(String msg, Session session) {
     return new StringBean(msg);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOBinaryStreamEncoder.java
@@ -40,6 +40,7 @@ public class WSCReturningClientEndpointWithIOBinaryStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public StringBean onMessage(String msg, Session session) {
     return new StringBean(msg);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOBinaryStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOBinaryStreamEncoder.java
@@ -45,16 +45,19 @@ public class WSCReturningClientEndpointWithIOBinaryStreamEncoder
     return new StringBean(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // throwing encoder is not used here!
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOTextStreamEncoder.java
@@ -40,6 +40,7 @@ public class WSCReturningClientEndpointWithIOTextStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public StringBean onMessage(String msg, Session session) {
     return new StringBean(msg);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithIOTextStreamEncoder.java
@@ -45,16 +45,19 @@ public class WSCReturningClientEndpointWithIOTextStreamEncoder
     return new StringBean(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // throwing encoder is not used here!
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextEncoder.java
@@ -45,16 +45,19 @@ public class WSCReturningClientEndpointWithTextEncoder
     return new StringBean(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // throwing encoder is not used here!
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextEncoder.java
@@ -40,6 +40,7 @@ public class WSCReturningClientEndpointWithTextEncoder
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public StringBean onMessage(String msg, Session session) {
     return new StringBean(msg);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextStreamEncoder.java
@@ -40,6 +40,7 @@ public class WSCReturningClientEndpointWithTextStreamEncoder
     super(new StringClientEndpoint());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public StringBean onMessage(String msg, Session session) {
     return new StringBean(msg);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextStreamEncoder.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCReturningClientEndpointWithTextStreamEncoder.java
@@ -45,16 +45,19 @@ public class WSCReturningClientEndpointWithTextStreamEncoder
     return new StringBean(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config); // throwing encoder is not used here!
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     String error = WebSocketCommonClient.getCauseMessage(t);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCTextDecoderServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCTextDecoderServer.java
@@ -32,7 +32,7 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.throwingcoder.ThrowingTex
 public class WSCTextDecoderServer {
 
   @OnMessage
-  public String echo(StringBean bean, Session session) {
+  public String echo(StringBean bean) {
     return bean.get();
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCTextStreamDecoderServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/throwingcoder/annotated/WSCTextStreamDecoderServer.java
@@ -33,7 +33,7 @@ import com.sun.ts.tests.websocket.ee.jakarta.websocket.throwingcoder.ThrowingTex
 public class WSCTextStreamDecoderServer {
 
   @OnMessage
-  public String echo(StringBean bean, Session session) {
+  public String echo(StringBean bean) {
     return bean.get();
   }
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryDecoderAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryDecoderAndSessionAndPathParamServer.java
@@ -33,6 +33,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanBinaryDecoder.class })
 public class WSBinaryDecoderAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(StringBean bean, Session session,
       @PathParam("param") String param) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryDecoderAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryDecoderAndSessionServer.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanBinaryDecoder.class })
 public class WSBinaryDecoderAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(StringBean bean, Session session) {
     return bean.get();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryStreamDecoderAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryStreamDecoderAndSessionAndPathParamServer.java
@@ -33,6 +33,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanBinaryStreamDecoder.class })
 public class WSBinaryStreamDecoderAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(StringBean bean, @PathParam("param") String param,
       Session s) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryStreamDecoderAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSBinaryStreamDecoderAndSessionServer.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanBinaryStreamDecoder.class })
 public class WSBinaryStreamDecoderAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(StringBean bean, Session s) {
     return bean.get();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteArrayAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteArrayAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint(value = "/bytearraysessionpathparam/{param}")
 public class WSByteArrayAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String bytesToString(@PathParam("param") String param, byte[] array,
       Session s) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteArrayAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteArrayAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint(value = "/bytearraysession")
 public class WSByteArrayAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String bytesToString(byte[] array, Session s) {
     return new String(array);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteBufferAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteBufferAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/bytebuffersessionpathparam/{param}")
 public class WSByteBufferAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(ByteBuffer b, @PathParam("param") String param,
       Session s) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteBufferAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSByteBufferAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/bytebuffersession")
 public class WSByteBufferAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(ByteBuffer b, Session s) {
     return IOUtil.byteBufferToString(b);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSDefaultMaxLengthServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSDefaultMaxLengthServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/defaultmaxlen")
 public class WSDefaultMaxLengthServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo) {
     try {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullBooleanAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullBooleanAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullbooleansessionpathparam/{param}")
 public class WSFullBooleanAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(@PathParam("{param}") Boolean param, Boolean b,
       Session s) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullBooleanAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullBooleanAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullbooleansession")
 public class WSFullBooleanAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Boolean b, Session s) {
     return String.valueOf(b.booleanValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullByteAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullByteAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullbytesessionpathparam/{param}")
 public class WSFullByteAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Byte b, @PathParam("param") Byte param, Session s) {
     return String.valueOf(b.byteValue()) + String.valueOf(param.byteValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullByteAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullByteAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullbytesession")
 public class WSFullByteAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Byte b, Session s) {
     return String.valueOf(b.byteValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullCharAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullCharAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullcharsessionpathparam/{param}")
 public class WSFullCharAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, Character c,
       @PathParam("param") Character param) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullCharAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullCharAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullcharsession")
 public class WSFullCharAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, Character c) {
     return String.valueOf(c.charValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullDoubleAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullDoubleAndSessionAndPathParamServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/fulldoublesessionpathparam/{param}")
 public class WSFullDoubleAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, Double d, @PathParam("param") Double param) {
     return (String.valueOf(d.doubleValue())

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullDoubleAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullDoubleAndSessionServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/fulldoublesession")
 public class WSFullDoubleAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, Double d) {
     return String.valueOf(d.doubleValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullFloatAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullFloatAndSessionAndPathParamServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/fullfloatsessionpathparam/{param}")
 public class WSFullFloatAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(@PathParam("param") Float param, Float f, Session s) {
     return (String.valueOf(f.floatValue()) + String.valueOf(param.floatValue()))

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullFloatAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullFloatAndSessionServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/fullfloatsession")
 public class WSFullFloatAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Float f, Session s) {
     return String.valueOf(f.floatValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullIntAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullIntAndSessionAndPathParamServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/fullintsessionpathparam/{param}")
 public class WSFullIntAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Integer i, @PathParam("param") Integer param, Session s) {
     return String.valueOf(i.intValue()) + String.valueOf(param.intValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullIntAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullIntAndSessionServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/fullintsession")
 public class WSFullIntAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Integer i, Session s) {
     return String.valueOf(i.intValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullLongAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullLongAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fulllongsessionpathparam/{param}")
 public class WSFullLongAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(@PathParam("param") Long param, Long l, Session s) {
     return String.valueOf(l.longValue()) + String.valueOf(param.longValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullLongAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullLongAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fulllongsession")
 public class WSFullLongAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Long l, Session s) {
     return String.valueOf(l.longValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullShortAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullShortAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullshortsessionpathparam/{param}")
 public class WSFullShortAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Short s, Session session,
       @PathParam("param") Short param) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullShortAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSFullShortAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/fullshortsession")
 public class WSFullShortAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Short s, Session session) {
     return String.valueOf(s.shortValue());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSInputStreamAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSInputStreamAndSessionAndPathParamServer.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/inputstreamsessionpathparam/{param}")
 public class WSInputStreamAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, @PathParam("param") String param,
       InputStream stream) throws IOException {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSInputStreamAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSInputStreamAndSessionServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/inputstreamsession")
 public class WSInputStreamAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(InputStream stream, Session s) throws IOException {
     String message = IOUtil.readFromStream(stream);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPongMessageAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPongMessageAndSessionAndPathParamServer.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/pongmessagesessionpathparam/{param}")
 public class WSPongMessageAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(PongMessage msg, @PathParam("param") String param,
       Session s) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPongMessageAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPongMessageAndSessionServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/pongmessagesession")
 public class WSPongMessageAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(PongMessage msg, Session s) {
     return IOUtil.byteBufferToString(msg.getApplicationData());

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveBooleanAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveBooleanAndSessionAndPathParamServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/primitivebooleansessionpathparam/{param}")
 public class WSPrimitiveBooleanAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(boolean b, Session s, @PathParam("param") boolean param) {
     return String.valueOf(b) + String.valueOf(param);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveBooleanAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveBooleanAndSessionServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/primitivebooleansession")
 public class WSPrimitiveBooleanAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(boolean b, Session s) {
     return String.valueOf(b);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveByteAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveByteAndSessionAndPathParamServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/primitivebytesessionpathparam/{param}")
 public class WSPrimitiveByteAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, @PathParam("param") byte param, byte b) {
     return String.valueOf(b) + String.valueOf(param);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveByteAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveByteAndSessionServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/primitivebytesession")
 public class WSPrimitiveByteAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(byte b, Session s) {
     return String.valueOf(b);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveCharAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveCharAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivecharsessionpathparam/{param}")
 public class WSPrimitiveCharAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(char c, @PathParam("param") char param, Session s) {
     return String.valueOf(c) + String.valueOf(param);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveCharAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveCharAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivecharsession")
 public class WSPrimitiveCharAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(char c, Session s) {
     return String.valueOf(c) + "char";

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveDoubleAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveDoubleAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivedoublesessionpathparam/{param}")
 public class WSPrimitiveDoubleAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(@PathParam("param") double param, double d, Session s) {
     return (String.valueOf(d) + String.valueOf(param)).replace(".0", "");

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveDoubleAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveDoubleAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivedoublesession")
 public class WSPrimitiveDoubleAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(double d, Session s) {
     return String.valueOf(d);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveFloatAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveFloatAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivefloatsessionpathparam/{param}")
 public class WSPrimitiveFloatAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(float f, Session s, @PathParam("param") float param) {
     return (String.valueOf(f) + String.valueOf(param)).replace(".0", "");

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveFloatAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveFloatAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivefloatsession")
 public class WSPrimitiveFloatAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(float f, Session s) {
     return String.valueOf(f);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveIntAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveIntAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitiveintsessionpathparam/{param}")
 public class WSPrimitiveIntAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echoInt(int i, Session s, @PathParam("param") int param) {
     return String.valueOf(i) + String.valueOf(param);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveIntAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveIntAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitiveintsession")
 public class WSPrimitiveIntAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echoInt(int i, Session s) {
     return String.valueOf(i);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveLongAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveLongAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivelongsessionpathparam/{param}")
 public class WSPrimitiveLongAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, @PathParam("param") long param, long l) {
     return String.valueOf(l) + String.valueOf(param);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveLongAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveLongAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/primitivelongsession")
 public class WSPrimitiveLongAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, long l) {
     return String.valueOf(l);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveShortAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveShortAndSessionAndPathParamServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/primitiveshortsessionpathparam/{param}")
 public class WSPrimitiveShortAndSessionAndPathParamServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(short s, @PathParam("param") short param,
       Session session) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveShortAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSPrimitiveShortAndSessionServer.java
@@ -28,6 +28,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 @ServerEndpoint("/primitiveshortsession")
 public class WSPrimitiveShortAndSessionServer {
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(short s, Session session) {
     return String.valueOf(s);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSReaderAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSReaderAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/readersessionpathparam/{param}")
 public class WSReaderAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String reader(java.io.Reader r, @PathParam("param") String param,
       Session s) throws IOException {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSReaderAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSReaderAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/readersession")
 public class WSReaderAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String reader(java.io.Reader r, Session s) throws IOException {
     String msg = IOUtil.readFromReader(r);

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSStringAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSStringAndSessionAndPathParamServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/stringsessionpathparam/{param}")
 public class WSStringAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(@PathParam("param") String param, String echo, Session s) {
     return echo + param;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSStringAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSStringAndSessionServer.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/stringsession")
 public class WSStringAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, Session s) {
     return echo;

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextDecoderAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextDecoderAndSessionAndPathParamServer.java
@@ -33,6 +33,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanTextDecoder.class })
 public class WSTextDecoderAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(@PathParam("param") String param, StringBean bean,
       Session s) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextDecoderAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextDecoderAndSessionServer.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanTextDecoder.class })
 public class WSTextDecoderAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(StringBean bean, Session s) {
     return bean.get();

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextStreamDecoderAndSessionAndPathParamServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextStreamDecoderAndSessionAndPathParamServer.java
@@ -33,6 +33,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanTextStreamDecoder.class })
 public class WSTextStreamDecoderAndSessionAndPathParamServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, StringBean bean,
       @PathParam("param") String param) {

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextStreamDecoderAndSessionServer.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/websocketmessage/WSTextStreamDecoderAndSessionServer.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
     StringBeanTextStreamDecoder.class })
 public class WSTextStreamDecoderAndSessionServer {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Session s, StringBean bean) {
     return bean.get();

--- a/src/com/sun/ts/tests/websocket/negdep/NegativeDeploymentClient.java
+++ b/src/com/sun/ts/tests/websocket/negdep/NegativeDeploymentClient.java
@@ -33,6 +33,7 @@ public class NegativeDeploymentClient extends WebSocketCommonClient {
 
   protected String tslib_name;
 
+  @Override
   public void setup(String[] args, Properties p) throws Fault {
     super.setup(args, p);
     tslib_name = p.getProperty("tslib.name");

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onclose/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onclose/AppConfig.java
@@ -31,13 +31,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(EchoServerEndpoint.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onclose/OnCloseStringHolderServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onclose/OnCloseStringHolderServerEndpoint.java
@@ -38,6 +38,7 @@ public class OnCloseStringHolderServerEndpoint {
     return close + echo;
   }
 
+  @SuppressWarnings("unused")
   @OnClose
   public void onClose(Session session, @PathParam("arg") StringHolder sb) {
     close = sb.toString();

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onclose/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onclose/TestListener.java
@@ -56,6 +56,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onerror/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onerror/AppConfig.java
@@ -31,13 +31,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(EchoServerEndpoint.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onerror/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onerror/TestListener.java
@@ -56,6 +56,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onmessage/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onmessage/AppConfig.java
@@ -31,13 +31,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(EchoServerEndpoint.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onmessage/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onmessage/OnMessageServerEndpoint.java
@@ -35,6 +35,7 @@ public class OnMessageServerEndpoint {
 
   // This header makes the endpoint invalid, since only Strings can be
   // @PathParams
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, @PathParam("arg") StringBean bean) {
     return echo.toString();

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onmessage/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onmessage/TestListener.java
@@ -56,6 +56,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onopen/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onopen/AppConfig.java
@@ -31,13 +31,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(EchoServerEndpoint.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onopen/OnOpenServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onopen/OnOpenServerEndpoint.java
@@ -42,6 +42,7 @@ public class OnOpenServerEndpoint {
 
   // This header makes the endpoint invalid, since only Strings can be
   // @PathParams
+  @SuppressWarnings("unused")
   @OnOpen
   public void onOpen(Session session, @PathParam("arg") StringBean sb) {
     open = sb.get();

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onopen/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/pasrv/onopen/TestListener.java
@@ -56,6 +56,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/srv/onclose/OnCloseStringHolderServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/srv/onclose/OnCloseStringHolderServerEndpoint.java
@@ -38,6 +38,7 @@ public class OnCloseStringHolderServerEndpoint {
     return close + echo;
   }
 
+  @SuppressWarnings("unused")
   @OnClose
   public void onClose(Session session, @PathParam("arg") StringHolder sb) {
     close = sb.toString();

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/srv/onmessage/OnMessageStringHolderServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/srv/onmessage/OnMessageStringHolderServerEndpoint.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.negdep.StringHolder;
 @ServerEndpoint("/invalid/{arg}")
 public class OnMessageStringHolderServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, @PathParam("arg") StringHolder bean) {
     return echo.toString();

--- a/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/srv/onopen/OnOpenStringHolderServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/invalidpathparamtype/srv/onopen/OnOpenStringHolderServerEndpoint.java
@@ -38,6 +38,7 @@ public class OnOpenStringHolderServerEndpoint {
     return open + echo;
   }
 
+  @SuppressWarnings("unused")
   @OnOpen
   public void onOpen(Session session, @PathParam("arg") StringHolder sb) {
     open = sb.toString();

--- a/src/com/sun/ts/tests/websocket/negdep/onclose/client/duplicate/AnnotatedOnCloseClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onclose/client/duplicate/AnnotatedOnCloseClientEndpoint.java
@@ -32,16 +32,19 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class AnnotatedOnCloseClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     clientEndpoint.onClose(session, closeReason);
@@ -52,6 +55,7 @@ public class AnnotatedOnCloseClientEndpoint
     clientEndpoint.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/negdep/onclose/client/toomanyargs/AnnotatedOnCloseClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onclose/client/toomanyargs/AnnotatedOnCloseClientEndpoint.java
@@ -32,11 +32,13 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class AnnotatedOnCloseClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
@@ -48,6 +50,7 @@ public class AnnotatedOnCloseClientEndpoint
     clientEndpoint.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/negdep/onclose/client/toomanyargs/AnnotatedOnCloseClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onclose/client/toomanyargs/AnnotatedOnCloseClientEndpoint.java
@@ -44,6 +44,7 @@ public class AnnotatedOnCloseClientEndpoint
     clientEndpoint.onMessage(msg);
   }
 
+  @SuppressWarnings("unused")
   @OnClose
   public void onClose(Session session, CloseReason closeReason,
       Throwable throwable) {

--- a/src/com/sun/ts/tests/websocket/negdep/onclose/srv/duplicate/OnCloseServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onclose/srv/duplicate/OnCloseServerEndpoint.java
@@ -37,11 +37,13 @@ public class OnCloseServerEndpoint {
     return echo + close;
   }
 
+  @SuppressWarnings("unused")
   @OnClose
   public void onClose(Session session) {
     close = "first @OnClose";
   }
 
+  @SuppressWarnings("unused")
   @OnClose
   public void onClose(Session session, CloseReason reason) {
     close = "second @OnClose";

--- a/src/com/sun/ts/tests/websocket/negdep/onclose/srv/toomanyargs/OnCloseServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onclose/srv/toomanyargs/OnCloseServerEndpoint.java
@@ -36,6 +36,7 @@ public class OnCloseServerEndpoint {
     return echo + close;
   }
 
+  @SuppressWarnings("unused")
   @OnClose
   public void onClose(Session session, Exception thisShouldNotBeHere) {
     close = "thisShouldNotBeHere";

--- a/src/com/sun/ts/tests/websocket/negdep/onerror/client/duplicate/AnnotatedOnErrorClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onerror/client/duplicate/AnnotatedOnErrorClientEndpoint.java
@@ -32,16 +32,19 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class AnnotatedOnErrorClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     clientEndpoint.onClose(session, closeReason);
@@ -51,6 +54,7 @@ public class AnnotatedOnErrorClientEndpoint
   public void onError(Throwable t) {
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/negdep/onerror/client/duplicate/AnnotatedOnErrorClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onerror/client/duplicate/AnnotatedOnErrorClientEndpoint.java
@@ -50,6 +50,7 @@ public class AnnotatedOnErrorClientEndpoint
     clientEndpoint.onClose(session, closeReason);
   }
 
+  @SuppressWarnings("unused")
   @OnError
   public void onError(Throwable t) {
   }

--- a/src/com/sun/ts/tests/websocket/negdep/onerror/client/toomanyargs/AnnotatedOnErrorClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onerror/client/toomanyargs/AnnotatedOnErrorClientEndpoint.java
@@ -50,6 +50,7 @@ public class AnnotatedOnErrorClientEndpoint
     clientEndpoint.onClose(session, closeReason);
   }
 
+  @SuppressWarnings("unused")
   @OnError
   public void onError(Session session, Throwable t, CloseReason closeReason) {
     clientEndpoint.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/negdep/onerror/client/toomanyargs/AnnotatedOnErrorClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onerror/client/toomanyargs/AnnotatedOnErrorClientEndpoint.java
@@ -32,16 +32,19 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class AnnotatedOnErrorClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     clientEndpoint.onClose(session, closeReason);

--- a/src/com/sun/ts/tests/websocket/negdep/onerror/srv/toomanyargs/OnErrorServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onerror/srv/toomanyargs/OnErrorServerEndpoint.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/invalid")
 public class OnErrorServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo) {
 
@@ -37,6 +38,7 @@ public class OnErrorServerEndpoint {
     throw new RuntimeException();
   }
 
+  @SuppressWarnings("unused")
   @OnError
   public void onError(Session session, Throwable thr, CloseReason reason)
       throws IOException {

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binarybytebufferint/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binarybytebufferint/OnMessageClientEndpoint.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedByteBufferClientEndpoin
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(ByteBuffer msg, int i) {
     clientEndpoint.onMessage(msg);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binarybytebufferint/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binarybytebufferint/OnMessageClientEndpoint.java
@@ -36,6 +36,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
@@ -46,6 +47,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(ByteBuffer.wrap(msg.getBytes()));
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryduplicate/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryduplicate/OnMessageClientEndpoint.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedByteBufferClientEndpoin
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
 
+  @Override
   @OnMessage
   public void onMessage(ByteBuffer msg) {
     clientEndpoint.onMessage(msg);
@@ -41,6 +42,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
@@ -51,6 +53,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(ByteBuffer.wrap(msg.getBytes()));
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryduplicate/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryduplicate/OnMessageClientEndpoint.java
@@ -37,6 +37,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(msg);
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(ByteBuffer msg, boolean finito) {
     clientEndpoint.onMessage(msg);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryinputstreamboolean/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryinputstreamboolean/OnMessageClientEndpoint.java
@@ -37,6 +37,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     // there is no server endpoint that sends binary messages
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
@@ -47,6 +48,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(ByteBuffer.wrap(msg.getBytes()));
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryinputstreamboolean/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/binaryinputstreamboolean/OnMessageClientEndpoint.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedByteBufferClientEndpoin
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(InputStream msg, boolean finito) {
     // there is no server endpoint that sends binary messages

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/nodecoder/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/nodecoder/OnMessageClientEndpoint.java
@@ -43,11 +43,13 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(ByteBuffer.wrap(holder.toString().getBytes()));
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongboolean/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongboolean/OnMessageClientEndpoint.java
@@ -37,6 +37,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     // there is no server endpoint that sends ping/pong messages
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
@@ -47,6 +48,7 @@ public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
     clientEndpoint.onMessage(ByteBuffer.wrap(msg.getBytes()));
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongboolean/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongboolean/OnMessageClientEndpoint.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedByteBufferClientEndpoin
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedByteBufferClientEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(PongMessage msg, boolean finito) {
     // there is no server endpoint that sends ping/pong messages

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongduplicate/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongduplicate/OnMessageClientEndpoint.java
@@ -43,6 +43,7 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
         .onMessage(IOUtil.byteBufferToString(msg.getApplicationData()));
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(PongMessage msg, Session session) {
     clientEndpoint

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongduplicate/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/pongduplicate/OnMessageClientEndpoint.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
@@ -48,11 +49,13 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
         .onMessage(IOUtil.byteBufferToString(msg.getApplicationData()));
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textbigdecimal/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textbigdecimal/OnMessageClientEndpoint.java
@@ -36,11 +36,13 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
     clientEndpoint.onMessage(decimal.toString());
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textduplicate/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textduplicate/OnMessageClientEndpoint.java
@@ -37,6 +37,7 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
     clientEndpoint.onError(session, t);
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(String msg, boolean finito) {
     clientEndpoint.onMessage(msg);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textduplicate/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textduplicate/OnMessageClientEndpoint.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.stringbean.StringBeanTextDecoder;
 @ClientEndpoint(decoders = { StringBeanTextDecoder.class })
 public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
@@ -46,6 +47,7 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
     clientEndpoint.onMessage(bean.get());
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textreaderboolean/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textreaderboolean/OnMessageClientEndpoint.java
@@ -38,11 +38,13 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
     clientEndpoint.onMessage(IOUtil.readFromReader(reader));
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textreaderboolean/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textreaderboolean/OnMessageClientEndpoint.java
@@ -33,6 +33,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(Reader reader, boolean finito) throws IOException {
     clientEndpoint.onMessage(IOUtil.readFromReader(reader));

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textstringint/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textstringint/OnMessageClientEndpoint.java
@@ -31,6 +31,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 @ClientEndpoint
 public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public void onMessage(String msg, int finito) throws IOException {
     clientEndpoint.onMessage(msg);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textstringint/OnMessageClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/client/textstringint/OnMessageClientEndpoint.java
@@ -36,11 +36,13 @@ public class OnMessageClientEndpoint extends AnnotatedStringClientEndpoint {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/pasrv/nomoreendpoints/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/pasrv/nomoreendpoints/AppConfig.java
@@ -29,13 +29,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(OnMessageServerEndpoint.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/pasrv/nomoreendpoints/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/pasrv/nomoreendpoints/OnMessageServerEndpoint.java
@@ -30,10 +30,11 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 public class OnMessageServerEndpoint {
 
   @OnMessage
-  public String echo(String echo) throws IOException {
+  public String echo(String echo) {
     return echo;
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, boolean finito) {
     return echo;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/pasrv/nomoreendpoints/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/pasrv/nomoreendpoints/TestListener.java
@@ -56,6 +56,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/ppsrv/nomoreendpoints/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/ppsrv/nomoreendpoints/AppConfig.java
@@ -29,13 +29,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(OnMessageServerEndpoint.class);
     return set;
   }

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/ppsrv/nomoreendpoints/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/ppsrv/nomoreendpoints/OnMessageServerEndpoint.java
@@ -30,10 +30,11 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 public class OnMessageServerEndpoint {
 
   @OnMessage
-  public String echo(String echo) throws IOException {
+  public String echo(String echo) {
     return echo;
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, boolean finito) {
     return echo;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/ppsrv/nomoreendpoints/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/ppsrv/nomoreendpoints/TestListener.java
@@ -54,6 +54,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/binarybytebufferint/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/binarybytebufferint/OnMessageServerEndpoint.java
@@ -30,8 +30,9 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/invalid")
 public class OnMessageServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
-  public String echo(ByteBuffer buffer, int finito) throws IOException {
+  public String echo(ByteBuffer buffer, int finito) {
     String s = null;
     s = IOUtil.byteBufferToString(buffer);
     return s;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/binaryduplicate/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/binaryduplicate/OnMessageServerEndpoint.java
@@ -35,8 +35,9 @@ public class OnMessageServerEndpoint {
     return IOUtil.readFromStream(stream);
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
-  public String echo(byte[] data, boolean finito) throws IOException {
+  public String echo(byte[] data, boolean finito) {
     return new String(data);
   }
 

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/binaryinputstreamboolean/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/binaryinputstreamboolean/OnMessageServerEndpoint.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/invalid")
 public class OnMessageServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(InputStream stream, boolean finito) throws IOException {
     String s = null;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/pongboolean/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/pongboolean/OnMessageServerEndpoint.java
@@ -30,8 +30,9 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/invalid")
 public class OnMessageServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
-  public String echo(PongMessage pong, boolean finito) throws IOException {
+  public String echo(PongMessage pong, boolean finito) {
     String s = null;
     s = IOUtil.byteBufferToString(pong.getApplicationData());
     return s;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/pongduplicate/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/pongduplicate/OnMessageServerEndpoint.java
@@ -31,12 +31,13 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 public class OnMessageServerEndpoint {
 
   @OnMessage
-  public String echo(PongMessage pong) throws IOException {
+  public String echo(PongMessage pong) {
     return IOUtil.byteBufferToString(pong.getApplicationData());
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
-  public String echo(PongMessage pong, Session session) throws IOException {
+  public String echo(PongMessage pong, Session session) {
     return IOUtil.byteBufferToString(pong.getApplicationData());
   }
 

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/textduplicate/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/textduplicate/OnMessageServerEndpoint.java
@@ -35,6 +35,7 @@ public class OnMessageServerEndpoint {
     return IOUtil.readFromReader(reader);
   }
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, boolean finito) {
     return echo;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/textreaderboolean/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/textreaderboolean/OnMessageServerEndpoint.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/invalid")
 public class OnMessageServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(Reader reader, boolean finito) throws IOException {
     String s = null;

--- a/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/textstringint/OnMessageServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onmessage/srv/textstringint/OnMessageServerEndpoint.java
@@ -29,6 +29,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 @ServerEndpoint("/invalid")
 public class OnMessageServerEndpoint {
 
+  @SuppressWarnings("unused")
   @OnMessage
   public String echo(String echo, int i) {
     return echo;

--- a/src/com/sun/ts/tests/websocket/negdep/onopen/client/duplicate/AnnotatedOnOpenClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onopen/client/duplicate/AnnotatedOnOpenClientEndpoint.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class AnnotatedOnOpenClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     clientEndpoint.onOpen(session, config, false);
@@ -42,16 +43,19 @@ public class AnnotatedOnOpenClientEndpoint
     clientEndpoint.onOpen(session, config, false);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     clientEndpoint.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/negdep/onopen/client/toomanyargs/AnnotatedOnOpenClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onopen/client/toomanyargs/AnnotatedOnOpenClientEndpoint.java
@@ -38,16 +38,19 @@ public class AnnotatedOnOpenClientEndpoint
     clientEndpoint.onOpen(session, config, false);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     clientEndpoint.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     clientEndpoint.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     clientEndpoint.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/negdep/onopen/client/toomanyargs/AnnotatedOnOpenClientEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onopen/client/toomanyargs/AnnotatedOnOpenClientEndpoint.java
@@ -32,6 +32,7 @@ import com.sun.ts.tests.websocket.common.client.AnnotatedStringClientEndpoint;
 public class AnnotatedOnOpenClientEndpoint
     extends AnnotatedStringClientEndpoint {
 
+  @SuppressWarnings("unused")
   @OnOpen
   public void onOpen(Session session, EndpointConfig config,
       Throwable throwable) {

--- a/src/com/sun/ts/tests/websocket/negdep/onopen/srv/duplicate/OnOpenServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onopen/srv/duplicate/OnOpenServerEndpoint.java
@@ -37,11 +37,13 @@ public class OnOpenServerEndpoint {
     return open + echo;
   }
 
+  @SuppressWarnings("unused")
   @OnOpen
   public void onOpen(Session session) {
     open = "session";
   }
 
+  @SuppressWarnings("unused")
   @OnOpen
   public void onOpen(EndpointConfig config) {
     open = "config";

--- a/src/com/sun/ts/tests/websocket/negdep/onopen/srv/toomanyargs/OnOpenServerEndpoint.java
+++ b/src/com/sun/ts/tests/websocket/negdep/onopen/srv/toomanyargs/OnOpenServerEndpoint.java
@@ -36,6 +36,7 @@ public class OnOpenServerEndpoint {
     return open + echo;
   }
 
+  @SuppressWarnings("unused")
   @OnOpen
   public void onOpen(Session session, String thisShouldNotBeHere) {
     open = "thisShouldNotBeHere";

--- a/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticated/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticated/AppConfig.java
@@ -32,13 +32,13 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSCGetUserPrincipalServer.class);
     set.add(WSCIsUserInRoleServer.class);
     set.add(WSCUnauthEchoServer.class);

--- a/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticated/WSCClient.java
+++ b/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticated/WSCClient.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,6 +49,7 @@ public class WSCClient extends WebSocketCommonClient {
     new WSCClient().run(args);
   }
 
+  @Override
   public void setup(String[] args, Properties p) throws Fault {
     user = assertProperty(p, "user");
     password = assertProperty(p, "password");

--- a/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedlogoff/WSCClient.java
+++ b/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedlogoff/WSCClient.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,6 +51,7 @@ public class WSCClient extends WebSocketCommonClient {
     new WSCClient().run(args);
   }
 
+  @Override
   public void setup(String[] args, Properties p) throws Fault {
     user = assertProperty(p, "user");
     password = assertProperty(p, "password");

--- a/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedssl/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedssl/AppConfig.java
@@ -32,13 +32,13 @@ public class AppConfig implements ServerApplicationConfig {
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     set.add(WSCGetUserPrincipalServer.class);
     set.add(WSCIsUserInRoleServer.class);
     return set;

--- a/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedssl/WSCClient.java
+++ b/src/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedssl/WSCClient.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,6 +52,7 @@ public class WSCClient extends WebSocketCommonClient {
     new WSCClient().run(args);
   }
 
+  @Override
   public void setup(String[] args, Properties p) throws Fault {
     user = assertProperty(p, "user");
     password = assertProperty(p, "password");

--- a/src/com/sun/ts/tests/websocket/spec/annotation/inheritance/AnnotatedClientEndpointSuperclassWithAnnotations.java
+++ b/src/com/sun/ts/tests/websocket/spec/annotation/inheritance/AnnotatedClientEndpointSuperclassWithAnnotations.java
@@ -35,21 +35,25 @@ public class AnnotatedClientEndpointSuperclassWithAnnotations
     super(new StringClientEndpoint());
   }
 
+  @Override
   @OnOpen
   public void onOpen(Session session, EndpointConfig config) {
     super.onOpen(session, config);
   }
 
+  @Override
   @OnMessage
   public void onMessage(String msg) {
     super.onMessage(msg);
   }
 
+  @Override
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
     super.onClose(session, closeReason);
   }
 
+  @Override
   @OnError
   public void onError(Session session, Throwable t) {
     super.onError(session, t);

--- a/src/com/sun/ts/tests/websocket/spec/application/lifecycle/WSCServerLifecycleServer.java
+++ b/src/com/sun/ts/tests/websocket/spec/application/lifecycle/WSCServerLifecycleServer.java
@@ -30,6 +30,7 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
 public class WSCServerLifecycleServer {
   int hitCount = 0;
 
+  @SuppressWarnings("unused")
   @OnMessage
   public int onMessage(String msg, Session session) {
     return hitCount++;

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/AppConfig.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/AppConfig.java
@@ -29,13 +29,13 @@ public class AppConfig
   @Override
   public Set<ServerEndpointConfig> getEndpointConfigs(
       Set<Class<? extends Endpoint>> endpointClasses) {
-    Set<ServerEndpointConfig> set = new HashSet<ServerEndpointConfig>();
+    Set<ServerEndpointConfig> set = new HashSet<>();
     return set;
   }
 
   @Override
   public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-    Set<Class<?>> set = new HashSet<Class<?>>();
+    Set<Class<?>> set = new HashSet<>();
     return set;
   }
 

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/TCKWebSocketContainerInitializer.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/TCKWebSocketContainerInitializer.java
@@ -28,6 +28,7 @@ import jakarta.servlet.ServletException;
 public class TCKWebSocketContainerInitializer
     implements ServletContainerInitializer {
 
+  @Override
   public void onStartup(Set<Class<?>> arg0, ServletContext context)
       throws ServletException {
     context.addListener(

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/TestListener.java
@@ -81,6 +81,7 @@ public class TestListener implements ServletContextListener {
    * @param sce
    *          The servlet context event
    */
+  @Override
   public void contextDestroyed(ServletContextEvent sce) {
     // Do nothing
   }

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/TestListener.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/TestListener.java
@@ -41,8 +41,6 @@ public class TestListener implements ServletContextListener {
     ServletContext context = sce.getServletContext();
     StringBuilder log = new StringBuilder();
 
-    final String servercontainer_name = "jakarta.websocket.server.ServerContainer";
-
     try {
       final ServerContainer serverContainer = (ServerContainer) sce
           .getServletContext()

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
@@ -1551,7 +1551,6 @@ public class WSClient extends WebSocketCommonClient {
    * @test_Strategy:
    */
   public void getPathParametersTest() throws Fault {
-    String testName = "getPathParametersTest";
     String message = "invoke test";
     boolean passed = true;
     String param1 = "test1";
@@ -1948,6 +1947,8 @@ public class WSClient extends WebSocketCommonClient {
           "TCKCloseEndpoint OnClose CloseCode=" + closeReason.getCloseCode());
       receivedMessageString
           .append("Pass_On_To_Error=" + closeReason.getReasonPhrase());
+      
+      @SuppressWarnings("unused")
       int i = 1 / 0;
     }
 

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
@@ -23,6 +23,8 @@ package com.sun.ts.tests.websocket.spec.servercontainer.addendpoint;
 import com.sun.ts.tests.websocket.common.client.WebSocketCommonClient;
 import com.sun.ts.tests.websocket.common.util.IOUtil;
 import com.sun.ts.tests.websocket.common.util.MessageValidator;
+import com.sun.ts.tests.websocket.common.util.SessionUtil;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -44,7 +46,7 @@ public class WSClient extends WebSocketCommonClient {
 
   private static StringBuffer receivedMessageString = new StringBuffer();
 
-  static CountDownLatch messageLatch;
+  static volatile CountDownLatch messageLatch;
 
   public static void main(String[] args) {
     new WSClient().run(args);
@@ -76,7 +78,6 @@ public class WSClient extends WebSocketCommonClient {
         + "First TextMessageHander received|"
         + "TCKTestServerString received String: Hello World in String|"
         + "First TextMessageHander received|" + "TCKTestServerString responds";
-    messageLatch = new CountDownLatch(20);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -84,10 +85,10 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(3);
       final Session session = clientContainer.connectToServer(
           TCKBasicStringEndpoint.class, config, new URI("ws://" + _hostname
               + ":" + _port + CONTEXT_ROOT + "/TCKTestServerString"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(search,
@@ -125,7 +126,6 @@ public class WSClient extends WebSocketCommonClient {
         + "First Basic ByteBuffer MessageHander received|"
         + "TCKTestServerByte received ByteBuffer: Hello World in ByteBuffer|"
         + "TCKTestServerByte responds: Message in bytes";
-    messageLatch = new CountDownLatch(25);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -133,12 +133,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(1);
       final Session session = clientContainer
           .connectToServer(TCKBasicByteEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServerByte"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
+      messageLatch = new CountDownLatch(1);
       SENT_BYTE_MESSAGE.put("Hello World in ByteBuffer".getBytes());
       SENT_BYTE_MESSAGE.flip();
       try {
@@ -146,7 +147,6 @@ public class WSClient extends WebSocketCommonClient {
       } catch (IOException e) {
         e.printStackTrace();
       }
-      messageLatch.countDown();
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(search,
@@ -184,20 +184,20 @@ public class WSClient extends WebSocketCommonClient {
     String message_sent_string = "BasicStringMessageHandler added";
 
     try {
-      messageLatch = new CountDownLatch(30);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       final Session session = clientContainer
           .connectToServer(TCKBasicEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       Set<MessageHandler> msgHanders = session.getMessageHandlers();
       receivedMessageString
           .append("Start with MessageHandler=" + msgHanders.size());
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText(message_sent_string);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -205,6 +205,7 @@ public class WSClient extends WebSocketCommonClient {
           .allocate(message_sent_bytebuffer.getBytes().length);
       data.put(message_sent_bytebuffer.getBytes());
       data.flip();
+      messageLatch = new CountDownLatch(3);
       session.getBasicRemote().sendBinary(data);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -258,12 +259,12 @@ public class WSClient extends WebSocketCommonClient {
     final String message_reader_msghandler = "BasicReaderMessageHander received=";
 
     try {
-      messageLatch = new CountDownLatch(50);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      // No message handlers to receive messages server sends in @OnOpen
       final Session session = clientContainer
           .connectToServer(TCKBasicEndpoint1.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
@@ -280,13 +281,14 @@ public class WSClient extends WebSocketCommonClient {
             int i = r.read(buffer);
             receivedMessageString.append("========" + message_reader_msghandler
                 + new String(buffer, 0, i));
+            messageLatch.countDown();
           } catch (IOException e) {
             e.printStackTrace();
           }
         }
       });
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(2);
       Writer writer = session.getBasicRemote().getSendWriter();
       writer.append(message_sent_reader);
       writer.close();
@@ -311,6 +313,7 @@ public class WSClient extends WebSocketCommonClient {
           .allocate((message_sent_bytebuffer).getBytes().length);
       data.put((message_sent_bytebuffer).getBytes());
       data.flip();
+      messageLatch = new CountDownLatch(3);
       session.getBasicRemote().sendBinary(data);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       Set<MessageHandler> msgHanders_3 = session.getMessageHandlers();
@@ -363,21 +366,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "TCKTestServer opened|"
@@ -419,19 +420,18 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.getBasicRemote().sendText("testName=" + testName);
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKTestServer opened|" + "session from Server is open=TRUE|"
@@ -472,20 +472,18 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.getBasicRemote().sendText("testName=" + testName);
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "TCKTestServer opened|"
@@ -525,19 +523,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.close();
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer opened|"
@@ -579,19 +577,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer opened|"
@@ -633,20 +634,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer opened|"
@@ -686,21 +689,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer1"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer1 opened|"
@@ -742,19 +743,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer1"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer1 opened|"
@@ -796,20 +800,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer1"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer1 opened|"
@@ -849,21 +855,19 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(20);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer2"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       session.close();
-
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer2 opened|"
@@ -905,19 +909,21 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer2"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer2 opened|"
@@ -959,20 +965,22 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/WSCloseTestServer2"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(1);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings(
           "TCKBasicEndpoint OnOpen|" + "WSCloseTestServer2 opened|"
@@ -1014,21 +1022,20 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
-
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKCloseEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
       session.close(new CloseReason(CloseReason.CloseCodes.TOO_BIG,
           "TCKCloseNowWithReason"));
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
       passed = MessageValidator.checkSearchStrings("TCKCloseEndpoint OnOpen|"
           + "TCKTestServer opened|" + "CKCloseEndpoint OnClose CloseCode|"
@@ -1061,7 +1068,6 @@ public class WSClient extends WebSocketCommonClient {
    */
   public void getContainerTest() throws Fault {
     boolean passed = true;
-    messageLatch = new CountDownLatch(15);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1069,11 +1075,12 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
       WebSocketContainer tmp = session.getContainer();
 
       if (clientContainer != tmp) {
@@ -1105,24 +1112,22 @@ public class WSClient extends WebSocketCommonClient {
    * @test_Strategy:
    */
   public void getIdTest() throws Fault {
-    messageLatch = new CountDownLatch(10);
-
     try {
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKGetIdEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      // No message handlers configured
 
       String tmp = session.getId();
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.getBasicRemote().sendText("testName=getId1Test");
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
-      System.out.println(receivedMessageString.toString());
+      // No message handlers configured
 
       session.close();
       System.err.println("getId=" + tmp);
@@ -1147,7 +1152,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getId1Test() throws Fault {
     boolean passed = true;
     String testName = "getId1Test";
-    messageLatch = new CountDownLatch(5);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1155,15 +1159,17 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       String tmp = session.getId();
 
       receivedMessageString.append("getId returned from client side" + tmp);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1202,21 +1208,21 @@ public class WSClient extends WebSocketCommonClient {
     boolean passed = true;
 
     try {
-      messageLatch = new CountDownLatch(15);
       WebSocketContainer clientContainer = ContainerProvider
           .getWebSocketContainer();
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       receivedMessageString
           .append("getMaxBinaryMessageBufferSize returned default value ="
               + session.getMaxBinaryMessageBufferSize());
       session.setMaxBinaryMessageBufferSize(size);
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int tmp = session.getMaxBinaryMessageBufferSize();
       if (tmp == size) {
@@ -1263,9 +1269,11 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer"));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       System.out.println("getMaxTextMessageBufferSize returned default value ="
           + session.getMaxTextMessageBufferSize());
@@ -1348,7 +1356,6 @@ public class WSClient extends WebSocketCommonClient {
     String testName = "setTimeout1Test";
     boolean passed = true;
     long tt = _ws_wait * 4 * 1000L;
-    messageLatch = new CountDownLatch(10);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1356,17 +1363,23 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?timeout=" + _ws_wait));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       System.out
           .println("getMaxIdleTimeout returned default value on client side ="
               + session.getMaxIdleTimeout());
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
       session.setMaxIdleTimeout(tt);
+
+      // Wait for 2 messages but not third (which should be sent after timeout)
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
-      Thread.sleep(_ws_wait * 8000);
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait * 8, TimeUnit.SECONDS);
       if (session.isOpen()) {
         passed = false;
         receivedMessageString.append("Session is still open after timeout");
@@ -1416,7 +1429,6 @@ public class WSClient extends WebSocketCommonClient {
   public void setTimeout2Test() throws Fault {
     String testName = "setTimeout2Test";
     boolean passed = true;
-    messageLatch = new CountDownLatch(5);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1424,16 +1436,23 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?timeout=" + _ws_wait));
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       System.out
           .println("getMaxIdleTimeout returned default value on client side ="
               + session.getMaxIdleTimeout());
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      // Session timeout is set on server
+      // Wait for 2 messages but not third (which should be sent after timeout)
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
-      Thread.sleep(_ws_wait * 8000);
+      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      SessionUtil.waitUntilClosed(session, _ws_wait * 8, TimeUnit.SECONDS);
       if (session.isOpen()) {
         passed = false;
         receivedMessageString.append("Session is still open after timeout");
@@ -1484,7 +1503,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getQueryStringTest() throws Fault {
     String testName = "getQueryStringTest";
     boolean passed = true;
-    messageLatch = new CountDownLatch(5);
     String querystring = "test1=value1&test2=value2&test3=value3";
 
     try {
@@ -1493,11 +1511,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?" + querystring));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1534,7 +1554,6 @@ public class WSClient extends WebSocketCommonClient {
     String testName = "getPathParametersTest";
     String message = "invoke test";
     boolean passed = true;
-    messageLatch = new CountDownLatch(5);
     String param1 = "test1";
     String param2 = "test2=xyz";
 
@@ -1544,11 +1563,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(1);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServerPathParam/" + param1 + "/" + param2));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(2);
       session.getBasicRemote().sendText(message);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1589,7 +1610,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getRequestURITest() throws Fault {
     String testName = "getRequestURITest";
     boolean passed = true;
-    messageLatch = new CountDownLatch(6);
     String querystring = "test1=value1&test2=value2&test3=value3";
 
     try {
@@ -1598,11 +1618,13 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer.connectToServer(TCKBasicEndpoint.class,
           config, new URI("ws://" + _hostname + ":" + _port + CONTEXT_ROOT
               + "/TCKTestServer?" + querystring));
-
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
@@ -1635,7 +1657,6 @@ public class WSClient extends WebSocketCommonClient {
   public void getOpenSessionsTest() throws Fault {
     boolean passed = true;
     String testName = "getOpenSessionsTest";
-    messageLatch = new CountDownLatch(30);
 
     try {
       WebSocketContainer clientContainer = ContainerProvider
@@ -1643,44 +1664,55 @@ public class WSClient extends WebSocketCommonClient {
       ClientEndpointConfig config = ClientEndpointConfig.Builder.create()
           .build();
 
+      messageLatch = new CountDownLatch(2);
       Session session = clientContainer
           .connectToServer(TCKOpenSessionEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os = getOpenSessions(receivedMessageString.toString());
 
+      messageLatch = new CountDownLatch(2);
       Session session1 = clientContainer
           .connectToServer(TCKOpenSessionEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session1.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os1 = getOpenSessions(receivedMessageString.toString());
 
+      messageLatch = new CountDownLatch(2);
       Session session2 = clientContainer
           .connectToServer(TCKOpenSessionEndpoint.class, config, new URI("ws://"
               + _hostname + ":" + _port + CONTEXT_ROOT + "/TCKTestServer"));
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+
+      messageLatch = new CountDownLatch(4);
       session2.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os2 = getOpenSessions(receivedMessageString.toString());
 
       session.close();
+      SessionUtil.waitUntilClosed(session, _ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(4);
       session1.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 
       int os3 = getOpenSessions(receivedMessageString.toString());
 
       session1.close();
+      SessionUtil.waitUntilClosed(session1, _ws_wait, TimeUnit.SECONDS);
 
-      messageLatch.await(_ws_wait, TimeUnit.SECONDS);
+      messageLatch = new CountDownLatch(4);
       session2.getBasicRemote().sendText("testName=" + testName);
       messageLatch.await(_ws_wait, TimeUnit.SECONDS);
 

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
@@ -1959,6 +1959,7 @@ public class WSClient extends WebSocketCommonClient {
     }
   }
 
+  @SuppressWarnings("unused")
   private int getOpenSessions(String message) {
     int start = receivedMessageString.lastIndexOf("getOpenSessions=");
     int stop = receivedMessageString

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
@@ -1733,6 +1733,7 @@ public class WSClient extends WebSocketCommonClient {
       receivedMessageString.append("TCKBasicEndpoint OnOpen");
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           messageLatch.countDown();
           receivedMessageString.append(message);
@@ -1741,6 +1742,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+        @Override
         public void onMessage(ByteBuffer data) {
           byte[] data1 = new byte[data.remaining()];
           data.get(data1);
@@ -1753,6 +1755,7 @@ public class WSClient extends WebSocketCommonClient {
 
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append(
           "TCKBasicEndpoint OnClose CloseCode=" + closeReason.getCloseCode());
@@ -1786,9 +1789,11 @@ public class WSClient extends WebSocketCommonClient {
           .append(message);
     }
 
+    @Override
     public void onOpen(Session session, EndpointConfig config) {
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           receivedMessageString
               .append("========First TextMessageHander received=")
@@ -1799,6 +1804,7 @@ public class WSClient extends WebSocketCommonClient {
       try {
         session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+          @Override
           public void onMessage(String message) {
             receivedMessageString
                 .append("========Second TextMessageHander received=")
@@ -1821,6 +1827,7 @@ public class WSClient extends WebSocketCommonClient {
 
   public final static class TCKBasicByteEndpoint extends Endpoint {
 
+    @Override
     public void onOpen(Session session, EndpointConfig config) {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
@@ -1837,6 +1844,7 @@ public class WSClient extends WebSocketCommonClient {
       try {
         session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+          @Override
           public void onMessage(ByteBuffer data) {
             receivedMessageString
                 .append(
@@ -1860,6 +1868,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           messageLatch.countDown();
           receivedMessageString.append(message);
@@ -1867,6 +1876,7 @@ public class WSClient extends WebSocketCommonClient {
       });
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append("onClose");
     }
@@ -1879,6 +1889,7 @@ public class WSClient extends WebSocketCommonClient {
       receivedMessageString.append("TCKCloseEndpoint OnOpen");
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           messageLatch.countDown();
           receivedMessageString.append(message);
@@ -1887,6 +1898,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+        @Override
         public void onMessage(ByteBuffer data) {
           byte[] data1 = new byte[data.remaining()];
           data.get(data1);
@@ -1898,6 +1910,7 @@ public class WSClient extends WebSocketCommonClient {
       });
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       receivedMessageString.append(
           "TCKCloseEndpoint OnClose CloseCode=" + closeReason.getCloseCode());
@@ -1906,6 +1919,7 @@ public class WSClient extends WebSocketCommonClient {
       int i = 1 / 0;
     }
 
+    @Override
     public void onError(Session session, Throwable t) {
       receivedMessageString.append("TCKCloseEndpoint OnError");
       receivedMessageString.append(t.getMessage());

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSCloseTestServer1.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSCloseTestServer1.java
@@ -88,7 +88,7 @@ public class WSCloseTestServer1 {
   }
 
   @OnClose
-  public void onClose3(CloseReason closeReason) {
+  public void onClose3() {
     System.out.println("==From WSCloseTestServer1 onClose(CloseReason)==");
   }
 

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSCloseTestServer2.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSCloseTestServer2.java
@@ -88,7 +88,7 @@ public class WSCloseTestServer2 {
   }
 
   @OnClose
-  public void onClose3(Session session, CloseReason closeReason) {
+  public void onClose3(Session session) {
     System.out
         .println("==From WSCloseTestServer2 onClose(Session, CloseReason)==");
     try {

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSTestServer.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSTestServer.java
@@ -280,10 +280,7 @@ public class WSTestServer {
   public void setMaxBinaryMessageBufferSizeTest2(ByteBuffer message_b,
       Session session) {
     System.out.println("In setMaxBinaryMessageBufferSizeTest2");
-    int size = 64;
     String message = "Binary Message over size 64=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    String message1 = message.substring(0, size - 1);
-    String message2 = message.substring(size, 90 - 1);
 
     ByteBuffer data = ByteBuffer
         .wrap(("========TCKTestServer received ByteBuffer: ").getBytes());
@@ -304,10 +301,7 @@ public class WSTestServer {
   public void setMaxTextMessageBufferSize2Test(String message_r,
       Session session) {
     System.out.println("In setMaxTextMessageBufferSize2Test");
-    int size = 64;
     String message = "String Message over size 64=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    String message1 = message.substring(0, size - 1);
-    String message2 = message.substring(size, 90 - 1);
 
     try {
       session.getBasicRemote()

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSTestServer.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSTestServer.java
@@ -158,6 +158,7 @@ public class WSTestServer {
     }
   }
 
+  @SuppressWarnings("unused")
   public void close1Test(String message, Session session) {
     try {
       session.close();
@@ -166,6 +167,7 @@ public class WSTestServer {
     }
   }
 
+  @SuppressWarnings("unused")
   public void close2Test(String message, Session session) {
     try {
       session.close(new CloseReason(CloseReason.CloseCodes.TOO_BIG,
@@ -298,6 +300,7 @@ public class WSTestServer {
     }
   }
 
+  @SuppressWarnings("unused")
   public void setMaxTextMessageBufferSize2Test(String message_r,
       Session session) {
     System.out.println("In setMaxTextMessageBufferSize2Test");

--- a/src/com/sun/ts/tests/websocket/spec/session/sessionid/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/session/sessionid/WSClient.java
@@ -244,6 +244,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<String>() {
 
+        @Override
         public void onMessage(String message) {
           receivedMessageString.append(message);
           messageLatch.countDown();
@@ -252,6 +253,7 @@ public class WSClient extends WebSocketCommonClient {
 
       session.addMessageHandler(new MessageHandler.Whole<ByteBuffer>() {
 
+        @Override
         public void onMessage(ByteBuffer data) {
           String message_string = IOUtil.byteBufferToString(data);
 
@@ -263,6 +265,7 @@ public class WSClient extends WebSocketCommonClient {
       });
     }
 
+    @Override
     public void onClose(Session session, CloseReason closeReason) {
       session_id_endpoint_onClose = session.getId();
       session_endpoint_onClose = session;

--- a/src/com/sun/ts/tests/websocket/spec/session/sessionid/WSTestServer.java
+++ b/src/com/sun/ts/tests/websocket/spec/session/sessionid/WSTestServer.java
@@ -131,7 +131,7 @@ public class WSTestServer {
   }
 
   @OnClose
-  public void onClose(Session session) {
+  public void onClose() {
     System.out.println("==From onClose==");
   }
 


### PR DESCRIPTION
I have included a number of commits that just clean-up the code. I'm happy to move them to a separate PR if required.

The priority for me is the commit that fixes the tests. Not only does it reduce TCK runtime from ~30mins to ~20mins (for me, anyway) it fixes the two timeout tests that have been unreliable for as long as I have had access to the TCK.