### PR TITLE
[issue 266] switch to Jakarta EE 9 application schema

### DIFF
--- a/src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat12_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd" version="5">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat13_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat14_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application-client.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,9 +17,7 @@
 
 -->
 
-<application-client version="8" metadata-complete="true" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application-client_8.xsd">
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd">
   <display-name>testapp</display-name>
    
 </application-client>

--- a/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,11 +17,7 @@
 
 -->
 
-<application xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-        http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd"
-      version="7">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <module>
     <ejb>testApp_ejb.jar</ejb>
   </module>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <display-name>assembly_compat_single_compat12_50</display-name>
   <description>Application description</description>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd" version="5">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 
   <display-name>assembly_compat_single_compat13_50</display-name>
   <description>Application description</description>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 
   <display-name>assembly_compat_single_compat14_50</display-name>
   <description>Application description</description>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 
   <display-name>assembly_compat_standalone_jar_compat12_50</display-name>
   <description>Application description</description>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd" version="5">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_jar_compat13_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_jar_compat14_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 
   <description>Application description</description>
   <display-name>assembly_compat_standalone_war_compat12_50</display-name>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,7 @@
 
 -->
 
-<application version="5" xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-             http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 
   <description>Application description</description>
   <display-name>assembly_compat_standalone_war_compat14_50</display-name>

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <module>
 <java>ejb3_assembly_librarydirectory_custom_client.jar</java>
 </module>

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <module>
 <java>ejb3_assembly_librarydirectory_disable_client.jar</java>
 </module>

--- a/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <module>
 <web>
 <web-uri>ejb3_assembly_metainfandlibdir_web.war</web-uri>

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <module>
     <java>mdb_dest_jarwar_client.jar</java>
   </module>

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <module>
     <java>mdb_dest_topic_jarwar_client.jar</java>
   </module>

--- a/src/com/sun/ts/tests/ejb30/common/template/application.xml
+++ b/src/com/sun/ts/tests/ejb30/common/template/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <display-name>@DISPLAY_NAME@</display-name>
   <module>
     <java>@CLIENT_JAR@</java>

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>clientviewClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>clientview</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>clientviewClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>clientview</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>clientviewClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>clientview</display-name>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="7" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>cditestsejbweb</display-name>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/mdb/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/mdb/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="7" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>cditestsmdb</display-name>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/usecases/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/usecases/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="7" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>cditestsusecases</display-name>
   <module>

--- a/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
+++ b/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" version="5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
 <display-name>servlet_spec_crosscontext</display-name>
 <module>

--- a/src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" version="5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
 <display-name>servlet_ee_spec_crosscontext</display-name>
 <module>

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
     <display-name>servlet_ee_spec_security_runAs</display-name>
     <module>
         <java>servlet_ee_spec_security_runAs_client.jar</java>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest1Clnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest1</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest2Clnt1</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest2Clnt2</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest2</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbNoWebServiceRefInClientTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbNoWebServiceRefInClientTest</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbSOAPHandlersTest2Clnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefHCWithDDsTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefHCWithDDsTest</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefWithDDsTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefWithDDsTest</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>WSEjbWSRefRespBindAndAddressingCombinedTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="7" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>WSMTOMFeaturesTestUsingDDsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
   <description>Application description</description>
   <display-name>WSRespBindAndAddressingTestUsingDDsClnt</display-name>
   <module>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

For https://github.com/eclipse-ee4j/jakartaee-tck/issues/266

Updated the following files to https://jakarta.ee/xml/ns/jakartaee:
```
src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
src/com/sun/ts/tests/ejb30/common/template/application.xml
src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
```