### PR TITLE
Reverting the Authorization UG plugin versions

### DIFF
--- a/user_guides/jacc/pom.xml
+++ b/user_guides/jacc/pom.xml
@@ -47,6 +47,10 @@
         <status></status>
         <doc.pdf>Jakarta-Authorization-TCK-Users-Guide.pdf</doc.pdf>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
+        <!-- XXX - jbake needs an older version than this -->
+        <asciidoctorj.version>1.6.2</asciidoctorj.version>
+        <jruby.version>9.2.6.0</jruby.version>
     </properties>
 
     <build>
@@ -153,17 +157,17 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>2.0.0-RC.1</version>
+                <version>${asciidoctor.maven.plugin.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby-complete</artifactId>
-                        <version>9.2.12.0</version>
+                        <version>${jruby.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>2.4.0</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>


### PR DESCRIPTION
This change is to revert the some of the plugin version upgrades  for jacc userguide in https://github.com/eclipse-ee4j/jakartaee-tck/pull/406 as it causes failure in Jenkins CI. 

The exact root cause of the userguide build failure is unknown but the the applied version works fine.

More details in the  https://github.com/eclipse-ee4j/jakartaee-tck/pull/406 discussion.