### PR TITLE
copy tck jars to <glassfish_home>/glassfish/domains/domain1/lib

### DIFF
--- a/install/concurrency/bin/ts.jte
+++ b/install/concurrency/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -296,3 +296,10 @@ command.testExecuteSameJVM=com.sun.ts.lib.harness.ExecuteTSTestSameJVMCmd \
 ## is set to true)
 ######################################################################
 tslib.name=concurrencytck
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib/ext

--- a/install/concurrency/bin/ts.jte.jdk11
+++ b/install/concurrency/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -295,3 +295,11 @@ command.testExecuteSameJVM=com.sun.ts.lib.harness.ExecuteTSTestSameJVMCmd \
 ## is set to true)
 ######################################################################
 tslib.name=concurrencytck
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib
+

--- a/install/concurrency/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/concurrency/bin/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -152,13 +152,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/concurrencytck.jar" tofile="${webcontainer.home}/domains/domain1/lib/ext/concurrencytck.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${webcontainer.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/concurrencytck.jar" tofile="${extension.dir}/concurrencytck.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${webcontainer.home}/domains/domain1/lib/ext/concurrencytck.jar" quiet="true"/>
-       <delete file="${webcontainer.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/concurrencytck.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
 </project>

--- a/install/connector/bin/ts.jte
+++ b/install/connector/bin/ts.jte
@@ -692,5 +692,13 @@ deliverable.class=com.sun.ts.lib.deliverable.connector.StandaloneDeliverable
 ###########################################################################
 tools.jar=${jdk.home}/lib/tools.jar
 
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${connector.domain}/lib/ext
+
+
 
 

--- a/install/connector/bin/ts.jte.jdk11
+++ b/install/connector/bin/ts.jte.jdk11
@@ -690,5 +690,9 @@ deliverable.class=com.sun.ts.lib.deliverable.connector.StandaloneDeliverable
 ###########################################################################
 tools.jar=${jdk.home}/lib/tools.jar
 
-
-
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${connector.domain}/lib

--- a/install/connector/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/connector/bin/xml/impl/glassfish/config.vi.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,13 +92,13 @@
 
     <!-- this copies the connector jar files to the instance lib directory.  -->
     <target name="copy.connector.jars" >
-        <copy file="${ts.home}/lib/connector.jar" tofile="${connector.domain}/lib/ext/connector.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${connector.domain}/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/connector.jar" tofile="${extension.dir}/connector.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.connector.jars" >
-        <delete file="${connector.domain}/lib/ext/connector.jar" quiet="yes" />
-        <delete file="${connector.domain}/lib/ext/tsharness.jar" quiet="yes" />
+        <delete file="${extension.dir}/connector.jar" quiet="yes" />
+        <delete file="${extension.dir}/tsharness.jar" quiet="yes" />
     </target>
 
 </project>

--- a/install/jakartaee/bin/ts.jte.jdk11
+++ b/install/jakartaee/bin/ts.jte.jdk11
@@ -478,7 +478,7 @@ s1as.se.jmsServer=imqbroker
 #       app server's extension directory.  The CTS config.vi
 #       target will copy the CTS library jars to this location.
 ###############################################################
-extension.dir=${s1as.domain}/lib/ext
+extension.dir=${s1as.domain}/lib
 
 ###############################################################
 # @instance.listenerName - Default value for the iiop listener

--- a/install/jaxrs/bin/ts.jte
+++ b/install/jaxrs/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -431,3 +431,11 @@ impl.vi=
 impl.vi.deploy.dir=
 
 tslib.name=jaxrstck
+
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib/ext

--- a/install/jaxrs/bin/ts.jte.gf
+++ b/install/jaxrs/bin/ts.jte.gf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -412,3 +412,11 @@ jaxrs.classes=${web.modules}/jakarta.ws.rs-api.jar
 jersey.home=D:/CTS/CTS_JAXRS/jaxrstck/jersey
 jaxrs_impl_lib=${web.modules}/jersey-container-servlet-core.jar
 servlet_adaptor=org/glassfish/jersey/servlet/ServletContainer.class
+
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib/ext

--- a/install/jaxrs/bin/ts.jte.jdk11
+++ b/install/jaxrs/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -410,3 +410,10 @@ impl.vi=
 impl.vi.deploy.dir=
 
 tslib.name=jaxrstck
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib

--- a/install/jaxrs/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/jaxrs/bin/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -161,13 +161,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/${tslib.name}.jar" tofile="${web.home}/domains/domain1/lib/ext/${tslib.name}.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${web.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/${tslib.name}.jar" tofile="${extension.dir}/${tslib.name}.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${web.home}/domains/domain1/lib/ext/${tslib.name}.jar" quiet="true"/>
-       <delete file="${web.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/${tslib.name}.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
     <target name="add.users" depends="configPlatform">

--- a/install/jaxws/bin/ts.jte
+++ b/install/jaxws/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -543,3 +543,13 @@ s1as.domain.name=${glassfish.domain.name}
 s1as.domain=${s1as.domain.dir}/${s1as.domain.name}
 s1as.admin.host=${glassfish.admin.host}
 s1as.admin.port=${glassfish.admin.port}
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib/ext
+extension.dir.ri=${webcontainer.home.ri}/domains/domain1/lib/ext
+
+

--- a/install/jaxws/bin/ts.jte.jdk11
+++ b/install/jaxws/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -502,4 +502,14 @@ tslib.name=jaxwstck
 # of time the client will delay in seconds.
 ###########################################################################
 client.delay=1
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib
+extension.dir.ri=${webcontainer.home.ri}/domains/domain1/lib
+
+
 

--- a/install/jaxws/bin/ts.jte.jdk19
+++ b/install/jaxws/bin/ts.jte.jdk19
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -502,4 +502,14 @@ tslib.name=jaxwstck
 # of time the client will delay in seconds.
 ###########################################################################
 client.delay=1
+
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib/
+extension.dir.ri=${webcontainer.home.ri}/domains/domain1/lib
+
 

--- a/install/jaxws/bin/xml/impl/glassfish/config.ri.xml
+++ b/install/jaxws/bin/xml/impl/glassfish/config.ri.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -159,13 +159,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/jaxwstck.jar" tofile="${webcontainer.home.ri}/domains/domain1/lib/ext/jaxwstck.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${webcontainer.home.ri}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/jaxwstck.jar" tofile="${extension.dir.ri}/jaxwstck.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir.ri}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${webcontainer.home.ri}/domains/domain1/lib/ext/jaxwstck.jar" quiet="true"/>
-       <delete file="${webcontainer.home.ri}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir.ri}/jaxwstck.jar" quiet="true"/>
+       <delete file="${extension.dir.ri}/tsharness.jar" quiet="true"/>
     </target>
 
     <target name="add.users" depends="configPlatform">

--- a/install/jaxws/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/jaxws/bin/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -158,13 +158,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/jaxwstck.jar" tofile="${webcontainer.home}/domains/domain1/lib/ext/jaxwstck.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${webcontainer.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/jaxwstck.jar" tofile="${extension.dir}/jaxwstck.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${webcontainer.home}/domains/domain1/lib/ext/jaxwstck.jar" quiet="true"/>
-       <delete file="${webcontainer.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/jaxwstck.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
     <target name="add.users" depends="configPlatform">

--- a/install/jms/bin/ts.jte
+++ b/install/jms/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -284,3 +284,11 @@ admin.pass.file=/tmp/ripassword
 jndi.fs.dir=/tmp/ri_admin_objects
 jndi.factory.initial="java.naming.factory.initial=com.sun.jndi.fscontext.RefFSContextFactory"
 jndi.provider.url="java.naming.provider.url=file:///${jndi.fs.dir}"
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${glassfish.home}/domains/domain1/lib/ext
+

--- a/install/jms/bin/ts.jte.jdk11
+++ b/install/jms/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -283,3 +283,11 @@ admin.pass.file=/tmp/ripassword
 jndi.fs.dir=/tmp/ri_admin_objects
 jndi.factory.initial="java.naming.factory.initial=com.sun.jndi.fscontext.RefFSContextFactory"
 jndi.provider.url="java.naming.provider.url=file:///${jndi.fs.dir}"
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${glassfish.home}/domains/domain1/lib/
+

--- a/install/jms/ra/bin/ts.jte.glassfish
+++ b/install/jms/ra/bin/ts.jte.glassfish
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -303,3 +303,10 @@ glassfish.master.pass=changeit
 glassfish.server.instance=server
 glassfish.domain.name=domain1
 jmsServer=imqbroker
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${glassfish.home}/domains/domain1/lib/ext

--- a/install/jms/ra/xml/impl/glassfish/config.vi.xml
+++ b/install/jms/ra/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -400,8 +400,8 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/jmstck.jar" tofile="${glassfish.home}/domains/domain1/lib/ext/jmstck.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${glassfish.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/jmstck.jar" tofile="${extension.dir}/jmstck.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="copy.jmsra.jarfile">
@@ -442,8 +442,8 @@
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${glassfish.home}/domains/domain1/lib/ext/jmstck.jar" quiet="true"/>
-       <delete file="${glassfish.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/jmstck.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
     <target name="add.users" >

--- a/install/jsonb/bin/ts.jte
+++ b/install/jsonb/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -243,3 +243,10 @@ env.ts_win32.menu=true
 ## is set to true)
 ######################################################################
 tslib.name=jsonbtck
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib/ext

--- a/install/jsonb/bin/ts.jte.jdk11
+++ b/install/jsonb/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -239,3 +239,11 @@ env.ts_win32.menu=true
 ## is set to true)
 ######################################################################
 tslib.name=jsonbtck
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib
+

--- a/install/jsonb/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/jsonb/bin/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -132,13 +132,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/jsonbtck.jar" tofile="${web.home}/domains/domain1/lib/ext/jsonbtck.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${web.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/jsonbtck.jar" tofile="${extension.dir}/jsonbtck.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${web.home}/domains/domain1/lib/ext/jsonbtck.jar" quiet="true"/>
-       <delete file="${web.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/jsonbtck.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
 </project>

--- a/install/saaj/bin/ts.jte
+++ b/install/saaj/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -289,3 +289,9 @@ command.testExecuteSameJVM=com.sun.ts.lib.harness.ExecuteTSTestSameJVMCmd \
 ######################################################################
 tslib.name=saajtck
 
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib/ext

--- a/install/saaj/bin/ts.jte.jdk11
+++ b/install/saaj/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -287,4 +287,12 @@ command.testExecuteSameJVM=com.sun.ts.lib.harness.ExecuteTSTestSameJVMCmd \
 ## is set to true)
 ######################################################################
 tslib.name=saajtck
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${webcontainer.home}/domains/domain1/lib
+
 

--- a/install/saaj/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/saaj/bin/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -133,13 +133,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/saajtck.jar" tofile="${webcontainer.home}/domains/domain1/lib/ext/saajtck.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${webcontainer.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/saajtck.jar" tofile="${extension.dir}/saajtck.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${webcontainer.home}/domains/domain1/lib/ext/saajtck.jar" quiet="true"/>
-       <delete file="${webcontainer.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/saajtck.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
 </project>

--- a/install/websocket/bin/ts.jte
+++ b/install/websocket/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -351,3 +351,11 @@ s1as.domain.name=domain1
 s1as.domain=${s1as.domain.dir}/${s1as.domain.name}
 s1as.admin.host=${glassfish.admin.host}
 s1as.admin.port=${glassfish.admin.port}
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib/ext
+

--- a/install/websocket/bin/ts.jte.jdk11
+++ b/install/websocket/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -351,3 +351,11 @@ s1as.domain.name=domain1
 s1as.domain=${s1as.domain.dir}/${s1as.domain.name}
 s1as.admin.host=${glassfish.admin.host}
 s1as.admin.port=${glassfish.admin.port}
+
+###############################################################
+# @extension.dir - The extension directory of RI. 
+# The CTS config.vi target will copy the CTS library 
+# jars to this location, used only for RI.
+###############################################################
+extension.dir=${web.home}/domains/domain1/lib/
+

--- a/install/websocket/bin/xml/impl/glassfish/config.vi.xml
+++ b/install/websocket/bin/xml/impl/glassfish/config.vi.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -158,13 +158,13 @@
     </target>
 
     <target name="copy.tck.jars">
-        <copy file="${ts.home}/lib/${tslib.name}.jar" tofile="${web.home}/domains/domain1/lib/ext/${tslib.name}.jar" overwrite="yes" />
-        <copy file="${ts.home}/lib/tsharness.jar" tofile="${web.home}/domains/domain1/lib/ext/tsharness.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/${tslib.name}.jar" tofile="${extension.dir}/${tslib.name}.jar" overwrite="yes" />
+        <copy file="${ts.home}/lib/tsharness.jar" tofile="${extension.dir}/tsharness.jar" overwrite="yes" />
     </target>
 
     <target name="delete.tck.jars">
-       <delete file="${web.home}/domains/domain1/lib/ext/${tslib.name}.jar" quiet="true"/>
-       <delete file="${web.home}/domains/domain1/lib/ext/tsharness.jar" quiet="true"/>
+       <delete file="${extension.dir}/${tslib.name}.jar" quiet="true"/>
+       <delete file="${extension.dir}/tsharness.jar" quiet="true"/>
     </target>
 
     <target name="add.users" depends="configPlatform">


### PR DESCRIPTION
PR for issue - https://github.com/eclipse-ee4j/jakartaee-tck/issues/629

Also address failure with same root cause at concurrency, connector, jaxrs, jaxws, jms, jsonb, saaj, websocket TCK's.
PS: the PR fixes Platform TCK issues of deployment, but testing is yet to be completed.

CI runs:

- https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/glassfish-ext-fix/7/
- https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/glassfish-ext-fix/14/ (re-run of failed connector tck)
- https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/glassfish-ext-fix/15/ (JDK 8 + GF 6.0 + TCK 9.1)

'java.ext.dirs' is no longer supported by JDK11, Glassfish 6.1 has removed support for loading class from `<glassfish_home>/glassfish/domains/domain1/lib/ext/`. 
glassfish PR for reference: https://github.com/eclipse-ee4j/glassfish/pull/23383.
Since ext directory is removed, we have to copy tck jars(in config.vi ant scripts) to `<glassfish_home>/glassfish//domains/domain1/lib`

Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>
