### PR TITLE
fix for webprofile failures due to common connector deployment failures(due to removal of webservices jar in web-profile).

### DIFF
--- a/bin/xml/impl/glassfish/connector.xml
+++ b/bin/xml/impl/glassfish/connector.xml
@@ -97,7 +97,7 @@
              Due to bug# 6842858, we need to deploy an annotation based .rar before
              the non-annotation based .rar files.  Failure to do so currently results
              in a ClassCastException at runtime of the TCK tests.
-          -->
+        -->
         <fileset  id="anno_rar_file"
                   dir="${ts.home}/dist/"
                   includes="com/sun/ts/tests/common/connector/whitebox/annotated/whitebox-anno_no_md.rar"/>
@@ -105,9 +105,24 @@
             <fileset refid="anno_rar_file"/>
         </ts.glassfish.deploy>
 
-        <fileset  id="archives"
+        <if>
+          <contains string="${javaee.level}" substring="full"/>
+        <then>
+            <fileset  id="archives"
                   dir="${ts.home}/dist/"
                   includes="com/sun/ts/tests/common/connector/whitebox/**/*.rar"/>
+        </then>
+        <else>
+            <fileset  id="archives"
+                  dir="${ts.home}/dist/"
+                  includes="com/sun/ts/tests/common/connector/whitebox/*.rar,
+                            com/sun/ts/tests/common/connector/whitebox/ibanno/*.rar,  
+                            com/sun/ts/tests/common/connector/whitebox/mdcomplete/*.rar,
+                            com/sun/ts/tests/common/connector/whitebox/mixedmode/*.rar,
+                            com/sun/ts/tests/common/connector/whitebox/multianno/*.rar"/>
+       </else>
+       </if>
+
         <ts.glassfish.deploy>
             <fileset refid="archives"/>
         </ts.glassfish.deploy>
@@ -228,10 +243,15 @@
             <param name="poolName" value="cts-connector-pool-old-dd-whitebox-xa-param.rar"/>
         </antcall>
 
-        <antcall target="create-a-connection-pool" >
-            <param name="rarName" value="whitebox-permissiondd"/>
-            <param name="poolName" value="cts-connector-pool-whitebox-permissiondd.rar"/>
-        </antcall>
+        <if>
+          <contains string="${javaee.level}" substring="full"/>
+        <then>
+            <antcall target="create-a-connection-pool" >
+                <param name="rarName" value="whitebox-permissiondd"/>
+                <param name="poolName" value="cts-connector-pool-whitebox-permissiondd.rar"/>
+            </antcall>
+        </then>
+        </if>
 
     </target>
 
@@ -305,9 +325,14 @@
             <param name="poolName" value="cts-connector-pool-old-dd-whitebox-xa-param.rar"/>
         </antcall>
 
-        <antcall target="delete-connector-connection-pool" >
-            <param name="poolName" value="cts-connector-pool-whitebox-permissiondd.rar"/>
-        </antcall>
+        <if>
+          <contains string="${javaee.level}" substring="full"/>
+        <then>
+            <antcall target="delete-connector-connection-pool" >
+                <param name="poolName" value="cts-connector-pool-whitebox-permissiondd.rar"/>
+            </antcall>
+        </then>
+        </if>
 
     </target>
 
@@ -402,10 +427,15 @@
             <param name="jndiName" value="${oldwhitebox-xa-param}"/>
         </antcall>
 
-        <antcall target="create-a-connector-resource" >
-            <param name="poolName" value="cts-connector-pool-whitebox-permissiondd.rar"/>
-            <param name="jndiName" value="${whitebox-permissiondd}"/>
-        </antcall>
+        <if>
+          <contains string="${javaee.level}" substring="full"/>
+        <then>
+            <antcall target="create-a-connector-resource" >
+                <param name="poolName" value="cts-connector-pool-whitebox-permissiondd.rar"/>
+                <param name="jndiName" value="${whitebox-permissiondd}"/>
+            </antcall>
+        </then>
+        </if>
 
     </target>
 

--- a/src/com/sun/ts/tests/jaspic/tssv/config/SOAPTSServerAuthConfig.java
+++ b/src/com/sun/ts/tests/jaspic/tssv/config/SOAPTSServerAuthConfig.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.jaspic.tssv.config;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Hashtable;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.AuthException;
+import javax.security.auth.callback.CallbackHandler;
+import jakarta.servlet.http.HttpServletRequest;
+
+import javax.security.auth.Subject;
+import java.util.Map;
+import java.util.logging.Level;
+
+
+
+import jakarta.xml.soap.MimeHeaders;
+import jakarta.xml.soap.Name;
+import jakarta.xml.soap.SOAPBody;
+import jakarta.xml.soap.SOAPElement;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
+import jakarta.xml.soap.SOAPPart;
+
+
+import com.sun.ts.tests.jaspic.tssv.util.JASPICData;
+import com.sun.ts.tests.jaspic.tssv.util.TSLogger;
+
+public class SOAPTSServerAuthConfig extends TSServerAuthConfig {
+  
+  protected SOAPTSServerAuthConfig(String layer, String applicationCtxt,
+      CallbackHandler cbkHandler, Map props) {
+    super(layer, applicationCtxt, cbkHandler, props);
+  }
+
+  public SOAPTSServerAuthConfig(String layer, String applicationCtxt,
+      CallbackHandler cbkHandler, Map props, TSLogger tsLogger) {
+
+    super(layer, applicationCtxt, cbkHandler, props);
+
+    if (tsLogger != null) {
+      logger = tsLogger;
+    }
+
+    String str = "SOAPTSServerAuthConfig called for layer=" + layer
+        + " : appContext=" + applicationCtxt;
+    logger.log(Level.INFO, str);
+  }
+
+  @Override
+  public String getAuthContextID(MessageInfo messageInfo) {
+    logger.log(Level.INFO, "getAuthContextID called");
+    String rval = null;
+
+    if (messageLayer.equals(JASPICData.LAYER_SOAP)) {
+      rval = getOpName((SOAPMessage) messageInfo.getRequestMessage());
+    } else {
+      super.getAuthContextID(messageInfo);
+    }    
+
+    return rval;
+  }
+
+  private String getOpName(SOAPMessage message) {
+    if (message == null) {
+      return null;
+    }
+
+    String rvalue = null;
+
+    // first look for a SOAPAction header.
+    // this is what .net uses to identify the operation
+
+    MimeHeaders headers = message.getMimeHeaders();
+    if (headers != null) {
+      String[] actions = headers.getHeader("SOAPAction");
+      if (actions != null && actions.length > 0) {
+        rvalue = actions[0];
+        if (rvalue != null && rvalue.equals("\"\"")) {
+          rvalue = null;
+        }
+      }
+    }
+
+    // if that doesn't work then we default to trying the name
+    // of the first child element of the SOAP envelope.
+
+    if (rvalue == null) {
+      Name name = getName(message);
+      if (name != null) {
+        rvalue = name.getLocalName();
+      }
+    }
+
+    return rvalue;
+  }
+
+  private Name getName(SOAPMessage message) {
+    Name rvalue = null;
+    SOAPPart soap = message.getSOAPPart();
+    if (soap != null) {
+      try {
+        SOAPEnvelope envelope = soap.getEnvelope();
+        if (envelope != null) {
+          SOAPBody body = envelope.getBody();
+          if (body != null) {
+            Iterator it = body.getChildElements();
+            while (it.hasNext()) {
+              Object o = it.next();
+              if (o instanceof SOAPElement) {
+                rvalue = ((SOAPElement) o).getElementName();
+                break;
+              }
+            }
+          }
+        }
+      } catch (SOAPException se) {
+        if (logger.isLoggable(Level.FINE)) {
+          logger.log(Level.FINE, "WSS: Unable to get SOAP envelope", se);
+        }
+      }
+    }
+
+    return rvalue;
+  }
+
+}

--- a/src/com/sun/ts/tests/jaspic/tssv/config/TSAuthConfigProvider.java
+++ b/src/com/sun/ts/tests/jaspic/tssv/config/TSAuthConfigProvider.java
@@ -214,8 +214,16 @@ public class TSAuthConfigProvider
         logger.log(Level.INFO, msg);
       }
 
-      ServerAuthConfig serverAuthConfig = new TSServerAuthConfig(layer,
-          appContext, handler, properties, logger);
+      ServerAuthConfig serverAuthConfig = null;
+
+      if(JASPICData.LAYER_SOAP.equals(layer)) {
+          serverAuthConfig = new SOAPTSServerAuthConfig(layer,
+            appContext, handler, properties, logger);
+      } else {
+          serverAuthConfig = new TSServerAuthConfig(layer,
+            appContext, handler, properties, logger);
+      }
+
       serverAuthConfigMap.put(layer + appContext, serverAuthConfig);
       return serverAuthConfig;
     } catch (Exception e) {

--- a/src/com/sun/ts/tests/jaspic/tssv/config/TSServerAuthConfig.java
+++ b/src/com/sun/ts/tests/jaspic/tssv/config/TSServerAuthConfig.java
@@ -29,15 +29,6 @@ import javax.security.auth.Subject;
 import java.util.Map;
 import java.util.logging.Level;
 
-import jakarta.xml.soap.MimeHeaders;
-import jakarta.xml.soap.Name;
-import jakarta.xml.soap.SOAPBody;
-import jakarta.xml.soap.SOAPElement;
-import jakarta.xml.soap.SOAPEnvelope;
-import jakarta.xml.soap.SOAPException;
-import jakarta.xml.soap.SOAPMessage;
-import jakarta.xml.soap.SOAPPart;
-
 import com.sun.ts.tests.jaspic.tssv.util.JASPICData;
 import com.sun.ts.tests.jaspic.tssv.util.TSLogger;
 
@@ -52,19 +43,19 @@ import com.sun.ts.tests.jaspic.tssv.util.TSLogger;
  */
 public class TSServerAuthConfig
     implements jakarta.security.auth.message.config.ServerAuthConfig {
-  private static String messageLayer = null;
+  protected static String messageLayer = null;
 
-  private static String appContext = null;
+  protected static String appContext = null;
 
-  private static CallbackHandler handler = null;
+  protected static CallbackHandler handler = null;
 
-  private static TSLogger logger = TSLogger.getTSLogger(JASPICData.LOGGER_NAME);
+  protected static TSLogger logger = TSLogger.getTSLogger(JASPICData.LOGGER_NAME);
 
-  private static Map properties = null;
+  protected static Map properties = null;
 
-  private static Map authMandatoryMap;
+  protected static Map authMandatoryMap;
 
-  private TSServerAuthConfig(String layer, String applicationCtxt,
+  protected TSServerAuthConfig(String layer, String applicationCtxt,
       CallbackHandler cbkHandler, Map props) {
     messageLayer = layer;
     appContext = applicationCtxt;
@@ -136,11 +127,7 @@ public class TSServerAuthConfig
     logger.log(Level.INFO, "getAuthContextID called");
     String rval = null;
 
-    if (messageLayer.equals(JASPICData.LAYER_SOAP)) {
-
-      rval = getOpName((SOAPMessage) messageInfo.getRequestMessage());
-
-    } else if (messageLayer.equals(JASPICData.LAYER_SERVLET)) {
+    if (messageLayer.equals(JASPICData.LAYER_SERVLET)) {
       HttpServletRequest request = (HttpServletRequest) messageInfo
           .getRequestMessage();
       rval = request.getServletPath() + " " + request.getMethod();
@@ -260,69 +247,6 @@ public class TSServerAuthConfig
         logger.log(Level.INFO, msg);
       }
     }
-  }
-
-  private String getOpName(SOAPMessage message) {
-    if (message == null) {
-      return null;
-    }
-
-    String rvalue = null;
-
-    // first look for a SOAPAction header.
-    // this is what .net uses to identify the operation
-
-    MimeHeaders headers = message.getMimeHeaders();
-    if (headers != null) {
-      String[] actions = headers.getHeader("SOAPAction");
-      if (actions != null && actions.length > 0) {
-        rvalue = actions[0];
-        if (rvalue != null && rvalue.equals("\"\"")) {
-          rvalue = null;
-        }
-      }
-    }
-
-    // if that doesn't work then we default to trying the name
-    // of the first child element of the SOAP envelope.
-
-    if (rvalue == null) {
-      Name name = getName(message);
-      if (name != null) {
-        rvalue = name.getLocalName();
-      }
-    }
-
-    return rvalue;
-  }
-
-  private Name getName(SOAPMessage message) {
-    Name rvalue = null;
-    SOAPPart soap = message.getSOAPPart();
-    if (soap != null) {
-      try {
-        SOAPEnvelope envelope = soap.getEnvelope();
-        if (envelope != null) {
-          SOAPBody body = envelope.getBody();
-          if (body != null) {
-            Iterator it = body.getChildElements();
-            while (it.hasNext()) {
-              Object o = it.next();
-              if (o instanceof SOAPElement) {
-                rvalue = ((SOAPElement) o).getElementName();
-                break;
-              }
-            }
-          }
-        }
-      } catch (SOAPException se) {
-        if (logger.isLoggable(Level.FINE)) {
-          logger.log(Level.FINE, "WSS: Unable to get SOAP envelope", se);
-        }
-      }
-    }
-
-    return rvalue;
   }
 
   /**


### PR DESCRIPTION
fix for web-profile test failures listed by wiki - https://github.com/eclipse-ee4j/jakartaee-tck/wiki/Jakarta-EE-9-TCK-results
CI runs with the fix:
- https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-grao/job/master/38/testReport/
- https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-grao/job/master/39/testReport/
- https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-grao/job/master/41/testReport/
- https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-grao/job/master/40/testReport/ 
- https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-grao/job/master/43/testReport/  (rerun of failed test-suites)

For web profile tests, fix doesn't deploy whitebox/permissiondd.rar(permissiodd has dependency on jakarta.xml.ws.WebServicePermission class, which has been removed from web-profile in glassfish 6). 

Also removes dependency on jakarta.xml.soap.* packages during JASPIC web-profile execution, to avoid failures.
signed-off-by: Gurunandan <gurunandan.rao@oracle.com>