### PR TITLE
Remove org.omg.CORBA.ORB references from TCK tests

### DIFF
--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,17 +20,11 @@
 
 package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resource;
 
-import javax.naming.NamingException;
-
-import org.omg.CORBA.ORB;
-
 import com.sun.javatest.Status;
 import com.sun.ts.lib.deliverable.cts.resource.Dog;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ClientBase;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceIF;
 import com.sun.ts.tests.ejb30.common.annotation.resource.UserTransactionNegativeIF;
-import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
-import com.sun.ts.tests.ejb30.common.helper.TLogger;
 
 import jakarta.annotation.Resource;
 import jakarta.ejb.EJB;
@@ -48,9 +42,6 @@ public class Client extends ClientBase {
 
   @EJB(beanName = "UserTransactionNegativeBean")
   private static UserTransactionNegativeIF userTransactionNegativeBean;
-
-  @Resource
-  private static ORB orb;
 
   @Resource(name = "dog", description = "inject a custom jndi resource")
   private static Dog dog;
@@ -83,30 +74,6 @@ public class Client extends ClientBase {
     Client theTests = new Client();
     Status s = theTests.run(args, System.out, System.err);
     s.exit();
-  }
-
-  /*
-   * @testName: clientOrbTest
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy:
-   *
-   */
-  public void clientOrbTest() throws Fault {
-    if (orb == null) {
-      throw new Fault("orb is not injected");
-    } else {
-      TLogger.log("orb is injected: " + orb);
-    }
-    try {
-      ORB orb2 = (ORB) ServiceLocator.lookup("java:comp/ORB");
-      if (orb2 == null) {
-        throw new Fault("orb from lookup is null");
-      }
-    } catch (NamingException e) {
-      throw new Fault(e);
-    }
   }
 
   /*
@@ -219,15 +186,6 @@ public class Client extends ClientBase {
 
   /*
    * @testName: queueTest
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy:
-   *
-   */
-
-  /*
-   * @testName: orbTest
    * 
    * @assertion_ids:
    * 

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,8 +23,6 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resource;
 import java.net.URL;
 
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.lib.deliverable.cts.resource.Dog;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
@@ -174,13 +172,6 @@ public class ResourceFieldBean extends ResourceBeanBase implements ResourceIF {
     return "queue";
   }
 
-  @Resource(name = "myOrb", type = ORB.class, description = "corba orb", shareable = false)
-  private Object orb;
-
-  protected String getOrbName() {
-    return "myOrb";
-  }
-
   @Resource(name = "myTransactionSynchronizationRegistry", description = "TransactionSynchronizationRegistry injected")
   private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
@@ -239,10 +230,6 @@ public class ResourceFieldBean extends ResourceBeanBase implements ResourceIF {
 
   protected UserTransaction getUserTransaction() {
     return ut;
-  }
-
-  protected ORB getOrb() {
-    return (ORB) this.orb;
   }
 
   protected TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,8 +23,6 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resource;
 import java.net.URL;
 
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.lib.deliverable.cts.resource.Dog;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
@@ -315,21 +313,6 @@ public class ResourceSetterBean extends ResourceBeanBase implements ResourceIF {
 
   protected jakarta.transaction.UserTransaction getUserTransaction() {
     return userTransaction;
-  }
-
-  //////////////////////////////////////////////////////////////////////
-
-  protected String getOrbName() {
-    return "myOrb";
-  }
-
-  @Resource(name = "myOrb", type = ORB.class, description = "corba orb", shareable = false)
-  private void setOrb(Object orb) {
-    this.orb = orb;
-  }
-
-  protected ORB getOrb() {
-    return (ORB) this.orb;
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceTypeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resource/ResourceTypeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,15 +20,12 @@
 
 package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resource;
 
-import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.ORB_JNDI_NAME;
 import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.TRANSACTION_SYNCHRONIZATION_REGISTRY_JNDI_NAME;
 
 import java.net.URL;
 
 import javax.naming.NamingException;
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.lib.deliverable.cts.resource.Dog;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
@@ -71,7 +68,6 @@ import jakarta.transaction.UserTransaction;
     @Resource(name = "connectionFactoryT", type = ConnectionFactory.class),
     @Resource(name = "queue", type = Queue.class),
     @Resource(name = "topic", type = Topic.class),
-    @Resource(name = "myOrb", type = ORB.class, description = "corba orb", shareable = false),
     @Resource(name = "myTransactionSynchronizationRegistry", type = TransactionSynchronizationRegistry.class, description = "TransactionSynchronizationRegistry type-level injection"),
     @Resource(name = "myTimerService", type = TimerService.class, description = "TimerService type-level injection"),
     @Resource(name = "dog", type = Dog.class, description = "a custom resouce") })
@@ -131,10 +127,6 @@ public class ResourceTypeBean extends ResourceBeanBase implements ResourceIF {
 
   protected String getQueueName() {
     return "queue";
-  }
-
-  protected String getOrbName() {
-    return "myOrb";
   }
 
   protected String getTransactionSynchronizationRegistryName() {
@@ -215,14 +207,6 @@ public class ResourceTypeBean extends ResourceBeanBase implements ResourceIF {
     return (UserTransaction) getEJBContext().lookup(getUserTransactionName());
   }
 
-  protected ORB getOrb() {
-    try {
-      return (ORB) ServiceLocator.lookup(ORB_JNDI_NAME);
-    } catch (NamingException e) {
-      e.printStackTrace();
-    }
-    return null;
-  }
 
   protected TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
     try {

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -174,10 +174,4 @@ public class Client extends ClientBase {
    * 
    */
 
-  /*
-   * @todo how to declare it in dd? testName: orbTest
-   * 
-   * @test_Strategy:
-   * 
-   */
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,8 +23,6 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resourcenoat;
 import java.net.URL;
 
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceIF;
@@ -140,14 +138,6 @@ public class ResourceFieldBean extends ResourceBeanBase implements ResourceIF {
     return "queue";
   }
 
-  // @Resource(name="myOrb", type=ORB.class, description="corba orb",
-  // shareable=false)
-  private ORB orb;
-
-  protected String getOrbName() {
-    return "myOrb";
-  }
-
   public ResourceFieldBean() {
   }
 
@@ -192,10 +182,6 @@ public class ResourceFieldBean extends ResourceBeanBase implements ResourceIF {
 
   protected UserTransaction getUserTransaction() {
     return userTransaction;
-  }
-
-  protected ORB getOrb() {
-    return this.orb;
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourcenoat/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,8 +23,6 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resourcenoat;
 import java.net.URL;
 
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceIF;
@@ -70,8 +68,6 @@ public class ResourceSetterBean extends ResourceBeanBase implements ResourceIF {
   private Topic topic;
 
   private Queue queue;
-
-  private ORB orb;
 
   public ResourceSetterBean() {
   }
@@ -266,16 +262,6 @@ public class ResourceSetterBean extends ResourceBeanBase implements ResourceIF {
 
   protected String getOrbName() {
     return "myOrb";
-  }
-
-  // @Resource(name="myOrb", type=ORB.class, description="corba orb",
-  // shareable=false)
-  private void setOrb(ORB orb) {
-    this.orb = orb;
-  }
-
-  protected ORB getOrb() {
-    return this.orb;
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -166,13 +166,6 @@ public class Client extends ClientBase {
    * @testName: queueTest
    * 
    * @assertion_ids:
-   * 
-   * @test_Strategy:
-   * 
-   */
-
-  /*
-   * @todo how to declare it in dd? testName: orbTest
    * 
    * @test_Strategy:
    * 

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceFieldBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceFieldBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,8 +23,6 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resourceoverride;
 import java.net.URL;
 
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceIF;
@@ -137,13 +135,6 @@ public class ResourceFieldBean extends ResourceBeanBase implements ResourceIF {
     return "queue";
   }
 
-  @Resource(name = "myOrb", type = ORB.class, description = "corba orb", shareable = false)
-  private ORB orb;
-
-  protected String getOrbName() {
-    return "myOrb";
-  }
-
   public ResourceFieldBean() {
   }
 
@@ -188,10 +179,6 @@ public class ResourceFieldBean extends ResourceBeanBase implements ResourceIF {
 
   protected UserTransaction getUserTransaction() {
     return ut;
-  }
-
-  protected ORB getOrb() {
-    return this.orb;
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceSetterBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceSetterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,8 +23,6 @@ package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resourceoverride;
 import java.net.URL;
 
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceIF;
@@ -71,8 +69,6 @@ public class ResourceSetterBean extends ResourceBeanBase implements ResourceIF {
   private Topic topic;
 
   private Queue queue;
-
-  private ORB orb;
 
   public ResourceSetterBean() {
   }
@@ -262,15 +258,6 @@ public class ResourceSetterBean extends ResourceBeanBase implements ResourceIF {
 
   protected String getOrbName() {
     return "myOrb";
-  }
-
-  @Resource(name = "myOrb", type = ORB.class, description = "corba orb", shareable = false)
-  private void setOrb(ORB orb) {
-    this.orb = orb;
-  }
-
-  protected ORB getOrb() {
-    return this.orb;
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceTypeBean.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/annotation/resourceoverride/ResourceTypeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,14 +20,10 @@
 
 package com.sun.ts.tests.ejb30.bb.session.stateless.annotation.resourceoverride;
 
-import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.ORB_JNDI_NAME;
-
 import java.net.URL;
 
 import javax.naming.NamingException;
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceBeanBase;
 import com.sun.ts.tests.ejb30.common.annotation.resource.ResourceIF;
@@ -63,8 +59,7 @@ import jakarta.transaction.UserTransaction;
     @Resource(name = "connectionFactoryQ", type = ConnectionFactory.class, authenticationType = AuthenticationType.APPLICATION, shareable = false, description = "<resource-ref>"),
     @Resource(name = "connectionFactoryT", type = ConnectionFactory.class, authenticationType = AuthenticationType.APPLICATION, shareable = false, description = "<resource-ref>"),
     @Resource(name = "queue", type = Queue.class, description = "<resource-env-ref>"),
-    @Resource(name = "topic", type = Topic.class, description = "<resource-env-ref>"),
-    @Resource(name = "myOrb", type = ORB.class, description = "corba orb", shareable = false) })
+    @Resource(name = "topic", type = Topic.class, description = "<resource-env-ref>") })
 
 public class ResourceTypeBean extends ResourceBeanBase implements ResourceIF {
 
@@ -113,10 +108,6 @@ public class ResourceTypeBean extends ResourceBeanBase implements ResourceIF {
 
   protected String getQueueName() {
     return "queue";
-  }
-
-  protected String getOrbName() {
-    return "myOrb";
   }
 
   public ResourceTypeBean() {
@@ -175,15 +166,6 @@ public class ResourceTypeBean extends ResourceBeanBase implements ResourceIF {
 
   protected jakarta.transaction.UserTransaction getUserTransaction() {
     return getEJBContext().getUserTransaction();
-  }
-
-  protected ORB getOrb() {
-    try {
-      return (ORB) ServiceLocator.lookup(ORB_JNDI_NAME);
-    } catch (NamingException e) {
-      e.printStackTrace();
-    }
-    return null;
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean4Super.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/basic/RemoteCalculatorBean4Super.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,24 +20,22 @@
 
 package com.sun.ts.tests.ejb30.bb.session.stateless.basic;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.calc.BaseRemoteCalculator;
 import com.sun.ts.tests.ejb30.common.calc.RemoteCalculator;
-
 import jakarta.annotation.Resource;
+import jakarta.ejb.SessionContext;
 
 abstract public class RemoteCalculatorBean4Super extends BaseRemoteCalculator
     implements RemoteCalculator {
 
   @Resource
-  private ORB orb;
+  private SessionContext sctx;
 
   @Override
   public int remoteAdd(int a, int b) {
     int retValue;
     retValue = super.remoteAdd(a, b);
-    return retValue + (orb == null ? 0 : orb.toString().length());
-  }
-
+    return retValue + (sctx == null ? 0 : sctx.toString().length());
+    }
+  
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/defaultinterceptor/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/defaultinterceptor/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -149,34 +149,5 @@ public class Client extends ClientBase {
    * Verifies only one is invoked.
    *
    */
-  /*
-   * @testName: isInterceptorInjectionDoneForCallbackBean1
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy: two default interceptors are configured for an ejb jar.
-   * Verifies injections on both interceptor and its superclass are all done by
-   * the time PostConstruct is called.
-   *
-   */
-  /*
-   * @testName: isInterceptorInjectionDoneForCallbackBean2
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy: two default interceptors are configured for an ejb jar.
-   * Verifies injections on both interceptor and its superclass are all done by
-   * the time PostConstruct is called.
-   *
-   */
-  /*
-   * @testName: isInterceptorInjectionDoneForSingleDefaultInterceptorJar
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy: single default interceptors are configured for an ejb jar.
-   * Verifies only one is invoked.
-   *
-   */
-
+  
 }

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/annotated/Client.java
@@ -155,14 +155,6 @@ public class Client extends ClientBase3 {
    */
 
   /*
-   * @testName: appclientInjectionCompleteInPostConstruct
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy:
-   */
-
-  /*
    * @testName: ejbCreateTreatedAsPostConstruct
    * 
    * @assertion_ids:

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/Client.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -142,14 +142,6 @@ public class Client extends ClientBase3NoAnnotation {
 
   /*
    * @testName: appclientPostConstructCallOrder
-   * 
-   * @assertion_ids:
-   * 
-   * @test_Strategy:
-   */
-
-  /*
-   * @testName: appclientInjectionCompleteInPostConstruct
    * 
    * @assertion_ids:
    * 

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/ejb3_bb_stateless_callback_method_descriptor_client.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateless/callback/method/descriptor/ejb3_bb_stateless_callback_method_descriptor_client.xml
@@ -18,22 +18,6 @@
 -->
 
 <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd">
-   <resource-ref>
-        <res-ref-name>orbInClientBase2</res-ref-name>
-        <res-type>org.omg.CORBA.ORB</res-type>
-        <injection-target>
-            <injection-target-class>com.sun.ts.tests.ejb30.common.callback.ClientBase2NoAnnotation</injection-target-class>
-            <injection-target-name>orbInClientBase2</injection-target-name>
-        </injection-target>
-    </resource-ref>
-    <resource-ref>
-        <res-ref-name>orbInClientBase3</res-ref-name>
-        <res-type>org.omg.CORBA.ORB</res-type>
-        <injection-target>
-            <injection-target-class>com.sun.ts.tests.ejb30.common.callback.ClientBase3NoAnnotation</injection-target-class>
-            <injection-target-name>orbInClientBase3</injection-target-name>
-        </injection-target>
-    </resource-ref>
     <post-construct>
         <lifecycle-callback-class>com.sun.ts.tests.ejb30.common.callback.ClientBase2NoAnnotation</lifecycle-callback-class>
         <lifecycle-callback-method>postConstructInBase2NoAnnotation</lifecycle-callback-method>

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +49,7 @@ abstract public class ClientBase extends EETest {
   protected String getCustomeResourceName() {
     return null;
   }
-
+  
   /*
    * @class.setup_props:
    */
@@ -311,22 +311,6 @@ abstract public class ClientBase extends EETest {
   public void userTransactionLookupNegativeTest() throws Fault {
     try {
       getUserTransactionNegativeBean().testUserTransactionNegativeLookup();
-    } catch (TestFailedException e) {
-      throw new Fault("Test Failed", e);
-    }
-  }
-
-  /*
-   * testName: orbTest
-   * 
-   * @test_Strategy:
-   *
-   */
-  public void orbTest() throws Fault {
-    try {
-      getResourceFieldBean().testOrb();
-      getResourceSetterBean().testOrb();
-      getResourceTypeBean().testOrb();
     } catch (TestFailedException e) {
       throw new Fault("Test Failed", e);
     }

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/Constants.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,8 +24,6 @@ public interface Constants {
   public static final String PREFIX = "java:comp/env/";
 
   public static final String USER_TRANSACTION_JNDI_NAME = "java:comp/UserTransaction";
-
-  public static final String ORB_JNDI_NAME = "java:comp/ORB";
 
   public static final String TIMER_SERVICE_JNDI_NAME = "java:comp/TimerService";
 

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/EnvSharingBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/EnvSharingBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,8 +28,6 @@ import java.util.List;
 
 import javax.naming.NamingException;
 import javax.sql.DataSource;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
 import com.sun.ts.tests.ejb30.common.helper.TestFailedException;
@@ -120,10 +118,6 @@ abstract public class EnvSharingBeanBase extends ResourceBeanBase
   }
 
   protected String getOrbName() {
-    return null;
-  }
-
-  protected ORB getOrb() {
     return null;
   }
 

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,6 @@
 
 package com.sun.ts.tests.ejb30.common.annotation.resource;
 
-import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.ORB_JNDI_NAME;
 import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.PREFIX;
 import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.TIMER_SERVICE_JNDI_NAME;
 import static com.sun.ts.tests.ejb30.common.annotation.resource.Constants.TRANSACTION_SYNCHRONIZATION_REGISTRY_JNDI_NAME;
@@ -31,7 +30,6 @@ import java.net.URL;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.lib.deliverable.cts.resource.Dog;
 import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
@@ -99,10 +97,6 @@ abstract public class ResourceBeanBase implements ResourceIF {
   abstract protected Topic getTopic();
 
   abstract protected String getTopicName();
-
-  abstract protected ORB getOrb();
-
-  abstract protected String getOrbName();
 
   protected TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
     return null;
@@ -397,27 +391,6 @@ abstract public class ResourceBeanBase implements ResourceIF {
     // UserTransaction ut4 = (UserTransaction)
     // ServiceLocator.lookup(PREFIX + getUserTransactionName());
     // verify(ut4, "Naming context lookup "+ PREFIX + getUserTransactionName());
-    // } catch (NamingException e) {
-    // throw new TestFailedException(e);
-    // }
-  }
-
-  public void testOrb() throws TestFailedException {
-    ORB orb1 = getOrb();
-    verify(orb1, "getOrb()");
-    orb1 = null;
-
-    try {
-      ORB orb3 = (ORB) ServiceLocator.lookup(ORB_JNDI_NAME);
-      verify(orb3, "Naming context lookup " + ORB_JNDI_NAME);
-    } catch (NamingException e) {
-      throw new TestFailedException(e);
-    }
-
-    // try {
-    // ORB orb4 = (ORB)
-    // ServiceLocator.lookup(PREFIX + getOrbName());
-    // verify(orb4, "Naming context lookup "+ PREFIX + getOrbName());
     // } catch (NamingException e) {
     // throw new TestFailedException(e);
     // }

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceIF.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,8 +52,6 @@ public interface ResourceIF {
   public void testQueue() throws TestFailedException;
 
   public void testTopic() throws TestFailedException;
-
-  public void testOrb() throws TestFailedException;
 
   public void testCustomResourceInjected() throws TestFailedException;
 

--- a/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceNoop.java
+++ b/src/com/sun/ts/tests/ejb30/common/annotation/resource/ResourceNoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,9 +55,6 @@ public class ResourceNoop implements ResourceIF {
   }
 
   public void testQueue() {
-  }
-
-  public void testOrb() {
   }
 
   public void testMailSession() {

--- a/src/com/sun/ts/tests/ejb30/common/callback/ClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/ClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021  Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,20 +85,6 @@ abstract public class ClientBase extends EETest {
 
   protected static final String[] INTERCEPTORS_CDA = new String[] { "C", "D",
       "A" };
-
-  // for interceptor injection tests. All ancestors of interceptors can perform
-  // injections
-  protected static final String[] INJECTIONS_2BASE_A_2BASE_B = new String[] {
-      "BASEBASE", "BASE", "A", "BASEBASE", "BASE", "B" };
-
-  protected static final String[] INJECTIONS_2BASE_B_2BASE_A = new String[] {
-      "BASEBASE", "BASE", "B", "BASEBASE", "BASE", "A" };
-
-  protected static final String[] INJECTIONS_2BASE_A = new String[] {
-      "BASEBASE", "BASE", "A" };
-
-  protected static final String[] INJECTIONS_2BASE_B = new String[] {
-      "BASEBASE", "BASE", "B" };
 
   protected static final String[] INJECTIONS_NONE = new String[] {};
 
@@ -396,45 +382,6 @@ abstract public class ClientBase extends EETest {
   public void singleDefaultInterceptorJar() throws Fault {
     List actual = getSingleDefaultInterceptorBean().getPostConstructCalls();
     Helper.compareResultList(INTERCEPTORS_A, actual);
-  }
-
-  /*
-   * testName: isInterceptorInjectionDoneForCallbackBean1
-   * 
-   * @test_Strategy: two default interceptors are configured for an ejb jar.
-   * Verifies injections on both interceptor and its superclass are all done by
-   * the time PostConstruct is called.
-   *
-   */
-  public void isInterceptorInjectionDoneForCallbackBean1() throws Fault {
-    List actual = getBean().getInjectionLocations();
-    Helper.compareResultList(INJECTIONS_2BASE_A_2BASE_B, actual);
-  }
-
-  /*
-   * testName: isInterceptorInjectionDoneForCallbackBean2
-   * 
-   * @test_Strategy: two default interceptors are configured for an ejb jar.
-   * Verifies injections on both interceptor and its superclass are all done by
-   * the time PostConstruct is called.
-   *
-   */
-  public void isInterceptorInjectionDoneForCallbackBean2() throws Fault {
-    List actual = getBean2().getInjectionLocations();
-    Helper.compareResultList(INJECTIONS_2BASE_B_2BASE_A, actual);
-  }
-
-  /*
-   * testName: isInterceptorInjectionDoneForSingleDefaultInterceptorJar
-   * 
-   * @test_Strategy: single default interceptors are configured for an ejb jar.
-   * Verifies only one is invoked.
-   *
-   */
-  public void isInterceptorInjectionDoneForSingleDefaultInterceptorJar()
-      throws Fault {
-    List actual = getSingleDefaultInterceptorBean().getInjectionLocations();
-    Helper.compareResultList(INJECTIONS_2BASE_A, actual);
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/src/com/sun/ts/tests/ejb30/common/callback/ClientBase2.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/ClientBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,16 +20,11 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.Resource;
 
 abstract public class ClientBase2 extends ClientBase2NoAnnotation {
-  @Resource
-  private static ORB orbInClientBase2;
 
   public ClientBase2() {
   }
@@ -41,12 +36,5 @@ abstract public class ClientBase2 extends ClientBase2NoAnnotation {
   @PostConstruct
   private static void postConstructInBase2() {
     addPostConstructCall(BASE2);
-    // check injected fields
-    if (orbInClientBase2 != null) {
-      addInjectedField(orbInClientBase2);
-    } else {
-      TLogger.log("WARNING: ClientBase2.orbInClientBase2 has not been "
-          + "initialized when checking inside ClientBase2.postConstructInBase2()");
-    }
   }
 }

--- a/src/com/sun/ts/tests/ejb30/common/callback/ClientBase2NoAnnotation.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/ClientBase2NoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,14 +23,10 @@ package com.sun.ts.tests.ejb30.common.callback;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.helper.Helper;
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 
 abstract public class ClientBase2NoAnnotation extends ClientBase {
-  // @Resource
-  private static ORB orbInClientBase2;
 
   protected static final String BASE2 = "BASE2";
 
@@ -63,13 +59,6 @@ abstract public class ClientBase2NoAnnotation extends ClientBase {
   // @PostConstruct
   private static void postConstructInBase2NoAnnotation() {
     addPostConstructCall(BASE2);
-    // check injected fields
-    if (orbInClientBase2 != null) {
-      addInjectedField(orbInClientBase2);
-    } else {
-      TLogger.log("WARNING: ClientBase2.orbInClientBase2 has not been "
-          + "initialized when checking inside ClientBase2.postConstructInBase2()");
-    }
   }
 
   public static List getInjectedFields() {
@@ -108,25 +97,6 @@ abstract public class ClientBase2NoAnnotation extends ClientBase {
   public void appclientPostConstructCallOrder() throws Fault {
     List actual = getPostConstructCalls();
     Helper.compareResultList(BASE2_BASE3_CLIENT, actual);
-  }
-
-  /*
-   * testName: appclientInjectionCompleteInPostConstruct
-   * 
-   * @test_Strategy:
-   */
-  public void appclientInjectionCompleteInPostConstruct() throws Fault {
-    // ClientBase2.orbInClientBase2, ClientBase2.orbInClientBase3,
-    // Client.orbInClient
-    int expectedNumOfElements = 3;
-    List actual = getInjectedFields();
-    if (actual.size() == 3) {
-      TLogger
-          .log("Got expected " + expectedNumOfElements + " fields: " + actual);
-    } else {
-      throw new Fault("Expected " + expectedNumOfElements
-          + " fields to be injected, but actual injected fields are " + actual);
-    }
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/common/callback/ClientBase3.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/ClientBase3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,12 +20,7 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
-import com.sun.ts.tests.ejb30.common.helper.TLogger;
-
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.Resource;
 
 /**
  * the direct superclass of Client classes that test application client
@@ -33,8 +28,6 @@ import jakarta.annotation.Resource;
  * stateless/callback/method/annotated/Client.
  */
 abstract public class ClientBase3 extends ClientBase2 {
-  @Resource
-  private static ORB orbInClientBase3;
 
   public ClientBase3() {
   }
@@ -42,13 +35,6 @@ abstract public class ClientBase3 extends ClientBase2 {
   @PostConstruct
   private static void postConstructInBase3() {
     addPostConstructCall(BASE3);
-    // check injected fields
-    if (orbInClientBase3 != null) {
-      addInjectedField(orbInClientBase3);
-    } else {
-      TLogger.log("WARNING: ClientBase3.orbInClientBase3 has not been "
-          + "initialized when checking inside ClientBase3.postConstructInBase3()");
-    }
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/common/callback/ClientBase3NoAnnotation.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/ClientBase3NoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,6 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 
 /**
@@ -30,8 +28,6 @@ import com.sun.ts.tests.ejb30.common.helper.TLogger;
  * stateless/callback/method/descriptor/Client.
  */
 abstract public class ClientBase3NoAnnotation extends ClientBase2NoAnnotation {
-  // @Resource
-  private static ORB orbInClientBase3;
 
   public ClientBase3NoAnnotation() {
   }
@@ -39,13 +35,6 @@ abstract public class ClientBase3NoAnnotation extends ClientBase2NoAnnotation {
   // @PostConstruct
   private static void postConstructInBase3NoAnnotation() {
     addPostConstructCall(BASE3);
-    // check injected fields
-    if (orbInClientBase3 != null) {
-      addInjectedField(orbInClientBase3);
-    } else {
-      TLogger.log("WARNING: ClientBase3.orbInClientBase3 has not been "
-          + "initialized when checking inside ClientBase3.postConstructInBase3()");
-    }
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/common/callback/InterceptorA.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/InterceptorA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,11 +20,8 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import jakarta.annotation.Resource;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.InvocationContext;
 
@@ -34,16 +31,13 @@ import jakarta.interceptor.InvocationContext;
  * throws list, though not necessary.
  */
 public class InterceptorA extends InterceptorBase {
-  @Resource()
-  private ORB orb;
 
   public InterceptorA() {
     super();
   }
 
   public String getInjectedLocation() {
-    String result = (orb == null) ? NOT_INJECTED : "A";
-    return result;
+    return NOT_INJECTED;
   }
 
   @Override

--- a/src/com/sun/ts/tests/ejb30/common/callback/InterceptorB.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/InterceptorB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,13 +20,8 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
-import jakarta.annotation.Resource;
 
 public class InterceptorB extends InterceptorBase {
-  @Resource()
-  private ORB orb;
 
   @Override
   protected String getShortName() {
@@ -34,8 +29,7 @@ public class InterceptorB extends InterceptorBase {
   }
 
   protected String getInjectedLocation() {
-    String result = (orb == null) ? NOT_INJECTED : "B";
-    return result;
+    return NOT_INJECTED;
   }
 
   protected void myCreate(jakarta.interceptor.InvocationContext inv)

--- a/src/com/sun/ts/tests/ejb30/common/callback/InterceptorBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/InterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,21 +25,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 
-import jakarta.annotation.Resource;
 import jakarta.interceptor.InvocationContext;
 
 abstract public class InterceptorBase extends InterceptorBaseBase {
 
-  @Resource()
-  private ORB orb;
-
   private String getInjectedBaseLocation() {
-    String result = (orb == null) ? NOT_INJECTED : "BASE";
-    return result;
+    return NOT_INJECTED;
   }
 
   protected String getShortName() {

--- a/src/com/sun/ts/tests/ejb30/common/callback/InterceptorBaseBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/InterceptorBaseBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,23 +20,16 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
-import jakarta.annotation.Resource;
 
 abstract public class InterceptorBaseBase {
   protected static final String NOT_INJECTED = "NOT_INJECTED";
 
   protected static final String POSTCONSTRUCT_CALLS_IN_CONTEXTDATA = "POSTCONSTRUCT_CALLS_IN_CONTEXTDATA";
 
-  @Resource()
-  private ORB orbInBaseBase;
-
   abstract protected String getInjectedLocation();
 
   protected String getInjectedBaseBaseLocation() {
-    String result = (orbInBaseBase == null) ? NOT_INJECTED : "BASEBASE";
-    return result;
+    return NOT_INJECTED;
   }
 
   /**

--- a/src/com/sun/ts/tests/ejb30/common/callback/InterceptorC.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/InterceptorC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,11 +20,8 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import jakarta.annotation.Resource;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.InvocationContext;
 
@@ -34,16 +31,13 @@ import jakarta.interceptor.InvocationContext;
  * throws list, though not necessary.
  */
 public class InterceptorC extends InterceptorBase {
-  @Resource()
-  private ORB orb;
 
   public InterceptorC() {
     super();
   }
 
   public String getInjectedLocation() {
-    String result = (orb == null) ? NOT_INJECTED : "C";
-    return result;
+    return NOT_INJECTED;
   }
 
   @Override

--- a/src/com/sun/ts/tests/ejb30/common/callback/InterceptorD.java
+++ b/src/com/sun/ts/tests/ejb30/common/callback/InterceptorD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,22 +20,14 @@
 
 package com.sun.ts.tests.ejb30.common.callback;
 
-import org.omg.CORBA.ORB;
-
-import jakarta.annotation.Resource;
-
 public class InterceptorD extends InterceptorBase {
-  @Resource()
-  private ORB orb;
-
   @Override
   protected String getShortName() {
     return "D";
   }
 
   protected String getInjectedLocation() {
-    String result = (orb == null) ? NOT_INJECTED : "D";
-    return result;
+    return NOT_INJECTED;
   }
 
   protected void myCreate(jakarta.interceptor.InvocationContext inv)

--- a/src/com/sun/ts/tests/ejb30/common/sessioncontext/TestBeanBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/sessioncontext/TestBeanBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,12 +20,9 @@
 
 package com.sun.ts.tests.ejb30.common.sessioncontext;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 import com.sun.ts.tests.ejb30.common.helper.TestFailedException;
 
-import jakarta.annotation.Resource;
 import jakarta.ejb.EJBException;
 import jakarta.ejb.SessionContext;
 
@@ -39,9 +36,6 @@ abstract public class TestBeanBase implements TestIF {
   abstract protected TwoLocalIF getTwoLocal() throws TestFailedException;
 
   abstract protected AcceptLocalIF getAcceptLocalBean();
-
-  @Resource(name = "null")
-  private ORB orb;
 
   public void getBusinessObjectLocal1() throws TestFailedException {
     ThreeLocal1IF local = getLocal1();

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclient2ejbjars/StatelessAnnotationUsedRemoteCalculatorBean.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclient2ejbjars/StatelessAnnotationUsedRemoteCalculatorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,6 @@
  */
 
 package com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars;
-
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.calc.BaseRemoteCalculator;
 import com.sun.ts.tests.ejb30.common.calc.RemoteCalculator;
@@ -56,9 +54,6 @@ public class StatelessAnnotationUsedRemoteCalculatorBean
   @Resource(name = "sessionContext") // NOT to be ignored
   private SessionContext sessionContext;
 
-  @Resource(name = "orb") // NOT to be ignored
-  private ORB orb;
-
   public StatelessAnnotationUsedRemoteCalculatorBean() {
   }
 
@@ -86,11 +81,6 @@ public class StatelessAnnotationUsedRemoteCalculatorBean
           + "injected, but its actual value is null.  The ejb-jar where "
           + "this bean is in has been marked as metadata-complete=false");
     }
-    if (orb == null) {
-      throw new IllegalStateException("orb field should have been "
-          + "injected, but its actual value is null.  The ejb-jar where "
-          + "this bean is in has been marked as metadata-complete=false");
-    }
     return postConstructCallsCount + a + b;
   }
 
@@ -102,5 +92,6 @@ public class StatelessAnnotationUsedRemoteCalculatorBean
     // do the same thing as remoteAdd(int, int)
     return postConstructCallsCount + a + b;
   }
+ 
 
 }

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/Client.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,20 +24,15 @@ import java.util.Properties;
 
 import javax.naming.NamingException;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.javatest.Status;
 import com.sun.ts.lib.harness.EETest;
 import com.sun.ts.tests.ejb30.common.calc.RemoteCalculator;
 import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
 import com.sun.ts.tests.ejb30.common.helper.TLogger;
 
-import jakarta.annotation.Resource;
-import jakarta.annotation.Resources;
 import jakarta.ejb.EJB;
 import jakarta.ejb.EJBs;
 
-@Resources({ @Resource(name = "typeLevelOrbNotInjected", type = ORB.class) })
 @EJBs({
     @EJB(name = "typeLevelBeanNotInjected", beanInterface = RemoteCalculator.class, beanName = "StatelessRemoteCalculatorBean") })
 public class Client extends EETest {
@@ -52,9 +47,6 @@ public class Client extends EETest {
 
   @EJB(name = "statefulBeanNotInjected", beanName = "StatefulRemoteCalculatorBean")
   static RemoteCalculator statefulBeanNotInjected;
-
-  @Resource(name = "orbNotInjected")
-  static ORB orbNotInjected;
 
   protected Properties props;
 
@@ -132,11 +124,6 @@ public class Client extends EETest {
       throw new Fault("Field statefulBeanNotInjected must not be injected,"
           + " since a full application client descriptor is used. "
           + "This field has been initialized to " + statefulBeanNotInjected);
-    }
-    if (orbNotInjected != null) {
-      throw new Fault("Field orbNotInjected must not be injected,"
-          + " since a full application client descriptor is used. "
-          + "This field has been initialized to " + orbNotInjected);
     }
     String lookupName = "java:comp/env/typeLevelBeanNotInjected";
     Object lookupValue = null;

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/RemoteCalculatorBean0.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/appclientejbjars/RemoteCalculatorBean0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,22 +20,17 @@
 
 package com.sun.ts.tests.ejb30.misc.metadataComplete.appclientejbjars;
 
-import org.omg.CORBA.ORB;
 
 import com.sun.ts.tests.ejb30.common.calc.BaseRemoteCalculator;
 import com.sun.ts.tests.ejb30.common.calc.RemoteCalculator;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import jakarta.annotation.Resource;
 import jakarta.ejb.EJBContext;
 import jakarta.ejb.EJBException;
 
 abstract public class RemoteCalculatorBean0 extends BaseRemoteCalculator
     implements RemoteCalculator {
-
-  @Resource(name = "orb") // to be ignored
-  protected ORB orb;
 
   public RemoteCalculatorBean0() {
   }
@@ -60,11 +55,6 @@ abstract public class RemoteCalculatorBean0 extends BaseRemoteCalculator
   public int remoteAdd(int a, int b) {
     if (getEJBContext() != null) {
       throw new EJBException("SessionContext is not null: " + getEJBContext()
-          + ".  It should not be injected since this ejb-jar is marked"
-          + " as metadata-complete.");
-    }
-    if (orb != null) {
-      throw new EJBException("orb is not null: " + orb
           + ".  It should not be injected since this ejb-jar is marked"
           + " as metadata-complete.");
     }

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/TestServlet.java
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/TestServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,28 +25,21 @@ import java.io.PrintWriter;
 
 import javax.naming.NamingException;
 
-import org.omg.CORBA.ORB;
-
 import com.sun.ts.tests.ejb30.common.calc.RemoteCalculator;
 import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
 import com.sun.ts.tests.servlet.common.servlets.HttpTCKServlet;
 import com.sun.ts.tests.servlet.common.util.Data;
 
-import jakarta.annotation.Resource;
-import jakarta.annotation.Resources;
 import jakarta.ejb.EJB;
 import jakarta.ejb.EJBs;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@Resources({ @Resource(name = "typeLevelOrbNotInjected", type = ORB.class) })
+
 @EJBs({
     @EJB(name = "typeLevelBeanNotInjected", beanInterface = RemoteCalculator.class, beanName = "StatelessRemoteCalculatorBean") })
 public class TestServlet extends HttpTCKServlet {
-
-  @Resource(name = "orb")
-  private ORB orb;
 
   @EJB(name = "statelessBeanNotInjected", beanName = "StatelessRemoteCalculatorBean")
   private RemoteCalculator statelessBeanNotInjected;
@@ -101,14 +94,14 @@ public class TestServlet extends HttpTCKServlet {
   public void annotationNotProcessedForWar(HttpServletRequest request,
       HttpServletResponse response) throws ServletException, IOException {
     PrintWriter pw = response.getWriter();
-    if (orb == null && statelessBeanNotInjected == null
+    if (statelessBeanNotInjected == null
         && statefulBeanNotInjected == null) {
       pw.println(Data.PASSED + ".  Annotated fields are not injected, since "
           + "this war has been marked as metadata-complete.");
     } else {
       pw.println(Data.FAILED + ".  Annotated fields should not be injected, "
           + "since this war has been marked as metadata-complete.  But "
-          + "these fields were injected: " + orb + "\n"
+          + "these fields were injected: "  + "\n"
           + statelessBeanNotInjected + "\n" + statefulBeanNotInjected);
     }
   }

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/misc_metadataComplete_warejb_ejb.xml
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/misc_metadataComplete_warejb_ejb.xml
@@ -58,16 +58,6 @@
             <ejb-class>com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars.StatelessAnnotationUsedRemoteCalculatorBean</ejb-class>
             <session-type>Stateless</session-type>
             <transaction-type>Container</transaction-type>
-            <resource-ref>
-                <res-ref-name>orb</res-ref-name>
-                <res-type>org.omg.CORBA.ORB</res-type>
-                <res-auth>Container</res-auth>
-                <res-sharing-scope>Shareable</res-sharing-scope>
-                <injection-target>
-                    <injection-target-class>com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars.StatelessAnnotationUsedRemoteCalculatorBean</injection-target-class>
-                    <injection-target-name>orb</injection-target-name>
-                </injection-target>
-            </resource-ref>
             <resource-env-ref>
                 <resource-env-ref-name>sessionContext</resource-env-ref-name>
                 <resource-env-ref-type>jakarta.ejb.SessionContext</resource-env-ref-type>
@@ -92,16 +82,6 @@
             <ejb-class>com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars.StatelessAnnotationUsedRemoteCalculatorBean</ejb-class>
             <session-type>Stateless</session-type>
             <transaction-type>Container</transaction-type>
-            <resource-ref>
-                <res-ref-name>orb</res-ref-name>
-                <res-type>org.omg.CORBA.ORB</res-type>
-                <res-auth>Container</res-auth>
-                <res-sharing-scope>Shareable</res-sharing-scope>
-                <injection-target>
-                    <injection-target-class>com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars.StatelessAnnotationUsedRemoteCalculatorBean</injection-target-class>
-                    <injection-target-name>orb</injection-target-name>
-                </injection-target>
-            </resource-ref>
             <resource-env-ref>
                 <resource-env-ref-name>sessionContext</resource-env-ref-name>
                 <resource-env-ref-type>jakarta.ejb.SessionContext</resource-env-ref-type>
@@ -127,16 +107,6 @@
             <ejb-class>com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars.StatelessAnnotationUsedRemoteCalculatorBean</ejb-class>
             <session-type>Stateless</session-type>
             <transaction-type>Container</transaction-type>
-            <resource-ref>
-                <res-ref-name>orb</res-ref-name>
-                <res-type>org.omg.CORBA.ORB</res-type>
-                <res-auth>Container</res-auth>
-                <res-sharing-scope>Shareable</res-sharing-scope>
-                <injection-target>
-                    <injection-target-class>com.sun.ts.tests.ejb30.misc.metadataComplete.appclient2ejbjars.StatelessAnnotationUsedRemoteCalculatorBean</injection-target-class>
-                    <injection-target-name>orb</injection-target-name>
-                </injection-target>
-            </resource-ref>
             <resource-env-ref>
                 <resource-env-ref-name>sessionContext</resource-env-ref-name>
                 <resource-env-ref-type>jakarta.ejb.SessionContext</resource-env-ref-type>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/604

**Describe the change**
Remove all org.omg.CORBA.ORB references from TCK tests.
