### PR TITLE
#625 Resolve NullPointerException

### DIFF
--- a/src/com/sun/ts/lib/deliverable/cts/CTSPropertyManager.java
+++ b/src/com/sun/ts/lib/deliverable/cts/CTSPropertyManager.java
@@ -353,8 +353,11 @@ public class CTSPropertyManager extends AbstractPropertyManager {
     pTestProps.put("securedWebServicePort",
         getProperty("securedWebServicePort"));
     pTestProps.put("webServerPort", getProperty("webServerPort"));
-    pTestProps.put("client.cert.test.jdk.tls.client.protocols", 
-        getProperty("client.cert.test.jdk.tls.client.protocols", null));
+
+    String sTlsClientProtocols = getProperty("client.cert.test.jdk.tls.client.protocols", null);
+    if (sTlsClientProtocols != null) {
+        pTestProps.put("client.cert.test.jdk.tls.client.protocols", sTlsClientProtocols);
+    }
 
     // add properties used for JPA 2.2 tests.
     pTestProps.put("persistence.unit.name",

--- a/src/com/sun/ts/lib/deliverable/servlet/ServletPropertyManager.java
+++ b/src/com/sun/ts/lib/deliverable/servlet/ServletPropertyManager.java
@@ -83,8 +83,11 @@ public class ServletPropertyManager extends TCKPropertyManager {
         getProperty("porting.ts.url.class.1"));
     pTestProps.put("porting.ts.HttpsURLConnection.class.1",
         getProperty("porting.ts.HttpsURLConnection.class.1", null));
-    pTestProps.put("client.cert.test.jdk.tls.client.protocols",
-        getProperty("client.cert.test.jdk.tls.client.protocols", null));
+	
+	String sTlsClientProtocol = getProperty("client.cert.test.jdk.tls.client.protocols", null);
+	if (sTlsClientProtocol != null) {
+        pTestProps.put("client.cert.test.jdk.tls.client.protocols", sTlsClientProtocol);
+    }
 
     String tsHome = getProperty("TS_HOME", null);
     if (tsHome == null)


### PR DESCRIPTION
Add `client.cert.test.jdk.tls.client.protocols` to properties only if it is not null

```
java.lang.NullPointerException
	at java.util.Hashtable.put(Hashtable.java:460)
	at com.sun.ts.lib.deliverable.cts.CTSPropertyManager.getTestSpecificProperties(CTSPropertyManager.java:356)
	at com.sun.ts.lib.harness.TSHarnessObserver.startingTest(TSHarnessObserver.java:323)
	at com.sun.javatest.Harness$Notifier.startingTest(Harness.java:995)
	at com.sun.javatest.TestRunner.notifyStartingTest(TestRunner.java:212)
	at com.sun.javatest.DefaultTestRunner.runTest(DefaultTestRunner.java:167)
	at com.sun.javatest.DefaultTestRunner.access$100(DefaultTestRunner.java:43)
	at com.sun.javatest.DefaultTestRunner$1.run(DefaultTestRunner.java:66)
result: Not run. Test running...
```