### PR TITLE
show /etc/os-release in output so we know which OS Platform was used for test run

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -27,6 +27,10 @@ fi
 echo "TEST_SUITE:${test_suite}."
 echo "VEHICLE:${vehicle}."
 
+if [ -f "/etc/os-release" ]; then 
+  cat "/etc/os-release"; 
+fi
+
 if [ -z "${test_suite}" ]; then
   echo "Please supply a valid test_suite as argument"
   exit 1


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>