### PR TITLE
jstl fix with COMPAT option.

### DIFF
--- a/docker/jstltck.sh
+++ b/docker/jstltck.sh
@@ -97,6 +97,11 @@ cd $TCK_HOME/$GF_TOPLEVEL_DIR/glassfish/bin
 ./asadmin create-jvm-options -Djavax.xml.accessExternalStylesheet=all
 ./asadmin create-jvm-options -Djavax.xml.accessExternalSchema=all
 ./asadmin create-jvm-options -Djavax.xml.accessExternalDTD=file,http
+#https://github.com/eclipse-ee4j/jakartaee-tck/issues/631
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
+  ./asadmin create-jvm-options -Djava.locale.providers=COMPAT
+fi
+
 ./asadmin stop-domain
 ./asadmin start-domain
 

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -x
 
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2019, 2020 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -273,6 +273,10 @@ ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --password
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} version
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Djava.security.manager
+#https://github.com/eclipse-ee4j/jakartaee-tck/issues/631
+if [[ ("$JDK" == "JDK11" || "$JDK" == "jdk11") &&  $test_suite == jstl ]]; then
+  ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Djava.locale.providers=COMPAT
+fi
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} stop-domain
 
 sleep 5


### PR DESCRIPTION
Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>

JSTL tests are passing with COMPAT option. 
CI run:
-------
Standalone TCK with JDK 11 + GF 6.1 - https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/jstl-fix/3/
Platform TCK with JDK 11 + GF 6.1 - https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/jstl-fix/7/