### PR TITLE
Fix #262: Exclude two tests associated with WebSocket spec bug

### DIFF
--- a/install/websocket/bin/ts.jtx
+++ b/install/websocket/bin/ts.jtx
@@ -21,3 +21,6 @@
 # Web Socket 1.0 TCK Exclude List
 #
 
+# Issue https://github.com/eclipse-ee4j/websocket-api/issues/228
+com/sun/ts/tests/websocket/ee/jakarta/websocket/session/WSClient.java#getRequestURITest_from_standalone
+com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java#getRequestURITest_from_standalone


### PR DESCRIPTION
The WebSocket issue is:
https://github.com/eclipse-ee4j/websocket-api/issues/228

Signed-off-by: Mark Thomas <markt@apache.org>