### PR TITLE
issues#253: remove runMessageContext from StatefulOperations

### DIFF
--- a/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulOperations.java
+++ b/src/com/sun/ts/tests/ejb30/common/allowed/stateful/StatefulOperations.java
@@ -44,19 +44,6 @@ public class StatefulOperations extends Operations implements Constants {
   }
 
   @Override
-  public void runMessageContext(SessionContext sctx, Properties results) {
-    // getMessageContext test
-    // try {
-    // sctx.getMessageContext();
-    // results.setProperty(getMessageContext, allowed);
-    // } catch (IllegalStateException e) {
-    // results.setProperty(getMessageContext, disallowed);
-    // } catch (Exception e) {
-    // results.setProperty(getMessageContext, e.toString());
-    // }
-  }
-
-  @Override
   public void runRollbackOnly(SessionContext sctx, Properties results) {
     // getRollbackOnly test
     try {


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
For [issues/253](https://github.com/eclipse-ee4j/jakartaee-tck/issues/253)