### PR TITLE
Fix reference to non-existent `javax.jsp` package

### DIFF
--- a/install/jsp/docs/JSP2.3-ReleaseNotes.html
+++ b/install/jsp/docs/JSP2.3-ReleaseNotes.html
@@ -50,7 +50,7 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
    <li><p><strong>Jakarta Server Pages TCK tests signature, API, and End-to-End tests:</strong></p></li>
    <ul type="square">
 	   <li><p>A <strong>signature test</strong> that checks that all of the public APIs are supported in the Jakarta Server Pages Version 2.3 implementation that is being tested</p></li>
-   	<li><p><strong>API tests</strong> for all of the public APIs under the <code>javax.jsp</code> package</p></li>
+   	<li><p><strong>API tests</strong> for all of the public APIs under the <code>javax.servlet.jsp</code> package</p></li>
    	<li>
    	  <p><strong>End-To-End tests</strong> that demonstrate complianve with the Jakarta Server Pages 2.3 specification.</p></li>
    </ul>

--- a/lib/schemas/web-jsptaglibrary_2_0.xsd
+++ b/lib/schemas/web-jsptaglibrary_2_0.xsd
@@ -628,7 +628,7 @@
 	    <xsd:documentation>
 
 	      "true" if this attribute is of type
-	      javax.jsp.tagext.JspFragment, representing dynamic
+	      javax.servlet.jsp.tagext.JspFragment, representing dynamic
 	      content that can be re-evaluated as many times
 	      as needed by the tag handler.  If omitted or "false",
 	      the default is still type="java.lang.String"

--- a/lib/schemas/web-jsptaglibrary_2_1.xsd
+++ b/lib/schemas/web-jsptaglibrary_2_1.xsd
@@ -671,7 +671,7 @@
 	    <xsd:documentation>
 
 	      "true" if this attribute is of type
-	      javax.jsp.tagext.JspFragment, representing dynamic
+	      javax.servlet.jsp.tagext.JspFragment, representing dynamic
 	      content that can be re-evaluated as many times
 	      as needed by the tag handler.  If omitted or "false",
 	      the default is still type="java.lang.String"


### PR DESCRIPTION
There are a few references to `javax.jsp` which never existed.  These have been updated to `javax.servlet.jsp`