### PR TITLE
Add excludes for accepted TCK challenges https://github.com/eclipse-ee4j/servlet-api/issues/385 + https://github.com/eclipse-ee4j/servlet-api/issues/378

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,6 +30,18 @@ com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpupgradehandler/URLClient.j
 # TODO: In the next release after Jakarta EE 9 (perhaps Jakarta EE 9.1 or 10) the pull request will be merged and this exclude removed.
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7_anno
+
+#
+# In response to accepted Platform TCK challenge servlet-api/issues/385 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/594, exclude the following tests:
+#    com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+
+#
+# In response to accepted challenge eclipse-ee4j/servlet-api#378 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/593, exclude the following tests:
+#    com.sun.ts.tests.servlet.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+#    com.sun.ts.tests.servlet.pluggability.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
 
 ################
 # JSF

--- a/install/servlet/bin/ts.jtx
+++ b/install/servlet/bin/ts.jtx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates and others.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -30,5 +30,17 @@ com/sun/ts/tests/servlet/api/jakarta_servlet/servletrequest30/URLClient.java#asy
 # TODO: In the next release after Jakarta EE 9 (perhaps Jakarta EE 9.1 or 10) the pull request will be merged and this exclude removed.
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7_anno
+
+#
+# In response to accepted Platform TCK challenge servlet-api/issues/385 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/594, exclude the following tests:
+#    com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+
+#
+# In response to accepted challenge eclipse-ee4j/servlet-api#378 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/593, exclude the following tests:
+#    com.sun.ts.tests.servlet.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+#    com.sun.ts.tests.servlet.pluggability.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
 
 #


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/593
https://github.com/eclipse-ee4j/jakartaee-tck/issues/594

**Related Issue(s)**
https://github.com/eclipse-ee4j/servlet-api/issues/378
https://github.com/eclipse-ee4j/servlet-api/issues/385


**Describe the change**
This same change will be applied (after approved for merge) to the 9.0.x branch so we can release 9.0.1 Platform TCK + 5.0.1 Servlet TCK with the excluded (challenge accepted) tests.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
