### PR TITLE
config fixes for jsf, jpa tcks in jdk11

### DIFF
--- a/docker/jsftck.sh
+++ b/docker/jsftck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,9 +51,6 @@ unzip -q ${TCK_HOME}/latest-glassfish.zip -d ${TCK_HOME}
 TS_HOME=$TCK_HOME/$TCK_NAME
 echo "TS_HOME $TS_HOME"
 
-cd $TCK_HOME/$GF_TOPLEVEL_DIR/bin
-./asadmin start-domain
-
 cd $TS_HOME/bin
 if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
   export JAVA_HOME=${JDK11_HOME}
@@ -63,6 +60,11 @@ fi
 
 which java
 java -version
+
+cd $TCK_HOME/$GF_TOPLEVEL_DIR/bin
+./asadmin start-domain
+
+cd $TS_HOME/bin
 
 webServerHome=$TCK_HOME/$GF_TOPLEVEL_DIR/glassfish
 

--- a/release/tools/jpa.xml
+++ b/release/tools/jpa.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@
         <copy todir="${deliverable.bundle.dir}/bin" includeEmptyDirs="no">
             <fileset dir="${ts.home}/install/${deliverable.name.lower}/bin"
                      includes="**/*"
-                     excludes="ts.jte.*, **/workspace.xml, **/*.log, **/out"/>
+                     excludes="**/workspace.xml, **/*.log, **/out"/>
         </copy>
         <copy todir="${deliverable.bundle.dir}/lib">
             <fileset dir="${ts.home}/lib"


### PR DESCRIPTION

**Fixes Issue**
Fixes config issue in jsf & jpa standlaone TCKs when run in JDK11.

- jpa tck : ts.jte.jdk11 is missing from the bundle
 - jsf tck : config was starting glassfish with default jdk8 before setting java home to jdk11


**Describe the change**
jpa tck - added ts.jte.jdk11  to bundle
jsf tck - reordered setting java home before asadmin startdomain call  

This will pass the jsf tests, but more issues in jpa tck run to be fixed.