### PR TITLE
Fix #598 - always count down message latch *after* message is written

### DIFF
--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/clientendpointconfig/WSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -845,9 +845,9 @@ public class WSClient extends WebSocketCommonClient {
 
         @Override
         public void onMessage(String message) {
-          messageLatch.countDown();
           receivedMessageString
               .append("========Basic String MessageHander received=" + message);
+          messageLatch.countDown();
         }
       });
 

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/sessionexception/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/sessionexception/WSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/sessionexception/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/ee/jakarta/websocket/sessionexception/WSClient.java
@@ -164,8 +164,8 @@ public class WSClient extends WebSocketCommonClient {
 
         @Override
         public void onMessage(String message) {
-          messageLatch.countDown();
           receivedMessageString.append(message);
+          messageLatch.countDown();
         }
       });
     }

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
+++ b/src/com/sun/ts/tests/websocket/spec/servercontainer/addendpoint/WSClient.java
@@ -1774,8 +1774,8 @@ public class WSClient extends WebSocketCommonClient {
 
         @Override
         public void onMessage(String message) {
-          messageLatch.countDown();
           receivedMessageString.append(message);
+          messageLatch.countDown();
         }
       });
 
@@ -1823,9 +1823,9 @@ public class WSClient extends WebSocketCommonClient {
   public final static class TCKBasicStringEndpoint extends Endpoint {
 
     public void onMessage(String message) {
-      messageLatch.countDown();
       receivedMessageString.append("========First TextMessageHander received=")
           .append(message);
+      messageLatch.countDown();
     }
 
     @Override
@@ -1909,8 +1909,8 @@ public class WSClient extends WebSocketCommonClient {
 
         @Override
         public void onMessage(String message) {
-          messageLatch.countDown();
           receivedMessageString.append(message);
+          messageLatch.countDown();
         }
       });
     }
@@ -1930,8 +1930,8 @@ public class WSClient extends WebSocketCommonClient {
 
         @Override
         public void onMessage(String message) {
-          messageLatch.countDown();
           receivedMessageString.append(message);
+          messageLatch.countDown();
         }
       });
 


### PR DESCRIPTION
Signed-off-by: Mark Thomas <markt@apache.org>

---
name: Pull Request
about: Create a pull request for a Platform TCK change
title: ''
labels: ''
assignees: ''

---

**Fixes Issue**
#598

**Related Issue(s)**
None

**Describe the change**
Always count down message latch *after* message is written

**Additional context**
None

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
