### PR TITLE
increase JNLP memory from 2176Mi to 6GB to allow GlassFish Java heap to grow to the max of 4G without causing thrashing (unproven that this is happening)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ spec:
         value: "-XshowSettings:vm -Xmx2048m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
     resources:
       limits:
-        memory: 2176Mi
+        memory: "6Gi"
   - name: jakartaeetck-ci
     image: jakartaee/cts-base:0.2
     command:


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
