### PR TITLE
[issue#279] Ensure that standalone TCK version numbers have been incremented

### DIFF
--- a/release/tools/caj.xml
+++ b/release/tools/caj.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
 
-    <property name="deliverable.version"           value="1.3"/>
-    <property name="deliverable.tck.version"           value="1.3.0"/>
+    <property name="deliverable.version"           value="2.0"/>
+    <property name="deliverable.tck.version"           value="2.0.0"/>
     
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/concurrency.xml
+++ b/release/tools/concurrency.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
     
-    <property name="deliverable.version"           value="1.0"/>
-    <property name="deliverable.tck.version"           value="1.0.0"/>
+    <property name="deliverable.version"           value="2.0"/>
+    <property name="deliverable.tck.version"           value="2.0.0"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/connector.xml
+++ b/release/tools/connector.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
     
-    <property name="deliverable.version" value="1.7"/>
-    <property name="deliverable.tck.version" value="1.7.1"/>
+    <property name="deliverable.version" value="2.0"/>
+    <property name="deliverable.tck.version" value="2.0.0"/>
 
     <ts.taskdef name="getportingclasses" 
                 classname="com.sun.ant.taskdefs.common.GetPortingClasses"/>

--- a/release/tools/jacc.xml
+++ b/release/tools/jacc.xml
@@ -17,8 +17,8 @@
 -->
 
 <project name="JACC" basedir="." default="build">
-    <property name="deliverable.version" value="1.5"/>
-    <property name="deliverable.tck.version" value="1.5.1"/>
+    <property name="deliverable.version" value="2.0"/>
+    <property name="deliverable.tck.version" value="2.0.0"/>
 
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>

--- a/release/tools/jaspic.xml
+++ b/release/tools/jaspic.xml
@@ -24,8 +24,8 @@
     <ts.taskdef name="getportingclasses" 
                 classname="com.sun.ant.taskdefs.common.GetPortingClasses"/>
 
-    <property name="deliverable.version" value="1.1"/>
-    <property name="deliverable.tck.version" value="1.1.1"/>
+    <property name="deliverable.version" value="2.0"/>
+    <property name="deliverable.tck.version" value="2.0.0"/>
     
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/jaxrs.xml
+++ b/release/tools/jaxrs.xml
@@ -18,8 +18,8 @@
 
 <project name="JAXRS" basedir="." default="build">
     
-    <property name="deliverable.version"  value="2.1"/>
-    <property name="deliverable.tck.version"  value="2.1.0"/>
+    <property name="deliverable.version"  value="3.0"/>
+    <property name="deliverable.tck.version"  value="3.0.0"/>
 
     <property name="platform.folder" value="com/sun/ts/tests/jaxrs/platform/**"/>
     <property name="platform21.folder" value="com/sun/ts/tests/jaxrs/jaxrs21/platform/**"/>

--- a/release/tools/jms.xml
+++ b/release/tools/jms.xml
@@ -22,8 +22,8 @@
     <import file="../../bin/xml/ts.common.props.xml"/>
     <!-- import file="./tck-internal-default.xml"/ -->
     
-    <property name="deliverable.version"           value="2.0"/>
-    <property name="deliverable.tck.version"           value="2.0.0"/>
+    <property name="deliverable.version"           value="3.0"/>
+    <property name="deliverable.tck.version"           value="3.0.0"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/jsf.xml
+++ b/release/tools/jsf.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
 			
-    <property name="deliverable.version" value="2.3"/>
-    <property name="deliverable.tck.version" value="2.3.0"/>
+    <property name="deliverable.version" value="3.0"/>
+    <property name="deliverable.tck.version" value="3.0.0"/>
 
 	
     <target name="init">

--- a/release/tools/jsonb.xml
+++ b/release/tools/jsonb.xml
@@ -21,8 +21,8 @@
   <!-- IMPORTS -->
   <import file="../../bin/xml/ts.common.props.xml"/>
   
-  <property name="deliverable.version" value="1.0"/>
-  <property name="deliverable.tck.version" value="1.0.1"/>
+  <property name="deliverable.version" value="2.0"/>
+  <property name="deliverable.tck.version" value="2.0.0"/>
   <property name="exclude.source.folder" value="com/sun/ts/tests/jsonb/cdi/**"/>
   
   <condition property="exclude.classes" value="">

--- a/release/tools/jsonp.xml
+++ b/release/tools/jsonp.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
     
-    <property name="deliverable.version"           value="1.1"/>
-    <property name="deliverable.tck.version"           value="1.1.0"/>
+    <property name="deliverable.version"           value="2.0"/>
+    <property name="deliverable.tck.version"           value="2.0.0"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/jsp.xml
+++ b/release/tools/jsp.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
 	
-    <property name="deliverable.version" value="2.3"/>
-    <property name="deliverable.tck.version" value="2.3.0"/>
+    <property name="deliverable.version" value="3.0"/>
+    <property name="deliverable.tck.version" value="3.0.0"/>
 
     
     <target name="init">

--- a/release/tools/jstl.xml
+++ b/release/tools/jstl.xml
@@ -21,8 +21,8 @@
 	<!-- IMPORTS -->
 	<import file="../../bin/xml/ts.common.props.xml" />
 
-	<property name="deliverable.version" value="1.2" />
-        <property name="deliverable.tck.version" value="1.2.0" />
+	<property name="deliverable.version" value="2.0" />
+        <property name="deliverable.tck.version" value="2.0.0" />
 
 
 	<target name="init">

--- a/release/tools/jta.xml
+++ b/release/tools/jta.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
     <import file="../../bin/xml/ts.common.props.xml"/>
     
-    <property name="deliverable.version" value="1.3"/>
-    <property name="deliverable.tck.version" value="1.3.0"/>
+    <property name="deliverable.version" value="2.0"/>
+    <property name="deliverable.tck.version" value="2.0.0"/>
 
     
     <target name="init">

--- a/release/tools/securityapi.xml
+++ b/release/tools/securityapi.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
 	<import file="../../bin/xml/ts.common.props.xml"/>
 
-	<property name="deliverable.version"  value="1.0"/>
-        <property name="deliverable.tck.version"  value="1.0.1"/>
+	<property name="deliverable.version"  value="2.0"/>
+        <property name="deliverable.tck.version"  value="2.0.0"/>
 
 
 	<target name="init">

--- a/release/tools/servlet.xml
+++ b/release/tools/servlet.xml
@@ -21,8 +21,8 @@
     <!-- IMPORTS -->
 	<import file="../../bin/xml/ts.common.props.xml"/>
 
-	<property name="deliverable.version"  value="4.0"/>
-        <property name="deliverable.tck.version"  value="4.0.0"/>
+	<property name="deliverable.version"  value="5.0"/>
+        <property name="deliverable.tck.version"  value="5.0.0"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
Made a sweep through the standalone TCK version numbers that are in the Platform TCK for https://github.com/eclipse-ee4j/jakartaee-tck/issues/279

We still need to delete old standalone TCKs on [eclipse.downloads](https://download.eclipse.org/ee4j/jakartaee-tck/master/nightly/).

https://pastebin.com/mz3ZeyUy shows a timestamped list of the current files in master/nightly folder.

CC @edbratt 