### PR TITLE
update JNLP memory to 3gb (a little higher than 2176Mi) as 6GB may be too big (Jenkins ran for about an hour and was still looking for a large enough node to use)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ spec:
         value: "-XshowSettings:vm -Xmx2048m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
     resources:
       limits:
-        memory: "6Gi"
+        memory: "3Gi"
   - name: jakartaeetck-ci
     image: jakartaee/cts-base:0.2
     command:


### PR DESCRIPTION


Signed-off-by: Scott Marlow <smarlow@redhat.com>