### PR TITLE
eclipse-ee4j/ejb-api#123 - @Schedule is now repeatable

### DIFF
--- a/src/com/sun/ts/tests/ejb32/timer/service/common/AutoTimerBeanBase.java
+++ b/src/com/sun/ts/tests/ejb32/timer/service/common/AutoTimerBeanBase.java
@@ -47,4 +47,11 @@ public class AutoTimerBeanBase extends TimerBeanBase implements TimerIF {
 
   }
 
+  // Since Jakarta Enterprise Beans 4.0, @Schedule is repeatable
+  @Schedule(hour = "12", dayOfWeek = "Mon-Thu", persistent = true, info = "a6")
+  @Schedule(hour = "11", dayOfWeek = "Fri", persistent = false, info = "a7")
+  void doubleAutoTimersCallbackPersistentAndNot() {
+
+  }
+
 }

--- a/src/com/sun/ts/tests/ejb32/timer/service/singleton/Client.java
+++ b/src/com/sun/ts/tests/ejb32/timer/service/singleton/Client.java
@@ -35,6 +35,6 @@ public class Client extends ClientBase {
   public void setup(String[] args, Properties p) {
     super.setup(args, p);
     clientBean = singletonBean;
-    autoTimerCount = 6;
+    autoTimerCount = 8;
   }
 }

--- a/src/com/sun/ts/tests/ejb32/timer/service/stateless/Client.java
+++ b/src/com/sun/ts/tests/ejb32/timer/service/stateless/Client.java
@@ -34,6 +34,6 @@ public class Client extends ClientBase {
   public void setup(String[] args, Properties p) {
     super.setup(args, p);
     clientBean = statelessBean;
-    autoTimerCount = 6;
+    autoTimerCount = 8;
   }
 }


### PR DESCRIPTION
eclipse-ee4j/ejb-api#123
Make sure we have some flavor of the repeatable @schedule annotation.

This is a very simple change.
Based on what is already there, not sure if we can do really better at the minute.

Feedback welcome