### PR TITLE
#625 Make new property optional

### DIFF
--- a/src/com/sun/ts/lib/deliverable/cts/CTSPropertyManager.java
+++ b/src/com/sun/ts/lib/deliverable/cts/CTSPropertyManager.java
@@ -353,7 +353,8 @@ public class CTSPropertyManager extends AbstractPropertyManager {
     pTestProps.put("securedWebServicePort",
         getProperty("securedWebServicePort"));
     pTestProps.put("webServerPort", getProperty("webServerPort"));
-    pTestProps.put("client.cert.test.jdk.tls.client.protocols", getProperty("client.cert.test.jdk.tls.client.protocols"));
+    pTestProps.put("client.cert.test.jdk.tls.client.protocols", 
+        getProperty("client.cert.test.jdk.tls.client.protocols", null));
 
     // add properties used for JPA 2.2 tests.
     pTestProps.put("persistence.unit.name",

--- a/src/com/sun/ts/lib/deliverable/servlet/ServletPropertyManager.java
+++ b/src/com/sun/ts/lib/deliverable/servlet/ServletPropertyManager.java
@@ -84,7 +84,7 @@ public class ServletPropertyManager extends TCKPropertyManager {
     pTestProps.put("porting.ts.HttpsURLConnection.class.1",
         getProperty("porting.ts.HttpsURLConnection.class.1", null));
     pTestProps.put("client.cert.test.jdk.tls.client.protocols",
-        getProperty("client.cert.test.jdk.tls.client.protocols"));
+        getProperty("client.cert.test.jdk.tls.client.protocols", null));
 
     String tsHome = getProperty("TS_HOME", null);
     if (tsHome == null)


### PR DESCRIPTION
Make `client.cert.test.jdk.tls.client.protocols` optional. 

This is making the platform suite to fail with JDK8. See https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/master/1319/
