### PR TITLE
XJC: External parsing is disabled. Cannot parse URI

### DIFF
--- a/bin/xml/ts.top.import.xml
+++ b/bin/xml/ts.top.import.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -687,8 +687,9 @@
     <xjc schema="${ts.home}/lib/dtds/sun-application_6_0-0.dtd"
          binding="${ts.home}/src/${porting.package.dir}/jaxb-cust.xml"
          destdir="${ts.home}/src"
-         package="${porting.package}.app">
+         package="${porting.package}.app" fork="true">
         <arg value="-dtd"/>
+    	<jvmarg value="-DenableExternalEntityProcessing=true"/>
         <depends  dir="${ts.home}/lib/dtds" 
                   includes="sun-application_6_0-0.dtd"/>
         <produces dir="${ts.home}/src/${porting.package.dir}/app" 
@@ -697,8 +698,9 @@
     <xjc schema="${ts.home}/lib/dtds/sun-application-client_6_0-0.dtd"
          binding="${ts.home}/src/${porting.package.dir}/jaxb-cust.xml"
          destdir="${ts.home}/src"
-         package="${porting.package}.appclient">
+         package="${porting.package}.appclient" fork="true">
         <arg value="-dtd"/>
+    	<jvmarg value="-DenableExternalEntityProcessing=true"/>
         <depends  dir="${ts.home}/lib/dtds" 
                   includes="sun-application-client_5_0-0.dtd"/>
         <produces dir="${ts.home}/src/${porting.package.dir}/appclient" 
@@ -707,8 +709,9 @@
     <xjc schema="${ts.home}/lib/dtds/sun-ejb-jar_3_1-0.dtd"
          binding="${ts.home}/src/${porting.package.dir}/jaxb-cust.xml"
          destdir="${ts.home}/src"
-         package="${porting.package}.ejb">
+         package="${porting.package}.ejb" fork="true">
         <arg value="-dtd"/>
+    	<jvmarg value="-DenableExternalEntityProcessing=true"/>
         <depends  dir="${ts.home}/lib/dtds" includes="sun-ejb-jar_3_1-0.dtd"/>
         <produces dir="${ts.home}/src/${porting.package.dir}/ejb" 
                   includes="**/*"/>
@@ -716,8 +719,9 @@
     <xjc schema="${ts.home}/lib/dtds/sun-web-app_3_0-0.dtd"
          binding="${ts.home}/src/${porting.package.dir}/jaxb-cust.xml"
          destdir="${ts.home}/src"
-         package="${porting.package}.web">
+         package="${porting.package}.web" fork="true">
         <arg value="-dtd"/>
+    	<jvmarg value="-DenableExternalEntityProcessing=true"/>
         <depends  dir="${ts.home}/lib/dtds" includes="sun-web-app_3_0-0.dtd"/>
         <produces dir="${ts.home}/src/${porting.package.dir}/web" 
                   includes="**/*"/>


### PR DESCRIPTION
I tried with:
jdk1.8.0_231
jdk-11.0.7

Executing the Websockets I was getting all the time this error with the arguments -Djavax.xml.accessExternalStylesheet=all -Djavax.xml.accessExternalDTD=all -Djavax.xml.accessExternalSchema=all -Djakarta.xml.accessExternalStylesheet=all -Djakarta.xml.accessExternalDTD=all -Djakarta.xml.accessExternalSchema=all -DenableExternalEntityProcessing=true:

