### PR TITLE
JACC JTA standalone war deployment fix.

### DIFF
--- a/install/jacc/bin/ts.jte.jdk11
+++ b/install/jacc/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -141,7 +141,7 @@ s1as.db.ext.dirs=
 #       target will copy the library jars(jacctck.jar,tsharness.jar) 
 #        to this location.
 ###############################################################
-extension.dir=${s1as.domain}/lib/ext
+extension.dir=${s1as.domain}/lib
 
 ##############################################################################
 # @sjsas.master.password  -- Used as default password for keystore &  truststore

--- a/install/jta/bin/ts.jte.jdk11
+++ b/install/jta/bin/ts.jte.jdk11
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -86,7 +86,7 @@ tck.classes=${ts.home}/lib/tsharness.jar${pathsep}\
 # @extension.dir - The extension directory for the
 #                  server under test (if applicable).  
 ###############################################################
-extension.dir=${webServerHome}/domains/domain1/lib/ext
+extension.dir=${webServerHome}/domains/domain1/lib
 
 ########################################################################
 #


### PR DESCRIPTION
PR fixes issue https://github.com/eclipse-ee4j/jakartaee-tck/issues/638 for JACC and JTA standalone TCK.

CI run can be found here - https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/jacc-fix/4/
There are more failures with JACC TCK, I will raise new issue for those failures post merger of the PR(since root cause is different).

Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>
