### PR TITLE
Make Corba ORB referencing tests optional by adding 'ExcludeCorba' system property check.  

### DIFF
--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/envsharing/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,7 +44,8 @@ com/sun/ts/tests/ejb30/common/annotation/resource/ClientBase.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/ResourceIF.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/UserTransactionNegativeIF.class,
 com/sun/ts/tests/ejb30/common/helper/TLogger.class,
-com/sun/ts/tests/ejb30/common/helper/TestFailedException.class
+com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class
 "/>
   
   <import file="../../../../../../../../../../../src/com/sun/ts/tests/ejb30/common/import.xml"/>  

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resource;
 
 import javax.naming.NamingException;
 
+import com.sun.ts.tests.ejb30.common.system.Exclude;
 import org.omg.CORBA.ORB;
 
 import com.sun.javatest.Status;
@@ -94,6 +95,10 @@ public class Client extends ClientBase {
    *
    */
   public void clientOrbTest() throws Fault {
+    if (Exclude.ignoreCorba()) {
+      TLogger.logMsg("Corba testing is disabled, ignore " + this.getClass().getName() + ".#clientOrbTest use of Corba");
+      return;
+    }
     if (orb == null) {
       throw new Fault("orb is not injected");
     } else {

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,8 @@ com/sun/ts/tests/ejb30/common/annotation/resource/UserTransactionNegativeBeanBas
 com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/UserTransactionNegativeBean.class,
 com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
 com/sun/ts/tests/ejb30/common/helper/TLogger.class,
-com/sun/ts/tests/ejb30/common/helper/TestFailedException.class
+com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class
 "/>
   
   <property name="appclient.jar.classes" 
@@ -48,7 +49,8 @@ com/sun/ts/tests/ejb30/common/annotation/resource/ResourceIF.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/UserTransactionNegativeIF.class,
 com/sun/ts/tests/ejb30/common/helper/TLogger.class,
 com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
-com/sun/ts/tests/ejb30/common/helper/TestFailedException.class
+com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class
 "/>
   
   <import file="../../../../../../../../../../../src/com/sun/ts/tests/ejb30/common/import.xml"/>  

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,7 +45,8 @@ com/sun/ts/tests/ejb30/common/annotation/resource/ResourceIF.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/UserTransactionNegativeIF.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/ResourceNoop.class,
 com/sun/ts/tests/ejb30/common/helper/TLogger.class,
-com/sun/ts/tests/ejb30/common/helper/TestFailedException.class
+com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class
 "/>
   
   <import file="../../../../../../../../../../../src/com/sun/ts/tests/ejb30/common/import.xml"/>  

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,8 @@ com/sun/ts/tests/ejb30/common/annotation/resource/ResourceIF.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/ResourceNoop.class,
 com/sun/ts/tests/ejb30/common/annotation/resource/UserTransactionNegativeIF.class,
 com/sun/ts/tests/ejb30/common/helper/TLogger.class,
-com/sun/ts/tests/ejb30/common/helper/TestFailedException.class
+com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class
 "/>
   
   <import file="../../../../../../../../../../../src/com/sun/ts/tests/ejb30/common/import.xml"/>  

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean4Super.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean4Super.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,8 @@
 
 package com.sun.ts.tests.ejb30.bb.session.stateless.basic;
 
+import com.sun.ts.tests.ejb30.common.helper.TLogger;
+import com.sun.ts.tests.ejb30.common.system.Exclude;
 import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.calc.BaseRemoteCalculator;
@@ -37,7 +39,12 @@ abstract public class RemoteCalculatorBean4Super extends BaseRemoteCalculator
   public int remoteAdd(int a, int b) {
     int retValue;
     retValue = super.remoteAdd(a, b);
+    if (Exclude.ignoreCorba()) {
+      TLogger.logMsg("Corba testing is disabled, ignore " + this.getClass().getName() + ".#remoteAdd use of Corba");
+      return retValue; // TODO: may need to add the equivalent of what orb.toString().length() would of returned if enabled.
+    }
+    
     return retValue + (orb == null ? 0 : orb.toString().length());
   }
-
+  
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,8 @@ com/sun/ts/tests/ejb30/common/calc/BaseRemoteCalculator.class,
 com/sun/ts/tests/ejb30/common/calc/CalculatorException.class,
 com/sun/ts/tests/ejb30/common/calc/NoInterfaceRemoteCalculator.class,
 com/sun/ts/tests/ejb30/common/helper/TLogger.class,
-com/sun/ts/tests/ejb30/common/calc/RemoteCalculator.class
+com/sun/ts/tests/ejb30/common/calc/RemoteCalculator.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class
 "/>
   
   <property name="appclient.jar.classes" 

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,7 @@ import com.sun.ts.lib.harness.EETest;
 import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 import com.sun.ts.tests.ejb30.common.helper.TestFailedException;
+import com.sun.ts.tests.ejb30.common.system.Exclude;
 
 abstract public class ClientBase extends EETest {
   protected Properties props;
@@ -49,7 +50,7 @@ abstract public class ClientBase extends EETest {
   protected String getCustomeResourceName() {
     return null;
   }
-
+  
   /*
    * @class.setup_props:
    */
@@ -323,6 +324,11 @@ abstract public class ClientBase extends EETest {
    *
    */
   public void orbTest() throws Fault {
+    if (Exclude.ignoreCorba()) {
+      TLogger.logMsg("Corba testing is disabled, ignore " + this.getClass().getName() + ".#orbTest use of Corba");
+      return;
+    }
+    
     try {
       getResourceFieldBean().testOrb();
       getResourceSetterBean().testOrb();

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +31,7 @@ import java.net.URL;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
+import com.sun.ts.tests.ejb30.common.system.Exclude;
 import org.omg.CORBA.ORB;
 
 import com.sun.ts.lib.deliverable.cts.resource.Dog;
@@ -403,6 +404,11 @@ abstract public class ResourceBeanBase implements ResourceIF {
   }
 
   public void testOrb() throws TestFailedException {
+    if (Exclude.ignoreCorba()) {
+      TLogger.logMsg("Corba testing is disabled, ignore " + this.getClass().getName() + ".#testOrb use of Corba");
+      return;
+    }
+    
     ORB orb1 = getOrb();
     verify(orb1, "getOrb()");
     orb1 = null;

--- a/src/com/sun/ts/tests/ejb30/common/system/Exclude.java
+++ b/src/com/sun/ts/tests/ejb30/common/system/Exclude.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.common.system;
+
+/**
+ * A way for tests to check if an optional technology is excluded.  
+ * This is only for special technologies that cannot be reasonably 
+ * represented by a keyword property.  
+ *
+ * @author Scott Marlow
+ */
+public class Exclude {
+
+    /**
+     * @return true if Corba is excluded from TCK testing.
+     */
+    public static boolean ignoreCorba() {
+        return Boolean.getBoolean("ExcludeCorba");
+      }
+}

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclient2ejbjars/StatelessAnnotationUsedRemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclient2ejbjars/StatelessAnnotationUsedRemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@
 
 package com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars;
 
+import com.sun.ts.tests.ejb30.common.system.Exclude;
 import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.calc.BaseRemoteCalculator;
@@ -86,7 +87,7 @@ public class StatelessAnnotationUsedRemoteCalculatorBean
           + "injected, but its actual value is null.  The ejb-jar where "
           + "this bean is in has been marked as metadata-complete=false");
     }
-    if (orb == null) {
+    if (orb == null && !Exclude.ignoreCorba()) {
       throw new IllegalStateException("orb field should have been "
           + "injected, but its actual value is null.  The ejb-jar where "
           + "this bean is in has been marked as metadata-complete=false");
@@ -102,5 +103,6 @@ public class StatelessAnnotationUsedRemoteCalculatorBean
     // do the same thing as remoteAdd(int, int)
     return postConstructCallsCount + a + b;
   }
+ 
 
 }

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/build.xml
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,7 @@ com/sun/ts/tests/ejb30/common/calc/BaseRemoteCalculator.class,
 com/sun/ts/tests/ejb30/common/calc/CalculatorException.class,
 com/sun/ts/tests/ejb30/common/calc/NoInterfaceRemoteCalculator.class,
 com/sun/ts/tests/ejb30/common/calc/RemoteCalculator.class,
+com/sun/ts/tests/ejb30/common/system/Exclude.class,
 com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/InterceptorNotUsed.class,
 com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/InterceptorUsed.class,
 com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/RemoteCalculatorBean0.class,

--- a/user_guides/jakartaee/src/main/jbake/content/using.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/using.adoc
@@ -347,6 +347,11 @@ not a given set of tests is run - the `javaee.level` property in the
 javaee.level Property"]) and keywords (see link:#BCGHGJIC[Section 7.5.2,
 "Using Keywords to Create Groups and Subsets of Tests"]).
 
+If the (optional) Corba technology is not provided, you can exclude 
+the subset of tests that use Corba via the `ExcludeCorba` system property 
+setting in your ts.jte (e.g. add to `command.testExecute` + `testExecuteEjbEmbed` + 
+your application server command line options.    
+
 [[BCGBAHFF]][[setting-the-javaee.level-property]]
 
 7.5.1 Setting the javaee.level Property


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

---
Make Corba ORB referencing tests optional by adding 'ExcludeCorba' system property check.  If 'ExcludeCorba' is set to true, then tests should not expect to use Corba.
---

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/604

**Describe the change**
We cannot make reasonable use of `keywords` as we need to prevent the use of Corba within some tests without disabling the non-Corba aspects of those tests.  We normally would clone the specific part of tests that use the particular technology (Corba in this case) and have a new set of tests that are specific to that technology.  IMO, that doesn't seem to be a good match for the ejb30 tests as we would have to duplicate too much.

**Additional context**
We discussed removing the use of javax.rmi.PortableRemoteObject for which an additional pull request is still expected.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