```
bind.dtds:
dropping /home/jbescos/workspace/jakartaee-tck/lib/websockettck.jar from path as it doesn't exist
dropping /home/jbescos/programs/glassfish6/glassfish/modules/tyrus-websocket-core.jar from path as it doesn't exist
dropping /home/jbescos/programs/glassfish6/glassfish/modules/tyrus-container-grizzly.jar from path as it doesn't exist
      [xjc] build id of XJC is 3.0.0-M3
      [xjc] Checking timestamp of /home/jbescos/workspace/jakartaee-tck/lib/dtds/sun-application_6_0-0.dtd
      [xjc] Checking timestamp of /home/jbescos/workspace/jakartaee-tck/src/com/sun/ts/lib/implementation/sun/javaee/runtime/jaxb-cust.xml
      [xjc] Checking timestamp of /home/jbescos/workspace/jakartaee-tck/lib/dtds/sun-application_6_0-0.dtd
      [xjc] the last modified time of the inputs is  1579786959000
      [xjc] the last modified time of the outputs is -9223372036854775808
      [xjc] parsing a schema...
      [xjc] [ERROR] External parsing is disabled. Cannot parse URI: file:/home/jbescos/workspace/jakartaee-tck/lib/dtds/sun-application_6_0-0.dtd
      [xjc] unknown location
      [xjc] 
      [xjc] Failed to parse a schema.
      [xjc] Command invoked: xjc /home/jbescos/programs/java/jdk1.8.0_231/jre/bin/java -classpath /home/jbescos/workspace/jakartaee-tck/lib/jaxb-xjc.jar:/home/jbescos/workspace/jakartaee-tck/lib/jaxb-core.jar:/home/jbescos/workspace/jakartaee-tck/lib/jaxb-impl.jar:/home/jbescos/workspace/jakartaee-tck/lib/tsharness.jar:/home/jbescos/workspace/jakartaee-tck/lib/javatest.jar:/home/jbescos/programs/apache-ant-1.9.14/lib/ant.jar:/home/jbescos/workspace/jakartaee-tck/classes:/home/jbescos/programs/glassfish6/glassfish/modules/tyrus-client.jar:/home/jbescos/programs/glassfish6/glassfish/modules/tyrus-core.jar:/home/jbescos/programs/glassfish6/glassfish/modules/glassfish-grizzly-extra-all.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2-core.jar:/home/jbescos/programs/glassfish6/glassfish/modules/glassfish-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2-utils.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jakarta.annotation-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jakarta.inject-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/aopalliance-repackaged.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2-locator.jar:/home/jbescos/programs/glassfish6/glassfish/modules/javassist.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2-runlevel.jar:/home/jbescos/programs/glassfish6/glassfish/modules/class-model.jar:/home/jbescos/programs/glassfish6/glassfish/modules/asm.jar:/home/jbescos/programs/glassfish6/glassfish/modules/asm-analysis.jar:/home/jbescos/programs/glassfish6/glassfish/modules/asm-commons.jar:/home/jbescos/programs/glassfish6/glassfish/modules/asm-tree.jar:/home/jbescos/programs/glassfish6/glassfish/modules/asm-util.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jakarta.xml.bind-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jaxb-osgi.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jakarta.activation.jar:/home/jbescos/programs/glassfish6/glassfish/modules/scattered-archive-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hk2-config.jar:/home/jbescos/programs/glassfish6/glassfish/modules/tiger-types.jar:/home/jbescos/programs/glassfish6/glassfish/modules/hibernate-validator.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jakarta.validation-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/jboss-logging.jar:/home/jbescos/programs/glassfish6/glassfish/modules/classmate.jar:/home/jbescos/programs/glassfish6/glassfish/modules/nucleus-grizzly-all.jar:/home/jbescos/programs/glassfish6/glassfish/modules/config-types.jar:/home/jbescos/programs/glassfish6/glassfish/modules/management-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/internal-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/config-api.jar:/home/jbescos/programs/glassfish6/glassfish/modules/common-util.jar:/home/jbescos/programs/glassfish6/glassfish/modules/tyrus-server.jar:/home/jbescos/programs/glassfish6/glassfish/modules/tyrus-container-servlet.jar:/home/jbescos/programs/glassfish6/glassfish/modules/tyrus-container-grizzly-client.jar:/home/jbescos/programs/glassfish6/glassfish/modules/tyrus-spi.jar:/home/jbescos/programs/glassfish6/glassfish/modules/glassfish-corba-omgapi.jar:/home/jbescos/workspace/jakartaee-tck/lib/sigtest.jar:/home/jbescos/workspace/jakartaee-tck/lib/commons-httpclient-3.1.jar:/home/jbescos/workspace/jakartaee-tck/lib/commons-logging-1.1.3.jar:/home/jbescos/workspace/jakartaee-tck/lib/commons-codec-1.9.jar:/home/jbescos/programs/java/jdk1.8.0_231/lib/tools.jar com.sun.tools.xjc.XJCFacade -d /home/jbescos/workspace/jakartaee-tck/src -p com.sun.ts.lib.implementation.sun.javaee.runtime.app -dtd /home/jbescos/workspace/jakartaee-tck/lib/dtds/sun-application_6_0-0.dtd -b file:/home/jbescos/workspace/jakartaee-tck/bin/xml/../../src/com/sun/ts/lib/implementation/sun/javaee/runtime/jaxb-cust.xml
      [xjc] failure in the XJC task. Use the Ant -verbose switch for more details
  [antcall] Exiting /home/jbescos/workspace/jakartaee-tck/install/websocket/bin/build.xml.
      [ant] Exiting /home/jbescos/workspace/jakartaee-tck/install/websocket/bin/build.xml.
BUILD FAILED
/home/jbescos/workspace/jakartaee-tck/bin/xml/ts.import.xml:64: The following error occurred while executing this line:
/home/jbescos/workspace/jakartaee-tck/bin/xml/ts.top.import.xml:391: The following error occurred while executing this line:
/home/jbescos/workspace/jakartaee-tck/bin/xml/ts.top.import.xml:690: xjc failed
	at com.sun.tools.xjc.XJCBase.execute(XJCBase.java:679)
	at com.sun.tools.xjc.XJC2Task.execute(XJC2Task.java:25)
	at com.sun.istack.tools.ProtectedTask.execute(ProtectedTask.java:67)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:293)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
	at org.apache.tools.ant.Task.perform(Task.java:352)
	at org.apache.tools.ant.Target.execute(Target.java:437)
	at org.apache.tools.ant.Target.performTasks(Target.java:458)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1406)
	at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:36)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1261)
	at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:442)
	at org.apache.tools.ant.taskdefs.CallTarget.execute(CallTarget.java:105)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:293)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
	at org.apache.tools.ant.Task.perform(Task.java:352)
	at org.apache.tools.ant.Target.execute(Target.java:437)
	at org.apache.tools.ant.Target.performTasks(Target.java:458)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1406)
	at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:36)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1261)
	at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:442)
	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:293)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
	at org.apache.tools.ant.Task.perform(Task.java:352)
	at org.apache.tools.ant.Target.execute(Target.java:437)
	at org.apache.tools.ant.Target.performTasks(Target.java:458)
	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1406)
	at org.apache.tools.ant.Project.executeTarget(Project.java:1377)
	at org.apache.tools.ant.helper.DefaultExecutor.executeTargets(DefaultExecutor.java:41)
	at org.apache.tools.ant.Project.executeTargets(Project.java:1261)
	at org.apache.tools.ant.Main.runBuild(Main.java:857)
	at org.apache.tools.ant.Main.startAnt(Main.java:236)
	at org.apache.tools.ant.launch.Launcher.run(Launcher.java:287)
	at org.apache.tools.ant.launch.Launcher.main(Launcher.java:112)

```
The task needs the jvm argument -DenableExternalEntityProcessing=true
