### PR TITLE
Increment Platform/Jakarta RESTful Web Services TCK version for excludes for accepted TCK challenge https://github.com/eclipse-ee4j/jaxrs-api/issues/937

### DIFF
--- a/release/tools/jakartaee-tech-common.xml
+++ b/release/tools/jakartaee-tech-common.xml
@@ -24,7 +24,7 @@
     <!--    <property name="test.areas" value="samples"/> -->
 
     <property name="deliverable.version"           value="9.0"/>
-    <property name="deliverable.tck.version"           value="9.0.1"/>
+    <property name="deliverable.tck.version"           value="9.0.2"/>
 
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -30,7 +30,7 @@
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
     <property name="deliverable.version"           value="9.0"/>
-    <property name="deliverable.tck.version"           value="9.0.1"/>
+    <property name="deliverable.tck.version"           value="9.0.2"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxm/**/*, **/jaxm1.0.1/**/*,

--- a/release/tools/jaxrs.xml
+++ b/release/tools/jaxrs.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
 <project name="JAXRS" basedir="." default="build">
     
     <property name="deliverable.version"  value="3.0"/>
-    <property name="deliverable.tck.version"  value="3.0.0"/>
+    <property name="deliverable.tck.version"  value="3.0.1"/>
 
     <property name="platform.folder" value="com/sun/ts/tests/jaxrs/platform/**"/>
     <property name="platform21.folder" value="com/sun/ts/tests/jaxrs/jaxrs21/platform/**"/>

--- a/user_guides/jaxrs/src/main/jbake/content/attributes.conf
+++ b/user_guides/jaxrs/src/main/jbake/content/attributes.conf
@@ -26,7 +26,7 @@
 :JavaTestVersion: 5.0
 :jteFileName: <TS_HOME>/bin/ts.jte
 :jtxFileName: <TS_HOME>/bin/ts.jtx
-:TCKPackageName: jakarta-restful-ws-tck-3.0.0.zip
+:TCKPackageName: jakarta-restful-ws-tck-3.0.1.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/signaturetest/jaxrs
 :singleTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/jaxrs/api/rs/get


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

---
name: Pull Request
about: Increment TCK versions for https://github.com/eclipse-ee4j/jakartaee-tck/pull/603


---

**Fixes Issue**
https://github.com/eclipse-ee4j/jaxrs-api/issues/937

**Describe the change**
Release Jakarta EE Platform TCK 9.0.2
Release Jakarta RESTful Web Services TCK 3.0.1

**Additional context**
https://github.com/eclipse-ee4j/jakartaee-tck/wiki/TCK-Challenge-processing-status will be updated with status info.
https://github.com/eclipse-ee4j/jakartaee-tck/projects/2 will be updated after TCKs are released/promoted with excluded tests.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
