### PR TITLE
Revert previous expected status code change which is invalidating HTTP BASIC authentication testing.

### DIFF
--- a/src/com/sun/ts/tests/common/jspservletsec/SecBasicClient.java
+++ b/src/com/sun/ts/tests/common/jspservletsec/SecBasicClient.java
@@ -365,8 +365,9 @@ public class SecBasicClient extends BaseUrlClient {
     TEST_PROPS.setProperty(BASIC_AUTH_USER, "invalid");
     TEST_PROPS.setProperty(BASIC_AUTH_PASSWD, password);
     // The servlet is mapped to "/ServletSecTest" so this request should result
-    // in a 404 since no Servlet is mapped to the requested URI.
-    TEST_PROPS.setProperty(STATUS_CODE, NOT_FOUND);
+    // in a 404 since no Servlet is mapped to the requested URI or 401 if the container
+    // rejects the incoming BASIC header.
+    TEST_PROPS.setProperty(STATUS_CODE, UNAUTHORIZED + "," + NOT_FOUND);
     invoke();
 
     dumpResponse(); // debug aid


### PR DESCRIPTION
The change to the status code has changed the test from performing a security test to performing a path availability test instead, this is making tests within "servlet/spec/security/secbasic/Client.java" invalid, specifically "test7" and "test7_anno".

"test7" starts with a comment describing the intent of this test, the intent is to test that the container denies access to the resource when accessed with an invalid username and password.  The text also describes that "j_security_check" is appended to the URL to verify this does not "trick" the server into allowing the request through.  At no point is "j_security_check" being described as being used as the trigger for authentication.

For "test7" the path "/servlet_sec_secbasic_web/ServletSecTest/j_security_check" is accessed, this matches against the constraint defined in the web.xml:

```
  <security-constraint>
    <web-resource-collection>
      <web-resource-name>MySecureBit0</web-resource-name>
      <url-pattern>/ServletSecTest</url-pattern>
      <http-method>GET</http-method>
      <http-method>POST</http-method>
    </web-resource-collection>
    <auth-constraint>
      <role-name>Administrator</role-name>
    </auth-constraint>
    <user-data-constraint>
      <transport-guarantee>NONE</transport-guarantee>
    </user-data-constraint>
  </security-constraint>
```

This constraint should be matched and enforced before the underlying container moves to indicating the presence (or not) of the specified resource.  Responding with a HTTP 404 is providing information that should not be available to an unauthenticated identity.

For "test7_anno" the servlet is annotated with:

```
@ServletSecurity(value = @HttpConstraint(EmptyRoleSemantic.DENY), httpMethodConstraints = {
    @HttpMethodConstraint(value = "GET", rolesAllowed = "Administrator"),
    @HttpMethodConstraint(value = "POST", rolesAllowed = "Administrator") })
@WebServlet(name = "ServletSecAnnoTestLogicalName", urlPatterns = {
    "/ServletSecAnnoTest" })
```

Again these constraints should be being matched BEFORE allowing the request through for processing.

In both cases the web.xml contains the following meaning HTTP BASIC authentication has been selected as the chosen authentication mechanism to challenge with when authentication is required:

```
  <login-config>
    <auth-method>BASIC</auth-method>
    <realm-name>default</realm-name>
  </login-config>
```

A HTTP status code of 401 is the correct status code to challenge the remote client with after the failed authentication.

Revert "Correct the response code being looked for."

This reverts commit 947f34a3bd9055c599d9ccfa5239eff68afe9957.

Signed-off-by: Darran Lofthouse <darran.lofthouse@jboss.com>