### PR TITLE
[issue#211] as part of removing Jakarta Deployment, also remove references to (removed from GlassFish 6) org.glassfish.deployment.client.

### DIFF
--- a/src/com/sun/ts/lib/implementation/sun/javaee/glassfish/AutoDeploymentSeparateVM.java
+++ b/src/com/sun/ts/lib/implementation/sun/javaee/glassfish/AutoDeploymentSeparateVM.java
@@ -23,7 +23,6 @@ import java.util.*;
 import com.sun.ts.lib.porting.*;
 import com.sun.ts.lib.util.*;
 import com.sun.ts.lib.deliverable.*;
-import org.glassfish.deployment.client.*;
 import java.util.jar.JarFile;
 import java.util.jar.JarEntry;
 import org.jdom.input.SAXBuilder;


### PR DESCRIPTION
One more reference to GlassFish Deployment client removed.

Signed-off-by: Scott Marlow <smarlow@redhat.com>