### PR TITLE
allow permission to execute jimage, also access for jdk internals.

### DIFF
--- a/install/jakartaee/bin/client_policy.append
+++ b/install/jakartaee/bin/client_policy.append
@@ -3,7 +3,11 @@ grant {
 /* Required by CTS tests to read, write and delete files */
 /* File io permissions should only exist for appclient and web containers. */
 /* For signature tests, read permission is also required for EJB container. */
-	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete,execute";
+  	permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.reflect";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.vm.annotation";
+    
 
 /* CTS harness requirement */
     permission java.lang.RuntimePermission "setFactory";

--- a/install/jakartaee/bin/server_policy.append
+++ b/install/jakartaee/bin/server_policy.append
@@ -3,7 +3,11 @@ grant {
 /* Required by TS tests to read, write and delete files */
 /* File io permissions should only exist for appclient and web containers. */
 /* For signature tests, read permission is also required for EJB container. */
-	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete,execute";
+	permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.reflect";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.vm.annotation";
+    
 
 /* TS harness requirement */
     permission java.lang.RuntimePermission "setFactory";


### PR DESCRIPTION
Fix for signature failures with Platform Full Profile/ Platform Web Profile GF 6.1  + JDK 11
Fix for jimage execution permission failures and permission, more details can be found here - https://github.com/eclipse-ee4j/jakartaee-tck/issues/618#issuecomment-794310160

CI run -https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/signature-permission/lastCompletedBuild/testReport/