### PR TITLE
Fix Issue 624

### DIFF
--- a/src/com/sun/ts/tests/jsp/common/xml/common.xml
+++ b/src/com/sun/ts/tests/jsp/common/xml/common.xml
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,7 +38,6 @@
     <target name="compile" description="JSP specific compile target.">
         <ts.javac includes="${pkg.dir}/**/*.java,
                   ${tests.pkg.dir}/common/webclient/**/*.java,
-                  ${jspcommon.dir}/**/*.java,
-        ${jsp.commondir}/**/*.java"/>
+                  ${jspcommon.dir}/**/*.java"/>
     </target>
 </project>

--- a/src/com/sun/ts/tests/jsp/spec/el/jsp/build.xml
+++ b/src/com/sun/ts/tests/jsp/spec/el/jsp/build.xml
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +32,11 @@
                           ${elcommon.dir}/spec/Book.class"
                 prefix="${class.prefix}"/>
         </tscontent.war>
+    </target>
+
+    <target name="compile">
+        <ts.javac includes="${pkg.dir}/**/*.java,
+                           ${elcommon.dir}/**/*.java"/>
     </target>
 
 </project>


### PR DESCRIPTION
**Fixes Issue**
#624 

**Related Issue(s)**
None

**Describe the change**
Add a missing compilation step required because some of the JSP TCKs tests depend on the common EL code so that code needs to be compiled before the associated JSP TCK test WAR is packaged.
I also included a commit that performs some clean-up of some unnecessary configuration I cam across while investigating this issue.

**Additional context**
None

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
