### PR TITLE
Remove XML header from beans.xml files

### DIFF
--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
@@ -16,7 +16,6 @@
 
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
@@ -16,7 +16,6 @@
 
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
@@ -16,7 +16,6 @@
 
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"

--- a/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
@@ -16,7 +16,6 @@
 
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"


### PR DESCRIPTION
Signed-off-by: Brian Decker <bmdecker@us.ibm.com>

PR https://github.com/eclipse-ee4j/jakartaee-tck/pull/635 included XML headers in the beans.xml files, which the parser in Weld did not end up liking.  Quick fix to remove them.

CC @gurunrao @scottmarlow 
