### PR TITLE
Disable CDI for some restfulWS tests

### DIFF
--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0"
+       bean-discovery-mode="none">
+</beans>

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/build.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/build.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,19 +18,66 @@
 
 <project name="jaxrs_platform_beanvalidation_annotation" basedir="." default="usage">
 
-	<property name="app.name" value="jaxrs_platform_beanvalidation_annotation" />
+    <import file="../../../common/common.xml" />
 
-	<property name="resource.classes" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/*Resource*.class,
-		com/sun/ts/tests/jaxrs/common/util/JaxrsUtil.class,
-		com/sun/ts/tests/jaxrs/common/provider/StringBean.class,
-		com/sun/ts/tests/jaxrs/common/provider/StringBeanEntityProvider.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Not*.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Constraint*.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Group*.class,
- 			" />
-	<property name="appconfig.class" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/TSAppConfig.class" />
+    <property name="app.name" value="jaxrs_platform_beanvalidation_annotation" />
 
-	<import file="../../../common/common.xml" />
+    <property name="resource.classes" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/*Resource*.class,
+                                             com/sun/ts/tests/jaxrs/common/util/JaxrsUtil.class,
+                                             com/sun/ts/tests/jaxrs/common/provider/StringBean.class,
+                                             com/sun/ts/tests/jaxrs/common/provider/StringBeanEntityProvider.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Not*.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Constraint*.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Group*.class"
+    />
+    <property name="appconfig.class" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/TSAppConfig.class" />
+
+    <target name="package" if="resource.classes">
+        <propertyregex property="unified.resource.classes"
+                       input="${resource.classes}"
+                       regexp="\\"
+                       replace="/"
+                       defaultvalue="${resource.classes}"
+                       casesensitive="false" />	
+        <propertyregex property="relative.resource.classes"
+                       input="${unified.resource.classes}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.resource.classes}"
+                       select="\2" />
+        <propertyregex property="resource.sources"
+                       input="${relative.resource.classes}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+		
+        <propertyregex property="unified.appconfig.class"
+                       input="${appconfig.class}"
+                       regexp="\\"
+                       replace="/"
+                       casesensitive="false"
+                       defaultvalue="${appconfig.class}"/>		
+        <propertyregex property="relative.appconfig.class"
+                       input="${unified.appconfig.class}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.appconfig.class}"
+                       select="\2" />		
+        <propertyregex property="appconfig.source"
+                       input="${relative.appconfig.class}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+
+        <mkdir dir="${ts.home}/dist/${pkg.dir}" />
+        <ts.war archivename="${app.name}" descriptor="web.xml.template">
+            <zipfileset dir="${ts.home}/classes"
+                        includes="${unified.resource.classes}, ${unified.appconfig.class}"
+                        prefix="WEB-INF/classes" />	
+            <zipfileset dir="${ts.home}/src/${pkg.dir}"
+                        prefix="WEB-INF"
+                        includes="beans.xml"/>
+        </ts.war>
+        <move file="${ts.home}/dist/${pkg.dir}/${app.name}_web.war" tofile="${ts.home}/dist/${pkg.dir}/${app.name}_web.war.template" />
+    </target>
 
 </project>
 

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0"
+       bean-discovery-mode="none">
+</beans>

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/build.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/build.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,19 +18,66 @@
 
 <project name="jaxrs_platform_beanvalidation_annotation" basedir="." default="usage">
 
-	<property name="app.name" value="jaxrs_platform_beanvalidation_constraintviolationexceptionmapper" />
+    <import file="../../../common/common.xml" />
 
-	<property name="resource.classes" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/*Resource*.class,
-		com/sun/ts/tests/jaxrs/common/util/JaxrsUtil.class,
-		com/sun/ts/tests/jaxrs/common/provider/StringBean.class,
-		com/sun/ts/tests/jaxrs/common/provider/StringBeanEntityProvider.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Not*.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Constraint*.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Group*.class,
- 			" />
-	<property name="appconfig.class" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/TSAppConfig.class" />
+    <property name="app.name" value="jaxrs_platform_beanvalidation_constraintviolationexceptionmapper" />
 
-	<import file="../../../common/common.xml" />
+    <property name="resource.classes" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/*Resource*.class,
+                                             com/sun/ts/tests/jaxrs/common/util/JaxrsUtil.class,
+                                             com/sun/ts/tests/jaxrs/common/provider/StringBean.class,
+                                             com/sun/ts/tests/jaxrs/common/provider/StringBeanEntityProvider.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Not*.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Constraint*.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Group*.class"
+    />
+    <property name="appconfig.class" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/TSAppConfig.class" />
+
+    <target name="package" if="resource.classes">
+        <propertyregex property="unified.resource.classes"
+                       input="${resource.classes}"
+                       regexp="\\"
+                       replace="/"
+                       defaultvalue="${resource.classes}"
+                       casesensitive="false" />	
+        <propertyregex property="relative.resource.classes"
+                       input="${unified.resource.classes}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.resource.classes}"
+                       select="\2" />
+        <propertyregex property="resource.sources"
+                       input="${relative.resource.classes}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+		
+        <propertyregex property="unified.appconfig.class"
+                       input="${appconfig.class}"
+                       regexp="\\"
+                       replace="/"
+                       casesensitive="false"
+                       defaultvalue="${appconfig.class}"/>		
+        <propertyregex property="relative.appconfig.class"
+                       input="${unified.appconfig.class}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.appconfig.class}"
+                       select="\2" />		
+        <propertyregex property="appconfig.source"
+                       input="${relative.appconfig.class}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+
+        <mkdir dir="${ts.home}/dist/${pkg.dir}" />
+        <ts.war archivename="${app.name}" descriptor="web.xml.template">
+            <zipfileset dir="${ts.home}/classes"
+                        includes="${unified.resource.classes}, ${unified.appconfig.class}"
+                        prefix="WEB-INF/classes" />	
+            <zipfileset dir="${ts.home}/src/${pkg.dir}"
+                        prefix="WEB-INF"
+                        includes="beans.xml"/>
+        </ts.war>
+        <move file="${ts.home}/dist/${pkg.dir}/${app.name}_web.war" tofile="${ts.home}/dist/${pkg.dir}/${app.name}_web.war.template" />
+    </target>
 
 </project>
 

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0"
+       bean-discovery-mode="none">
+</beans>

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/build.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/build.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,19 +18,66 @@
 
 <project name="jaxrs_platform_beanvalidation_annotation" basedir="." default="usage">
 
-	<property name="app.name" value="jaxrs_platform_beanvalidation_validationexceptionmapper" />
+    <import file="../../../common/common.xml" />
 
-	<property name="resource.classes" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/*Resource*.class,
-		com/sun/ts/tests/jaxrs/common/util/JaxrsUtil.class,
-		com/sun/ts/tests/jaxrs/common/provider/StringBean.class,
-		com/sun/ts/tests/jaxrs/common/provider/StringBeanEntityProvider.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Not*.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Constraint*.class,
-		com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Group*.class,
- 			" />
-	<property name="appconfig.class" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/TSAppConfig.class" />
+    <property name="app.name" value="jaxrs_platform_beanvalidation_validationexceptionmapper" />
 
-	<import file="../../../common/common.xml" />
+    <property name="resource.classes" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/*Resource*.class,
+                                             com/sun/ts/tests/jaxrs/common/util/JaxrsUtil.class,
+                                             com/sun/ts/tests/jaxrs/common/provider/StringBean.class,
+                                             com/sun/ts/tests/jaxrs/common/provider/StringBeanEntityProvider.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Not*.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Constraint*.class,
+                                             com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/Group*.class"
+    />
+    <property name="appconfig.class" value="com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/TSAppConfig.class" />
+
+    <target name="package" if="resource.classes">
+        <propertyregex property="unified.resource.classes"
+                       input="${resource.classes}"
+                       regexp="\\"
+                       replace="/"
+                       defaultvalue="${resource.classes}"
+                       casesensitive="false" />	
+        <propertyregex property="relative.resource.classes"
+                       input="${unified.resource.classes}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.resource.classes}"
+                       select="\2" />
+        <propertyregex property="resource.sources"
+                       input="${relative.resource.classes}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+		
+        <propertyregex property="unified.appconfig.class"
+                       input="${appconfig.class}"
+                       regexp="\\"
+                       replace="/"
+                       casesensitive="false"
+                       defaultvalue="${appconfig.class}"/>		
+        <propertyregex property="relative.appconfig.class"
+                       input="${unified.appconfig.class}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.appconfig.class}"
+                       select="\2" />		
+        <propertyregex property="appconfig.source"
+                       input="${relative.appconfig.class}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+
+        <mkdir dir="${ts.home}/dist/${pkg.dir}" />
+        <ts.war archivename="${app.name}" descriptor="web.xml.template">
+            <zipfileset dir="${ts.home}/classes"
+                        includes="${unified.resource.classes}, ${unified.appconfig.class}"
+                        prefix="WEB-INF/classes" />	
+            <zipfileset dir="${ts.home}/src/${pkg.dir}"
+                        prefix="WEB-INF"
+                        includes="beans.xml"/>
+        </ts.war>
+        <move file="${ts.home}/dist/${pkg.dir}/${app.name}_web.war" tofile="${ts.home}/dist/${pkg.dir}/${app.name}_web.war.template" />
+    </target>
 
 </project>
 

--- a/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0"
+       bean-discovery-mode="none">
+</beans>

--- a/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/build.xml
+++ b/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/build.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,23 +17,68 @@
 -->
 
 <project name="jaxrs_spec_resourceconstructor" basedir="." default="usage" >
+    <import  file="../../common/common.xml" />
 
     <property name="app.name"  value="jaxrs_spec_resourceconstructor" />
 
     <property name="resource.classes"
               value="com/sun/ts/tests/jaxrs/spec/resourceconstructor/Resource.class,
-    	com/sun/ts/tests/jaxrs/spec/resourceconstructor/HeaderResource.class,
-    	com/sun/ts/tests/jaxrs/spec/resourceconstructor/CookieResource.class,
-    	com/sun/ts/tests/jaxrs/spec/resourceconstructor/MatrixResource.class,
-    	com/sun/ts/tests/jaxrs/spec/resourceconstructor/QueryResource.class,
-    	com/sun/ts/tests/jaxrs/spec/resourceconstructor/PathResource.class,
-        com/sun/ts/tests/jaxrs/common/provider/PrintingErrorHandler.class"
+                     com/sun/ts/tests/jaxrs/spec/resourceconstructor/HeaderResource.class,
+                     com/sun/ts/tests/jaxrs/spec/resourceconstructor/CookieResource.class,
+                     com/sun/ts/tests/jaxrs/spec/resourceconstructor/MatrixResource.class,
+                     com/sun/ts/tests/jaxrs/spec/resourceconstructor/QueryResource.class,
+                     com/sun/ts/tests/jaxrs/spec/resourceconstructor/PathResource.class,
+                     com/sun/ts/tests/jaxrs/common/provider/PrintingErrorHandler.class"
     />
     <property name="appconfig.class"
               value="com/sun/ts/tests/jaxrs/spec/resourceconstructor/TSAppConfig.class"
     />
 
-    <import  file="../../common/common.xml" />
+    <target name="package" if="resource.classes">
+        <propertyregex property="unified.resource.classes"
+                       input="${resource.classes}"
+                       regexp="\\"
+                       replace="/"
+                       defaultvalue="${resource.classes}"
+                       casesensitive="false" />	
+        <propertyregex property="relative.resource.classes"
+                       input="${unified.resource.classes}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.resource.classes}"
+                       select="\2" />
+        <propertyregex property="resource.sources"
+                       input="${relative.resource.classes}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
+		
+        <propertyregex property="unified.appconfig.class"
+                       input="${appconfig.class}"
+                       regexp="\\"
+                       replace="/"
+                       casesensitive="false"
+                       defaultvalue="${appconfig.class}"/>		
+        <propertyregex property="relative.appconfig.class"
+                       input="${unified.appconfig.class}"
+                       regexp="(.*)/src/(.*)"
+                       defaultvalue="${unified.appconfig.class}"
+                       select="\2" />		
+        <propertyregex property="appconfig.source"
+                       input="${relative.appconfig.class}"
+                       regexp=".class"
+                       replace=".java"
+                       casesensitive="false" />
 
+        <mkdir dir="${ts.home}/dist/${pkg.dir}" />
+        <ts.war archivename="${app.name}" descriptor="web.xml.template">
+            <zipfileset dir="${ts.home}/classes"
+                        includes="${unified.resource.classes}, ${unified.appconfig.class}"
+                        prefix="WEB-INF/classes" />	
+            <zipfileset dir="${ts.home}/src/${pkg.dir}"
+                        prefix="WEB-INF"
+                        includes="beans.xml"/>
+        </ts.war>
+        <move file="${ts.home}/dist/${pkg.dir}/${app.name}_web.war" tofile="${ts.home}/dist/${pkg.dir}/${app.name}_web.war.template" />
+    </target>
 </project>
 


### PR DESCRIPTION
Adds beans.xml with bean-discovery-mode="none"

Affects tests in:
- jaxrs/platform/beanvalidation
- jaxrs/spec/resourceconstructor

This change is in response to TCK challenges:
https://github.com/eclipse-ee4j/jaxrs-api/issues/938
https://github.com/eclipse-ee4j/jaxrs-api/issues/939

Signed-off-by: Brian Decker <bmdecker@us.ibm.com>

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @gthoman
