### PR TITLE
#625 Fix for 2 standalone servlet tests failing in jdk11

### DIFF
--- a/install/jakartaee/bin/ts.jte.jdk11
+++ b/install/jakartaee/bin/ts.jte.jdk11
@@ -1795,6 +1795,13 @@ nobodyuser=guest
 securedWebServicePort=1044
 securedWebServicePort.2=1045
 
+###############################################################################
+# @client.cert.test.jdk.tls.client.protocols JDK 11 in TLSv1.3 does not support
+#                        Post-Handshake Authentication, so TLSv1.2 must be used
+#                        for client-cert authentication to work.
+###############################################################################
+client.cert.test.jdk.tls.client.protocols=TLSv1.2
+
 ###############################################################
 # @login This property must be set to run appclient security
 #        tests

--- a/install/servlet/bin/ts.jte.jdk11
+++ b/install/servlet/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates and others.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the

--- a/install/servlet/bin/ts.jte.jdk11
+++ b/install/servlet/bin/ts.jte.jdk11
@@ -309,6 +309,13 @@ authpassword=javajoe
 ###############################################################
 securedWebServicePort=
 
+###############################################################################
+# @client.cert.test.jdk.tls.client.protocols JDK 11 in TLSv1.3 does not support
+#                        Post-Handshake Authentication, so TLSv1.2 must be used
+#                        for client-cert authentication to work.
+###############################################################################
+client.cert.test.jdk.tls.client.protocols=TLSv1.2
+
 ###################################################################
 ###################################################################
 ###################################################################

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcert/Client.java
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcert/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcert/Client.java
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcert/Client.java
@@ -38,6 +38,8 @@ public class Client extends EETest {
   private String hostname = null;
 
   private int portnum = 0;
+  
+  private String tlsVersion;
 
   private String pageBase = "/clientcert_web";
 
@@ -82,9 +84,15 @@ public class Client extends EETest {
     // Read relevant properties:
     hostname = p.getProperty(webHostProp);
     portnum = Integer.parseInt(p.getProperty("securedWebServicePort"));
+    tlsVersion = p.getProperty("client.cert.test.jdk.tls.client.protocols");
 
     TestUtil.logMsg(
         "securedWebServicePort =" + p.getProperty("securedWebServicePort"));
+    
+    if (tlsVersion != null) {
+        TestUtil.logMsg(
+            "client.cert.test.jdk.tls.client.protocols =" + tlsVersion);
+    }
 
   }
 
@@ -117,6 +125,10 @@ public class Client extends EETest {
     String testName = "clientCertTest";
     String url = ctsurl.getURLString("https", hostname, portnum,
         pageBase + authorizedPage);
+    
+    if (tlsVersion != null) {
+        System.setProperty("jdk.tls.client.protocols", tlsVersion);
+    }
 
     try {
       URL newURL = new URL(url);

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcert/clientcert.ear.sun-application.xml
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcert/clientcert.ear.sun-application.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sun-application PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Java EE Application 5.0//EN" "http://www.sun.com/software/appserver/dtds/sun-application_5_0-0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,6 @@
   <unique-id>0</unique-id>
   <security-role-mapping>
     <role-name>Administrator</role-name>
-    <principal-name>CN=CTS, OU=Java Software, O=Sun Microsystems Inc., L=Burlington, ST=MA, C=US</principal-name>
+    <principal-name>CN=CTS,OU=Java Software,O=Sun Microsystems Inc.,L=Burlington,ST=MA,C=US</principal-name>
   </security-role-mapping>
 </sun-application>

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcert/clientcert_web.war.sun-web.xml
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcert/clientcert_web.war.sun-web.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Servlet 2.5//EN" "http://www.sun.com/software/appserver/dtds/sun-web-app_2_5-0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,6 @@
     <context-root>clientcert_web</context-root>
     <security-role-mapping>
         <role-name>Administrator</role-name>
-        <principal-name>CN=CTS, OU=Java Software, O=Sun Microsystems Inc., L=Burlington, ST=MA, C=US</principal-name>
+        <principal-name>CN=CTS,OU=Java Software,O=Sun Microsystems Inc.,L=Burlington,ST=MA,C=US</principal-name>
     </security-role-mapping>
 </sun-web-app>

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/Client.java
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/Client.java
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/Client.java
@@ -43,6 +43,8 @@ public class Client extends EETest {
   private String hostname = null;
 
   private int portnum = 0;
+  
+  private String tlsVersion;
 
   private String pageBase = "/clientcertanno_web";
 
@@ -87,9 +89,15 @@ public class Client extends EETest {
     // Read relevant properties:
     hostname = p.getProperty(webHostProp);
     portnum = Integer.parseInt(p.getProperty("securedWebServicePort"));
+    tlsVersion = p.getProperty("client.cert.test.jdk.tls.client.protocols");
 
     TestUtil.logMsg(
         "securedWebServicePort =" + p.getProperty("securedWebServicePort"));
+    
+    if (tlsVersion != null) {
+        TestUtil.logMsg(
+            "client.cert.test.jdk.tls.client.protocols =" + tlsVersion);
+    }
 
   }
 
@@ -128,6 +136,10 @@ public class Client extends EETest {
     String testName = "clientCertTest";
     String url = ctsurl.getURLString("https", hostname, portnum,
         pageBase + authorizedPage);
+    
+    if (tlsVersion != null) {
+        System.setProperty("jdk.tls.client.protocols", tlsVersion);
+    }
 
     try {
       URL newURL = new URL(url);

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/clientcertanno.ear.sun-application.xml
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/clientcertanno.ear.sun-application.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sun-application PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Java EE Application 5.0//EN" "http://www.sun.com/software/appserver/dtds/sun-application_5_0-0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,6 @@
   <unique-id>0</unique-id>
   <security-role-mapping>
     <role-name>Administrator</role-name>
-    <principal-name>CN=CTS, OU=Java Software, O=Sun Microsystems Inc., L=Burlington, ST=MA, C=US</principal-name>
+    <principal-name>CN=CTS,OU=Java Software,O=Sun Microsystems Inc.,L=Burlington,ST=MA,C=US</principal-name>
   </security-role-mapping>
 </sun-application>

--- a/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/clientcertanno_web.war.sun-web.xml
+++ b/src/com/sun/ts/tests/servlet/spec/security/clientcertanno/clientcertanno_web.war.sun-web.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Servlet 2.5//EN" "http://www.sun.com/software/appserver/dtds/sun-web-app_2_5-0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,6 @@
     <context-root>clientcertanno_web</context-root>
     <security-role-mapping>
         <role-name>Administrator</role-name>
-        <principal-name>CN=CTS, OU=Java Software, O=Sun Microsystems Inc., L=Burlington, ST=MA, C=US</principal-name>
+        <principal-name>CN=CTS,OU=Java Software,O=Sun Microsystems Inc.,L=Burlington,ST=MA,C=US</principal-name>
     </security-role-mapping>
 </sun-web-app>

--- a/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/clientcert/HelloClientCert.ear.sun-application.xml
+++ b/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/clientcert/HelloClientCert.ear.sun-application.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE sun-application PUBLIC "-//Sun Microsystems, Inc.//DTD GlassFish Application Server 3.0 Java EE Application 6.0//EN" "http://www.sun.com/software/appserver/dtds/sun-application_6_0-0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@
     <unique-id>0</unique-id>
     <security-role-mapping>
         <role-name>Administrator</role-name>
-        <principal-name>CN=CTS, OU=Java Software, O=Sun Microsystems Inc., L=Burlington, ST=MA, C=US</principal-name>
+        <principal-name>CN=CTS,OU=Java Software,O=Sun Microsystems Inc.,L=Burlington,ST=MA,C=US</principal-name>
     </security-role-mapping>
     <security-role-mapping>
         <role-name>Manager</role-name>


### PR DESCRIPTION
This updates the GF specific principal to role mapping to use RFC 2253
formatting for the DN, and for the client-cert test sets TLSv1.2 as an
option for JDK 11.



---
name: Pull Request
about: Create a pull request for a Platform TCK change
title: 'Fix for 2 standalone servlet tests failing in jdk11'
labels: ''
assignees: ''

---

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/625

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
This updates the GF specific principal to role mapping to use RFC 2253
formatting for the DN, and for the client-cert test sets TLSv1.2 as an
option for JDK 11.

**Additional context**
https://www.eclipse.org/lists/glassfish-dev/msg00967.html

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman

Signed-off-by: arjantijms <arjan.tijms@gmail.com>