### PR TITLE
[549] correct JMS SPEC major version to 3.0

### DIFF
--- a/src/com/sun/ts/tests/jms/common/JmsTool.java
+++ b/src/com/sun/ts/tests/jms/common/JmsTool.java
@@ -114,9 +114,9 @@ public class JmsTool {
 
   public static final int COMMON_FACTORY = 17;
 
-  public static final String JMS_VERSION = "2.0";
+  public static final String JMS_VERSION = "3.0";
 
-  public static final int JMS_MAJOR_VERSION = 2;
+  public static final int JMS_MAJOR_VERSION = 3;
 
   public static final int JMS_MINOR_VERSION = 0;
 


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
Addresses the incorrect JMS SPEC version references https://github.com/eclipse-ee4j/jakartaee-tck/issues/549

Note that Jakarta EE 8 includes Jakarta Messaging (JMS) 2.0 and Jakarta EE 9 includes Jakarta Messaging (JMS) 3.0.