### PR TITLE
[exclude for pull/558] Exclude test due to change to status code change which is invalidating HTTP BASIC authentication testing

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -25,6 +25,11 @@
 #
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpupgradehandler/URLClient.java#upgradeTest
 
+#
+# Excluding this test until we can merge https://github.com/eclipse-ee4j/jakartaee-tck/pull/558
+# TODO: In the next release after Jakarta EE 9 (perhaps Jakarta EE 9.1 or 10) the pull request will be merged and this exclude removed.
+com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7
+com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7_anno
 
 ################
 # JSF

--- a/install/servlet/bin/ts.jtx
+++ b/install/servlet/bin/ts.jtx
@@ -24,4 +24,11 @@
 # BUG id 19793504
 #
 com/sun/ts/tests/servlet/api/jakarta_servlet/servletrequest30/URLClient.java#asyncStartedTest3
+
+#
+# Excluding this test until we can merge https://github.com/eclipse-ee4j/jakartaee-tck/pull/558
+# TODO: In the next release after Jakarta EE 9 (perhaps Jakarta EE 9.1 or 10) the pull request will be merged and this exclude removed.
+com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7
+com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7_anno
+
 #


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
Exclude the test since it is too late to apply the https://github.com/eclipse-ee4j/jakartaee-tck/pull/558 change for Jakarta EE 9.  It is too late as this test is also used in the already released (via ballot) Servlet TCK.