### PR TITLE
Issue #254 fix typo to display correct exception type/class

### DIFF
--- a/src/com/sun/ts/tests/servlet/api/jakarta_servlet/genericservlet/ServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/api/jakarta_servlet/genericservlet/ServletErrorPage.java
@@ -28,6 +28,7 @@ import jakarta.servlet.GenericServlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import jakarta.servlet.RequestDispatcher;
 import java.io.IOException;
 import java.io.PrintWriter;
 
@@ -37,17 +38,17 @@ import java.io.PrintWriter;
 
 public class ServletErrorPage extends GenericServlet {
 
-  private static final String STATUS_CODE = "jakarta.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "jakarta.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "javax.servlet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"jakarta.servlet.error.exception_type";
 
-  private static final String MESSAGE = "jakarta.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"jakarta.servlet.error.message";
 
-  private static final String EXCEPTION = "jakarta.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"jakarta.servlet.error.exception"
 
-  private static final String REQUEST_URI = "jakarta.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"jakarta.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "jakarta.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"jakarta.servlet.error.servlet_name"
 
   private static final String EXP_MESSAGE = "error page invoked";
 

--- a/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletresponse/ServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletresponse/ServletErrorPage.java
@@ -23,6 +23,7 @@
  */
 package com.sun.ts.tests.servlet.api.jakarta_servlet_http.httpservletresponse;
 
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,17 +37,17 @@ import java.io.PrintWriter;
 
 public class ServletErrorPage extends HttpServlet {
 
-  private static final String STATUS_CODE = "jakarta.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "jakarta.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "javax.servlet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"jakarta.servlet.error.exception_type";
 
-  private static final String MESSAGE = "jakarta.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"jakarta.servlet.error.message";
 
-  private static final String EXCEPTION = "jakarta.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"jakarta.servlet.error.exception"
 
-  private static final String REQUEST_URI = "jakarta.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"jakarta.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "jakarta.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"jakarta.servlet.error.servlet_name"
 
   private static final String EXP_MESSAGE = "error page invoked";
 

--- a/src/com/sun/ts/tests/servlet/spec/errorpage/SecondServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/spec/errorpage/SecondServletErrorPage.java
@@ -22,6 +22,7 @@ package com.sun.ts.tests.servlet.spec.errorpage;
 
 import com.sun.ts.tests.servlet.common.util.Data;
 
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,17 +36,17 @@ import java.io.PrintWriter;
 
 public class SecondServletErrorPage extends HttpServlet {
 
-  private static final String STATUS_CODE = "jakarta.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "jakarta.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "jakarta.servlet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"jakarta.servlet.error.exception_type";
 
-  private static final String MESSAGE = "jakarta.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"jakarta.servlet.error.message";
 
-  private static final String EXCEPTION = "jakarta.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"jakarta.servlet.error.exception"
 
-  private static final String REQUEST_URI = "jakarta.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"jakarta.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "jakarta.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"jakarta.servlet.error.servlet_name"
 
   private static final String EXP_MESSAGE = "error page invoked";
 
@@ -60,7 +61,8 @@ public class SecondServletErrorPage extends HttpServlet {
     pw.println("Servlet Name: " + req.getAttribute(SERVLET_NAME));
     pw.println("Request URI: " + req.getAttribute(REQUEST_URI));
     pw.println("Status Code: " + req.getAttribute(STATUS_CODE));
-    pw.println("Exception Type: " + req.getAttribute(EXCEPTION_TYPE));
+    // with the cast we even enforce it's a Class type
+    pw.println("Exception Type: " + ((Class)req.getAttribute(EXCEPTION_TYPE)).getName());
     pw.println("Exception: " + req.getAttribute(EXCEPTION));
     pw.print("Message: ");
     if (((String) req.getAttribute(MESSAGE)).indexOf(EXP_MESSAGE) > -1) {

--- a/src/com/sun/ts/tests/servlet/spec/errorpage/ServletErrorPage.java
+++ b/src/com/sun/ts/tests/servlet/spec/errorpage/ServletErrorPage.java
@@ -22,6 +22,7 @@ package com.sun.ts.tests.servlet.spec.errorpage;
 
 import com.sun.ts.tests.servlet.common.util.Data;
 
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,17 +36,17 @@ import java.io.PrintWriter;
 
 public class ServletErrorPage extends HttpServlet {
 
-  private static final String STATUS_CODE = "jakarta.servlet.error.status_code";
+  private static final String STATUS_CODE = RequestDispatcher.ERROR_STATUS_CODE; // "jakarta.servlet.error.status_code";
 
-  private static final String EXCEPTION_TYPE = "jakarta.servlet.error.exception_type";
+  private static final String EXCEPTION_TYPE = RequestDispatcher.ERROR_EXCEPTION_TYPE; //"jakarta.servlet.error.exception_type";
 
-  private static final String MESSAGE = "jakarta.servlet.error.message";
+  private static final String MESSAGE = RequestDispatcher.ERROR_MESSAGE; //"jakarta.servlet.error.message";
 
-  private static final String EXCEPTION = "jakarta.servlet.error.exception";
+  private static final String EXCEPTION = RequestDispatcher.ERROR_EXCEPTION;  //"jakarta.servlet.error.exception"
 
-  private static final String REQUEST_URI = "jakarta.servlet.error.request_uri";
+  private static final String REQUEST_URI = RequestDispatcher.ERROR_REQUEST_URI; //"jakarta.servlet.error.request_uri";
 
-  private static final String SERVLET_NAME = "jakarta.servlet.error.servlet_name";
+  private static final String SERVLET_NAME = RequestDispatcher.ERROR_SERVLET_NAME; //"jakarta.servlet.error.servlet_name"
 
   private static final String EXP_MESSAGE = "error page invoked";
 
@@ -60,7 +61,8 @@ public class ServletErrorPage extends HttpServlet {
     pw.println("Servlet Name: " + req.getAttribute(SERVLET_NAME));
     pw.println("Request URI: " + req.getAttribute(REQUEST_URI));
     pw.println("Status Code: " + req.getAttribute(STATUS_CODE));
-    pw.println("Exception Type: " + req.getAttribute(EXCEPTION_TYPE));
+    // with the cast we even enforce it's a Class type
+    pw.println("Exception Type: " + ((Class)req.getAttribute(EXCEPTION_TYPE)).getName());
     pw.println("Exception: " + req.getAttribute(EXCEPTION));
     pw.print("Message: ");
     if (((String) req.getAttribute(MESSAGE)).indexOf(EXP_MESSAGE) > -1) {

--- a/src/com/sun/ts/tests/servlet/spec/errorpage/URLClient.java
+++ b/src/com/sun/ts/tests/servlet/spec/errorpage/URLClient.java
@@ -72,7 +72,7 @@ public class URLClient extends AbstractUrlClient {
     TEST_PROPS.setProperty(APITEST, "servletErrorPageTest");
     TEST_PROPS.setProperty(STATUS_CODE, INTERNAL_SERVER_ERROR);
     TEST_PROPS.setProperty(SEARCH_STRING,
-        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: null|Exception: java.lang.IllegalStateException: error page invoked|Message: error page invoked");
+        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: java.lang.IllegalStateException|Exception: java.lang.IllegalStateException: error page invoked|Message: error page invoked");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, Data.FAILED);
     invoke();
 
@@ -120,7 +120,7 @@ public class URLClient extends AbstractUrlClient {
     TEST_PROPS.setProperty(APITEST, "heirarchyErrorMatchTest");
     TEST_PROPS.setProperty(STATUS_CODE, INTERNAL_SERVER_ERROR);
     TEST_PROPS.setProperty(SEARCH_STRING,
-        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: null|Exception: java.lang.IllegalThreadStateException: error page invoked|Message: error page invoked");
+        "Servlet Name: TestServlet|Request URI: /servlet_spec_errorpage_web/TestServlet|Status Code: 500|Exception Type: java.lang.IllegalThreadStateException|Exception: java.lang.IllegalThreadStateException: error page invoked|Message: error page invoked");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, Data.FAILED);
     invoke();
   }
@@ -146,7 +146,7 @@ public class URLClient extends AbstractUrlClient {
     TEST_PROPS.setProperty(SEARCH_STRING, "Second ErrorPage|"
         + "Servlet Name: WrappedException|"
         + "Request URI: /servlet_spec_errorpage_web/WrappedException|Status Code: 500|"
-        + "Exception Type: null|"
+        + "Exception Type: com.sun.ts.tests.servlet.spec.errorpage.TestException|"
         + "Exception: com.sun.ts.tests.servlet.spec.errorpage.TestException: error page invoked|Message: error page invoked");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, Data.FAILED);
     TEST_PROPS.setProperty(REQUEST,


### PR DESCRIPTION
Currently there is a typo here https://github.com/eclipse-ee4j/jakartaee-tck/blob/a50bf877a5413b812fad569d116c38160ba0aa41/src/com/sun/ts/tests/servlet/spec/errorpage/SecondServletErrorPage.java#L40 
Please note the attribute name `javax.serlvet.error.exception_type` rather than `javax.servlet.error.exception_type`
I guess the test was to assert as defined in the spec the servlet request attribute should contains the class of the exception in the type `java.lang.Class` but this test never fail despite the typo in  the attribute because even the assert is wrong because it's asserting it contains `null` https://github.com/eclipse-ee4j/jakartaee-tck/blob/a50bf877a5413b812fad569d116c38160ba0aa41/src/com/sun/ts/tests/servlet/spec/errorpage/URLClient.java#L149  which will be always true as the servlet request attribute name with the typo is unknown.
The current fix ensure there is no typo but using the constants from servlet-api.jar class RequestDispatcher https://github.com/eclipse-ee4j/jakartaee-tck/pull/277/files#diff-b13cef9ddaf95aab6349e782af97d75eR41 furthermore I even added a cast to `Class` to ensure the servlet request contains the correct attribute https://github.com/eclipse-ee4j/jakartaee-tck/pull/277/files#diff-16e0845578ace345bd725409b0fe1172R64