### PR TITLE
Add (9.0.x branch) excludes for accepted TCK challenges https://github.com/eclipse-ee4j/servlet-api/issues/385 + https://github.com/eclipse-ee4j/servlet-api/issues/378

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -31,6 +31,18 @@ com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpupgradehandler/URLClient.j
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7_anno
 
+#
+# In response to accepted Platform TCK challenge servlet-api/issues/385 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/594, exclude the following tests:
+#    com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+
+#
+# In response to accepted challenge eclipse-ee4j/servlet-api#378 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/593, exclude the following tests:
+#    com.sun.ts.tests.servlet.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+#    com.sun.ts.tests.servlet.pluggability.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
+
 ################
 # JSF
 ################

--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at

--- a/install/servlet/bin/ts.jtx
+++ b/install/servlet/bin/ts.jtx
@@ -32,3 +32,15 @@ com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7
 com/sun/ts/tests/servlet/spec/security/secbasic/Client.java#test7_anno
 
 #
+# In response to accepted Platform TCK challenge servlet-api/issues/385 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/594, exclude the following tests:
+#    com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest40/Client.java\#httpServletMappingDispatchTest
+
+#
+# In response to accepted challenge eclipse-ee4j/servlet-api#378 + https://github.com/eclipse-ee4j/jakartaee-tck/issues/593, exclude the following tests:
+#    com.sun.ts.tests.servlet.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+#    com.sun.ts.tests.servlet.pluggability.api.jakarta_servlet_http.cookie.URLClient#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java\#setMaxAgePositiveTest
+
+#

--- a/install/servlet/bin/ts.jtx
+++ b/install/servlet/bin/ts.jtx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates and others.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the

--- a/release/tools/jakartaee-tech-common.xml
+++ b/release/tools/jakartaee-tech-common.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@
     <!--    <property name="test.areas" value="samples"/> -->
 
     <property name="deliverable.version"           value="9.0"/>
-    <property name="deliverable.tck.version"           value="9.0.0"/>
+    <property name="deliverable.tck.version"           value="9.0.1"/>
 
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,7 @@
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
     <property name="deliverable.version"           value="9.0"/>
-    <property name="deliverable.tck.version"           value="9.0.0"/>
+    <property name="deliverable.tck.version"           value="9.0.1"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxm/**/*, **/jaxm1.0.1/**/*,

--- a/release/tools/servlet.xml
+++ b/release/tools/servlet.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@
 	<import file="../../bin/xml/ts.common.props.xml"/>
 
 	<property name="deliverable.version"  value="5.0"/>
-        <property name="deliverable.tck.version"  value="5.0.0"/>
+        <property name="deliverable.tck.version"  value="5.0.1"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/user_guides/servlet/src/main/jbake/content/attributes.conf
+++ b/user_guides/servlet/src/main/jbake/content/attributes.conf
@@ -26,7 +26,7 @@
 :JavaTestVersion: 5.0
 :jteFileName: <TS_HOME>/bin/ts.jte
 :jtxFileName: <TS_HOME>/bin/ts.jtx
-:TCKPackageName: jakarta-servlet-tck-5.0.0.zip
+:TCKPackageName: jakarta-servlet-tck-5.0.1.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/signaturetest/servlet
 :singleTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/servlet/api/client


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/593
https://github.com/eclipse-ee4j/jakartaee-tck/issues/594

**Related Issue(s)**
https://github.com/eclipse-ee4j/servlet-api/issues/378
https://github.com/eclipse-ee4j/servlet-api/issues/385


**Describe the change**
This change is so can release 9.0.1 Platform TCK + 5.0.1 Servlet TCK with the excluded (challenge accepted) tests.  Note that a [similar PR](https://github.com/eclipse-ee4j/jakartaee-tck/pull/596) was created against the master branch.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
