### PR TITLE
Update the policy provider and factory to the JDK 11 compatible variant.

### DIFF
--- a/bin/xml/impl/glassfish/common.xml
+++ b/bin/xml/impl/glassfish/common.xml
@@ -1411,7 +1411,7 @@
 
     <!--
        This target was created because we have tools, namely the runcts ant task,
-       that would like to be able to add the JVM options for JACC but not call
+       that would like to be able to add the JVM options for Jakarta Authorization but not call
        server restart.  This was due to techical glitches when restarting the server
        from a spawned process in the task.
     -->
@@ -1421,7 +1421,7 @@
          </antcall>
 
          <antcall target="create-jvm-options" >
-          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper"/>
+          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider"/>
          </antcall>
 
          <antcall target="create-jvm-options" >
@@ -1429,7 +1429,7 @@
          </antcall>
 
          <antcall target="create-jvm-options" >
-          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl "/>
+          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory "/>
          </antcall>
 
          <antcall target="create-one-jvm-option" >
@@ -1448,7 +1448,7 @@
 
     <!--
        This target was created because we have tools, namely the runcts ant task,
-       that would like to be able to remove the JVM options for JACC but not call
+       that would like to be able to remove the JVM options for Jakarta Authorization but not call
        server restart.  This was due to techical glitches when restarting the server
        from a spawned process in the task.
     -->
@@ -1458,7 +1458,7 @@
          </antcall>
         
          <antcall target="delete-jvm-options" >
-          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper"/>
+          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider"/>
          </antcall>
 
          <antcall target="delete-jvm-options" >
@@ -1466,7 +1466,7 @@
          </antcall>
 
          <antcall target="delete-jvm-options" >
-          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl "/>
+          <param name="jvm.options" value=" -Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory "/>
          </antcall>
 
          <antcall target="delete-one-jvm-option" >

--- a/user_guides/Template/src/main/jbake/content/debug-tips.inc
+++ b/user_guides/Template/src/main/jbake/content/debug-tips.inc
@@ -66,9 +66,9 @@ server :
 
 ** `-Djakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.ts.tests.jacc.provider.TSPolicyConfigurationFactoryImpl`
 
-** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper`
+** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider`
 
-** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl` +
+** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory` +
 
 [NOTE]
 =======================================================================

--- a/user_guides/concurrency/src/main/jbake/content/debug-tips.inc
+++ b/user_guides/concurrency/src/main/jbake/content/debug-tips.inc
@@ -47,9 +47,9 @@ server :
 
 ** `-Djakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.ts.tests.jacc.provider.TSPolicyConfigurationFactoryImpl`
 
-** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper`
+** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider`
 
-** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl` +
+** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory` +
 
 [NOTE]
 =======================================================================

--- a/user_guides/jacc/src/main/jbake/content/config.inc
+++ b/user_guides/jacc/src/main/jbake/content/config.inc
@@ -122,17 +122,17 @@ ant config.vi
 +
 The `config.vi` Ant task performs several actions, including:
 +
-* Sets the following JACC JVM options: +
+* Sets the following Jakarta Authorization JVM options: +
 [source,oac_no_warn]
 ----
 -Djakarta.security.jacc.policy.provider=
         com.sun.ts.tests.jacc.provider.TSPolicy
 -Dvendor.jakarta.security.jacc.policy.provider=
-        com.sun.enterprise.security.provider.PolicyWrapper
+        com.sun.enterprise.security.jacc.provider.SimplePolicyProvider
 -Djakarta.security.jacc.PolicyConfigurationFactory.provider=
         com.sun.ts.tests.jacc.provider.TSPolicyConfigurationFactoryImpl
 -Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=
-        com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl
+        com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory
 -Dlog.file.location=${log.file.location}
 ----
 Note that the `log.file.location` comes from the property of the same

--- a/user_guides/jacc/src/main/jbake/content/debug-tips.inc
+++ b/user_guides/jacc/src/main/jbake/content/debug-tips.inc
@@ -47,9 +47,9 @@ server :
 
 ** `-Djakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.ts.tests.jacc.provider.TSPolicyConfigurationFactoryImpl`
 
-** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper`
+** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider`
 
-** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl` +
+** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory` +
 
 [NOTE]
 =======================================================================

--- a/user_guides/jsf/src/main/jbake/content/debug-tips.inc
+++ b/user_guides/jsf/src/main/jbake/content/debug-tips.inc
@@ -65,9 +65,9 @@ server :
 
 ** `-Djakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.ts.tests.jacc.provider.TSPolicyConfigurationFactoryImpl`
 
-** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper`
+** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider`
 
-** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl` +
+** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory` +
 
 [NOTE]
 =======================================================================

--- a/user_guides/servlet/src/main/jbake/content/debug-tips.inc
+++ b/user_guides/servlet/src/main/jbake/content/debug-tips.inc
@@ -47,9 +47,9 @@ server :
 
 ** `-Djakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.ts.tests.jacc.provider.TSPolicyConfigurationFactoryImpl`
 
-** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.provider.PolicyWrapper`
+** `-Dvendor.jakarta.security.jacc.policy.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyProvider`
 
-** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.provider.PolicyConfigurationFactoryImpl` +
+** `-Dvendor.jakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.enterprise.security.jacc.provider.SimplePolicyConfigurationFactory` +
 
 [NOTE]
 =======================================================================


### PR DESCRIPTION

---
name: Pull Request
about: Create a pull request for a Platform TCK change
title: 'Update the policy provider and factory to the JDK 11 compatible variant.'
labels: '9.1'
assignees: ''

---

**Fixes Issue**
Specify the issue (link) that is solved with this pull request.

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
GlassFish contained two policy providers (authorization modules). 1 that contained large amounts of code copied from the JDK, with many references to sun.* packages. Another one that didn't. The first one is not JDK 11 compatible, while the second one is. This PR changes the policy provider and factory to use the JDK 11 compatible one.

**Additional context**
https://www.eclipse.org/lists/glassfish-dev/msg00976.html

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman

Signed-off-by: arjantijms <arjan.tijms@gmail.com>