### PR TITLE
Also set -Ddeployment.resource.validation=false for JSP, APPCLIENT, EJB tests

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -396,9 +396,13 @@ if [[ $test_suite == "javamail" || $test_suite == "samples" || $test_suite == "s
   ESCAPED_MAIL_USER=`echo ${MAIL_USER} | sed -e 's/@/%40/g'`
   cd  ${TS_HOME}/bin
   ant -DdestinationURL="imap://${ESCAPED_MAIL_USER}:${MAIL_PASSWORD}@${MAIL_HOST}:${IMAP_PORT}" populateMailbox
-  ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Ddeployment.resource.validation=false
 fi
 ### populateMailbox for javamail suite - End ###
+
+if [[ $test_suite == "javamail" || $test_suite == "samples" || $test_suite == "servlet" || $test_suite == "appclient" || $test_suite == "ejb" || $test_suite == "jsp" ]]; then
+  ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Ddeployment.resource.validation=false
+fi
+
 
 ##### configRI.sh ends here #####
 cd  ${TS_HOME}/bin


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
Should help address some of the https://ci.eclipse.org/jakartaee-tck/job/eftl-jakartaeetck-run-900/2/testReport failures that @smillidge mentioned were occurring for JSP 