### PR TITLE
update user_guides tool versions (in tck-packages.inc) for jta, connector, jsf, jsonb, jsp, jstl, securityapi, template

### DIFF
--- a/user_guides/Template/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/Template/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/connector/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/connector/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/jsf/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/jsf/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/jsonb/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/jsonb/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/jsp/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/jsp/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/jstl/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/jstl/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/jta/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/jta/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9

--- a/user_guides/securityapi/src/main/jbake/content/tck-packages.inc
+++ b/user_guides/securityapi/src/main/jbake/content/tck-packages.inc
@@ -1,7 +1,7 @@
-** JDOM 1.0
+** JDOM 1.1.3
 
 ** Apache Commons HTTP Client 3.1
 
-** Apache Commons Logging 1.1.1
+** Apache Commons Logging 1.1.3
 
-** Apache Commons Codec 1.3
+** Apache Commons Codec 1.9


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

It looks like the TCK user guide list of tools is showing incorrect tool versions for { jta, connector, jsf, jsonb, jsp, jstl, securityapi }

The following tools are listed with incorrect versions:
- JDOM
- Apache Commons HTTP Client
- Apache Commons Logging
- Apache Commons Codec

This pull request updates to the tool versions used in the Platform TCK.  This was already addressed individually for the other Standalone TCKs produced by the Platform TCK.

@tomjenkinson after this is reviewed + merged, IMO we should stage a new Transaction TCK zip for the ballot review.