### PR TITLE
Fix #535. Reverts #349 and address root cause of JSP test failure

### DIFF
--- a/src/com/sun/ts/tests/jsp/spec/el/jsp/ELJspVersionTag.java
+++ b/src/com/sun/ts/tests/jsp/spec/el/jsp/ELJspVersionTag.java
@@ -17,8 +17,6 @@
 package com.sun.ts.tests.jsp.spec.el.jsp;
 
 import com.sun.ts.tests.jsp.common.util.JspTestUtil;
-import jakarta.el.ELContext;
-import jakarta.el.ValueExpression;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.tagext.SimpleTagSupport;
@@ -26,15 +24,15 @@ import java.io.IOException;
 
 public class ELJspVersionTag extends SimpleTagSupport {
 
-  private ValueExpression poundExpr;
+  private String poundExpr;
 
-  public void setPoundExpr(ValueExpression poundExpr) {
+  public void setPoundExpr(String poundExpr) {
     this.poundExpr = poundExpr;
   }
 
   public void doTag() throws JspException, IOException {
-    ELContext elContext = getJspContext().getELContext();
     JspWriter out = getJspContext().getOut();
+
     try {
       out.println(poundExpr);
     } catch (Throwable t) {

--- a/src/web/jsp/spec/el/jsp/ELJspVersionTest.gf
+++ b/src/web/jsp/spec/el/jsp/ELJspVersionTest.gf
@@ -1,1 +1,1 @@
-ValueExpression[#{foo}]
+#{foo}

--- a/src/web/jsp/spec/el/jsp/WEB-INF/el_jsp.tld
+++ b/src/web/jsp/spec/el/jsp/WEB-INF/el_jsp.tld
@@ -20,7 +20,7 @@
 <taglib xmlns = "https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance" 
     xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" 
-    version = "2.1">
+    version = "3.0">
 
     <tlib-version>1.0</tlib-version>
     <short-name>el</short-name>

--- a/src/web/jsp/spec/el/jsp/WEB-INF/el_jsp_2.0.tld
+++ b/src/web/jsp/spec/el/jsp/WEB-INF/el_jsp_2.0.tld
@@ -17,10 +17,10 @@
 
 -->
 
-<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
-    version="3.0">
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
+    version="2.0">
 
     <tlib-version>1.0</tlib-version>
     <short-name>el_jsp_version</short-name>
@@ -32,9 +32,6 @@
     <attribute>
       <name>poundExpr</name>
       <required>true</required>
-      <deferred-value>
-        <type>java.lang.String</type>
-      </deferred-value>
     </attribute>
   </tag>
 </taglib>


### PR DESCRIPTION
The EL JSP version test is testing that TLDs before version 2.1 ignore
the #{...} syntax. Therefore the el_jsp_2.0.tld file needs to use a
schema version less than 2.1 - in this case it uses 2.0.
Also fixes the validity of the el_jsp.tld file.

Signed-off-by: Mark Thomas <markt@apache.org>