### PR TITLE
update deliverable.version to 9.0 when building the Platform TCK

### DIFF
--- a/docker/build_jakartaeetck.sh
+++ b/docker/build_jakartaeetck.sh
@@ -135,12 +135,12 @@ echo "########## Trunk.CTS ##########"
 mkdir -p $BASEDIR/internal/docs/jakartaee/
 cp $BASEDIR/internal/docs/dtd/*.dtd $BASEDIR/internal/docs/jakartaee/
 if [[ "$LICENSE" == "EFTL" || "$LICENSE" == "eftl" ]]; then
-  ant -f $BASEDIR/release/tools/build.xml -Ddeliverabledir=jakartaee -Ddeliverable.version=8.0 -Dskip.createbom="true" -Dskip.build="true" -Dbasedir=$BASEDIR/release/tools -DuseEFTLicensefile="true" jakartaee
+  ant -f $BASEDIR/release/tools/build.xml -Ddeliverabledir=jakartaee -Ddeliverable.version=9.0 -Dskip.createbom="true" -Dskip.build="true" -Dbasedir=$BASEDIR/release/tools -DuseEFTLicensefile="true" jakartaee
 else
-  ant -f $BASEDIR/release/tools/build.xml -Ddeliverabledir=jakartaee -Ddeliverable.version=8.0 -Dskip.createbom="true" -Dskip.build="true" -Dbasedir=$BASEDIR/release/tools jakartaee
+  ant -f $BASEDIR/release/tools/build.xml -Ddeliverabledir=jakartaee -Ddeliverable.version=9.0 -Dskip.createbom="true" -Dskip.build="true" -Dbasedir=$BASEDIR/release/tools jakartaee
 fi
 
-ant -f $BASEDIR/release/tools/build.xml -Ddeliverabledir=jakartaee -Ddeliverable.version=8.0 -Dskip.createbom="true" -Dskip.build="true" -Dbasedir=$BASEDIR/release/tools smoke
+ant -f $BASEDIR/release/tools/build.xml -Ddeliverabledir=jakartaee -Ddeliverable.version=9.0 -Dskip.createbom="true" -Dskip.build="true" -Dbasedir=$BASEDIR/release/tools smoke
 
 mkdir -p ${WORKSPACE}/jakartaeetck-bundles
 cd ${WORKSPACE}/jakartaeetck-bundles


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
In https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/master/1110/consoleText, we noticed:
```
Building zip: /home/jenkins/agent/workspace/jakartaee-tck_master/release/JAKARTAEE_BUILD/build_11-Oct-2020/bundle/cts-internal-8.0_11-Oct-2020.zip
```
This pr is to update `deliverable.version` to 9.0