### PR TITLE
Fix WebSocket signature test failure

### DIFF
--- a/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig_2.0_se8
+++ b/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig_2.0_se8
@@ -100,8 +100,8 @@ innr public abstract interface static Binary
 innr public abstract interface static BinaryStream
 innr public abstract interface static Text
 innr public abstract interface static TextStream
-meth public abstract void destroy()
-meth public abstract void init(jakarta.websocket.EndpointConfig)
+meth public void destroy()
+meth public void init(jakarta.websocket.EndpointConfig)
 
 CLSS public abstract interface static jakarta.websocket.Decoder$Binary<%0 extends java.lang.Object>
  outer jakarta.websocket.Decoder
@@ -143,8 +143,8 @@ innr public abstract interface static Binary
 innr public abstract interface static BinaryStream
 innr public abstract interface static Text
 innr public abstract interface static TextStream
-meth public abstract void destroy()
-meth public abstract void init(jakarta.websocket.EndpointConfig)
+meth public void destroy()
+meth public void init(jakarta.websocket.EndpointConfig)
 
 CLSS public abstract interface static jakarta.websocket.Encoder$Binary<%0 extends java.lang.Object>
  outer jakarta.websocket.Encoder


### PR DESCRIPTION
Align Java 8 with Java 11
Decoder and Encoder now have default NO-OP methods for init and destroy
Spotted this during my final checks before starting the WebSocket 2.0.0 release

Signed-off-by: Mark Thomas <markt@apache.org>