### PR TITLE
A small number of updates for Web Socket TCK docs.

### DIFF
--- a/install/websocket/docs/WebSocketJavadocAssertions.html
+++ b/install/websocket/docs/WebSocketJavadocAssertions.html
@@ -25,7 +25,7 @@
 <body bgcolor="white">
 <br>
 <CENTER>
-<h2>JavaTM API for WebSocket<br>WebSocket - 1.1<br>
+<h2>Jakarta API for WebSocket<br>WebSocket - 2.0<br>
 				JavaDoc Assertion Detail 
 			</h2>
 </CENTER>

--- a/install/websocket/docs/WebSocketTCK2.0-ReleaseNotes.html
+++ b/install/websocket/docs/WebSocketTCK2.0-ReleaseNotes.html
@@ -85,7 +85,7 @@ Platform, Standard Edition 8 (Java SE 8).</P>
 
 <h2><a name="install_setup_run">Installing, Setting Up, and Running the JavaTM API for WebSocket TCK</a></h2>
 
-<p>Refer to the <cite>Jakarta WebSocket TCK 2.0 User's Guide</cite> for complete instructions on installing, setting up, and running the Jakarta WebSocket TCK.
+<p>Refer to the <a href="pdf-usersguide/Jakarta-WebSocket-TCK-Users-Guide.pdf">Jakarta WebSocket Technology Compatibility Kit, Version 2.0 User's Guide</a> for complete instructions on installing, setting up, and running the Jakarta WebSocket TCK.
 The online version of the JT Harness version 5.0 documentation is available <a href="https://wiki.openjdk.java.net/display/CodeTools/Documentation">here</a>.</p>
 
 <hr>

--- a/install/websocket/docs/index.html
+++ b/install/websocket/docs/index.html
@@ -47,7 +47,7 @@ h4 {  font-style: italic; color: #000099}
       <li>The Release Notes updates may be available from the Jakarta WebSocket specification web site: <a href="https://jakarta.ee/specifications/websocket/2.0/">https://jakarta.ee/specifications/websocket/2.0/</a></li>
     </ul>
   </li>
-  <li> The <em>Jakarta WebSocket Technology Compatibility Kit, Version 2.0 User's Guide </em> provides the information that you need to install, set up, and  run  the Jakarta WebSocket TCK, Version 2.0.  In addition, the guide provides the rules  you must comply with to pass the Jakarta WebSocket TCK.</li>
+  <li> The <a href="pdf-usersguide/Jakarta-WebSocket-TCK-Users-Guide.pdf">Jakarta WebSocket Technology Compatibility Kit, Version 2.0 User's Guide</a> provides the information that you need to install, set up, and  run  the Jakarta WebSocket TCK, Version 2.0.  In addition, the guide provides the rules  you must comply with to pass the Jakarta WebSocket TCK.</li>
 
   <li>The <a href="assertions/WebSocketJavadocAssertions.html">Javadoc Assertion List</a> lists all the javadoc assertions that are tested by the Java API for WebSocket TCK.</li>
 </ul>

--- a/user_guides/websocket/src/main/jbake/content/config.inc
+++ b/user_guides/websocket/src/main/jbake/content/config.inc
@@ -63,7 +63,7 @@ environment variables:
 [source,oac_no_warn]
 ----
 websocket.api=${web.home}/modules/jakarta.websocket-api.jar \
-${pathsep}${web.home}/modules/javax.servlet-api.jar
+${pathsep}${web.home}/modules/jakarta.servlet-api.jar
 ----
 --
 +


### PR DESCRIPTION
Minor updates for Web Socket docs.
 - corrected missed javax reference in user-guide
 - fixed title of assertion HTML file
 - added links to User Guide from readme and release notes html files.
Signed-off-by: Ed Bratt <ed.bratt@oracle.com>