### PR TITLE
Restore copyright for java files not updated this year

### DIFF
--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/AsyncHandler/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/AsyncHandler/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/AsyncHandler/JAXBAsyncHandler.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/AsyncHandler/JAXBAsyncHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/AsyncHandler/XMLAsyncHandler.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/AsyncHandler/XMLAsyncHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Binding/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Binding/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/BindingProvider/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/BindingProvider/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Dispatch/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Dispatch/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/EndpointReference/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/EndpointReference/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Holder/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Holder/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/LogicalMessage/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/LogicalMessage/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/ProtocolException/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/ProtocolException/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Provider/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Provider/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/RespectBindingFeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/RespectBindingFeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Response/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Response/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Service/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Service/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Service_Mode/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Service_Mode/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/WebServiceContext/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/WebServiceContext/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/WebServiceException/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/WebServiceException/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/WebServicePermission/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/WebServicePermission/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/LogicalHandler/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/LogicalHandler/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/LogicalMessageContext/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/LogicalMessageContext/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/MessageContext/Scope/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/MessageContext/Scope/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/PortInfo/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler/PortInfo/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler_soap/SOAPHandler/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler_soap/SOAPHandler/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler_soap/SOAPMessageContext/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_handler_soap/SOAPMessageContext/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_http/HTTPBinding/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_http/HTTPBinding/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_http/HTTPException/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_http/HTTPException/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/AddressingFeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/AddressingFeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/AddressingFeature_Responses/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/AddressingFeature_Responses/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/MTOMFeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/MTOMFeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/SOAPBinding/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/SOAPBinding/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/SOAPFaultException/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_soap/SOAPFaultException/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_wsaddressing/W3CEndpointReference/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_wsaddressing/W3CEndpointReference/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_wsaddressing/W3CEndpointReferenceBuilder/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws_wsaddressing/W3CEndpointReferenceBuilder/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/AnnotationUtils.java
+++ b/src/com/sun/ts/tests/jaxws/common/AnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/AttachmentHelper.java
+++ b/src/com/sun/ts/tests/jaxws/common/AttachmentHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/Constants.java
+++ b/src/com/sun/ts/tests/jaxws/common/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/HTTPSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/common/HTTPSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/HandlerTracker.java
+++ b/src/com/sun/ts/tests/jaxws/common/HandlerTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/Handler_Util.java
+++ b/src/com/sun/ts/tests/jaxws/common/Handler_Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/JAXWS_Data.java
+++ b/src/com/sun/ts/tests/jaxws/common/JAXWS_Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/JAXWS_Util.java
+++ b/src/com/sun/ts/tests/jaxws/common/JAXWS_Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase.java
+++ b/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase2.java
+++ b/src/com/sun/ts/tests/jaxws/common/LogicalHandlerBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/RequestConformanceChecker.java
+++ b/src/com/sun/ts/tests/jaxws/common/RequestConformanceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase.java
+++ b/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase2.java
+++ b/src/com/sun/ts/tests/jaxws/common/SOAPHandlerBase2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/common/XMLUtils.java
+++ b/src/com/sun/ts/tests/jaxws/common/XMLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/server/JavaBean.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/server/JavaBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/server/MarshallTest.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/server/MarshallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/server/MarshallTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/marshalltest/server/MarshallTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/nosei/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/nosei/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/nosei/server/EchoImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/nosei/server/EchoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/restful/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/restful/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/restful/server/TokensImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/restful/server/TokensImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/sessionmaintaintest/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/sessionmaintaintest/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/sessionmaintaintest/server/TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/sessionmaintaintest/server/TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/server/TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/server/TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/server/TestImplBase.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/server/TestImplBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/server/TestImplBaseBase.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/document/literal/webmethod/server/TestImplBaseBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/HandlerChainTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/HandlerChainTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/LogicalHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/LogicalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/SOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest1/SOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/HandlerChainTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/HandlerChainTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/LogicalHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/LogicalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/SOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/handlerchaintest2/SOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/nosei/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/nosei/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/nosei/server/EchoImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/j2w/rpc/literal/nosei/server/EchoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/asynctest/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/asynctest/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/asynctest/server/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/asynctest/server/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/catalogtest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/catalogtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/catalogtest/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/catalogtest/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/embedded/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/embedded/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/embedded/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/embedded/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/external/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/external/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/external/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/customization/external/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/HandlerChainTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/HandlerChainTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/LogicalHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/LogicalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/SOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/handlerchaintest/SOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/headertest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/headertest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/headertest/HeaderTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/headertest/HeaderTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/holdertest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/holdertest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/holdertest/HolderTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/holdertest/HolderTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/httptest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/httptest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/httptest/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/httptest/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/CompoundTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/CompoundTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/MarshallTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/MarshallTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/NewSchemaTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/NewSchemaTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/OneWayTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/marshalltest/OneWayTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl4.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/MTOMFeatureTestImpl4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/MTOMClientTwo.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/MTOMClientTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/MTOMTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/MTOMTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/MTOMTestTwoImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/MTOMTestTwoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/client/ClientLogicalHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/client/ClientLogicalHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/client/ClientSOAPHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/client/ClientSOAPHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/GetTrackerDataImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/GetTrackerDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/ServerLogicalHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/ServerLogicalHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/ServerSOAPHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/onewayhandlertest/server/ServerSOAPHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/wrapperstyle/marshalltest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/wrapperstyle/marshalltest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/wrapperstyle/marshalltest/MarshallTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/wrapperstyle/marshalltest/MarshallTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/handlertest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/handlertest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/headertest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/headertest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/headertest/HeaderTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/headertest/HeaderTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/holdertest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/holdertest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/holdertest/HolderTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/holdertest/HolderTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httpservletmsgctxpropstest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httpservletmsgctxpropstest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httpservletmsgctxpropstest/HttpTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httpservletmsgctxpropstest/HttpTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httptest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httptest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httptest/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/httptest/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/CompoundTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/CompoundTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/MarshallTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/MarshallTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/NewSchemaTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/NewSchemaTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/OneWayTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/marshalltest/OneWayTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/client/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/client/ClientLogicalHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/client/ClientLogicalHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/client/ClientSOAPHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/client/ClientSOAPHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/GetTrackerDataImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/GetTrackerDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/ServerLogicalHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/ServerLogicalHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/ServerSOAPHandler2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/onewayhandlertest/server/ServerSOAPHandler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/parametermodetest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/parametermodetest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/parametermodetest/ParameterModeTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/parametermodetest/ParameterModeTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloGuestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloGuestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl2.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloProtectedImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloUnprotectedImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/sec/secbasic/HelloUnprotectedImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/xmlnamemappingtest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/xmlnamemappingtest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/xmlnamemappingtest/XMLNameMappingTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/rpc/literal/xmlnamemappingtest/XMLNameMappingTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/AddNumbersImpl23001.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/AddNumbersImpl23001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/AddNumbersImpl23002.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/AddNumbersImpl23002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/Client.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor2.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/jaxws23/wsa/j2w/document/literal/anonymous/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/bare/AddressingEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/bare/AddressingEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/bare/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/bare/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/bare/J2WDLSharedEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/bare/J2WDLSharedEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/wrapped/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/wrapped/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/wrapped/J2WDLSharedEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/wrapped/J2WDLSharedEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/wrapped/JAXBAnnotationsImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/document/literal/wrapped/JAXBAnnotationsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint3.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint3Impl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint3Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint4.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint4Impl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint4Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint5.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint5Impl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint5Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint6.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint6Impl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpoint6Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/AddressingEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/J2WRLSharedEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withannotations/J2WRLSharedEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withoutannotations/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withoutannotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withoutannotations/J2WRLSharedEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/j2wmapping/rpc/literal/withoutannotations/J2WRLSharedEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/annotations/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/annotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/annotations/Handler.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/annotations/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/customization/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/customization/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/eprsubtypes/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/eprsubtypes/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/noncustomization/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/document/literal/noncustomization/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/rpc/literal/annotations/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/rpc/literal/annotations/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/rpc/literal/customization/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/rpc/literal/customization/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/rpc/literal/noncustomization/Client.java
+++ b/src/com/sun/ts/tests/jaxws/mapping/w2jmapping/rpc/literal/noncustomization/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/se/api/jakarta_xml_ws/Endpoint/Client.java
+++ b/src/com/sun/ts/tests/jaxws/se/api/jakarta_xml_ws/Endpoint/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/Client.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/DescriptionClient.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/DescriptionClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/HttpClient.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/SOAPClient.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/SOAPClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/SaajClient.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/SaajClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/StubContext.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/StubContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientLogicalHandler4.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientLogicalHandler4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientLogicalHandler6.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientLogicalHandler6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientSOAPHandler4.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientSOAPHandler4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientSOAPHandler6.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/dlhandlerclient/ClientSOAPHandler6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/doclithelloclient/ClientLogicalHandler.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/doclithelloclient/ClientLogicalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/faultclient/FaultTestClient.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/faultclient/FaultTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/rlhandlerclient/ClientLogicalHandler6.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/rlhandlerclient/ClientLogicalHandler6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/rlhandlerclient/ClientSOAPHandler6.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/rlhandlerclient/ClientSOAPHandler6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedclients/simpleclient/SimpleTestClient.java
+++ b/src/com/sun/ts/tests/jaxws/sharedclients/simpleclient/SimpleTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/GetTrackerDataImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/GetTrackerDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/Hello2Impl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/Hello2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/Hello3Impl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/Hello3Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerLogicalHandler4.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerLogicalHandler4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerLogicalHandler5.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerLogicalHandler5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerLogicalHandler6.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerLogicalHandler6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerSOAPHandler4.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerSOAPHandler4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerSOAPHandler5.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerSOAPHandler5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerSOAPHandler6.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhandlerservice/ServerSOAPHandler6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhelloproviderservice/Hello2Impl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhelloproviderservice/Hello2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhelloproviderservice/Hello3Impl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhelloproviderservice/Hello3Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhelloproviderservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/dlhelloproviderservice/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/Hello2Impl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/Hello2Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/Hello3Impl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/Hello3Impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/ServerLogicalHandler.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/doclithelloservice/ServerLogicalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/doclitservice/J2WDLSharedEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/doclitservice/J2WDLSharedEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/faultservice/SoapFaultTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/faultservice/SoapFaultTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/hellosecureservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/hellosecureservice/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/GetTrackerDataImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/GetTrackerDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/ServerLogicalHandler5.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/ServerLogicalHandler5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/ServerSOAPHandler5.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/rlhandlerservice/ServerSOAPHandler5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/rpclitservice/J2WRLSharedEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/rpclitservice/J2WRLSharedEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/simpleservice/ConformanceClaimHandler.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/simpleservice/ConformanceClaimHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/simpleservice/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/simpleservice/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/sharedwebservices/xmlbinddlhelloproviderservice/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/sharedwebservices/xmlbinddlhelloproviderservice/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/util/PublishEndpoint.java
+++ b/src/com/sun/ts/tests/jaxws/util/PublishEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/ByteArrayBuffer.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/ByteArrayBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/DOMUtil.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/DOMUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/EprUtil.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/EprUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/MapException.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/MapException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/MapRequiredException.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/MapRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/MemberSubmissionAddressingFeature.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/MemberSubmissionAddressingFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/MemberSubmissionEndpointReference.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/MemberSubmissionEndpointReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/MissingAddressingHeaderException.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/MissingAddressingHeaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/W3CAddressingConstants.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/W3CAddressingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/WsaBaseSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/WsaBaseSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/common/WsaSOAPUtils.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/common/WsaSOAPUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/action/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl2.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl4.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/AddressingFeatureTestImpl4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/addressingfeature/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/AddNumbersImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/AddNumbersImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/AddNumbersImpl4.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/AddNumbersImpl4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor2.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/NonAnonymousRespProcessor2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/anonymous/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/MyEPR.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/epr/MyEPR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/refps/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/refps/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/refps/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/refps/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/refps/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/refps/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/requestresponse/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/typesubstitution/CarDealerImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/typesubstitution/CarDealerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/typesubstitution/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/j2w/document/literal/typesubstitution/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/action/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/AddressingFeatureTestImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/AddressingFeatureTestImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/AddressingFeatureTestImpl2.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/AddressingFeatureTestImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/AddressingFeatureTestImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/AddressingFeatureTestImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/addressingfeature/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/AddNumbersImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/AddNumbersImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/AddNumbersImpl4.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/AddNumbersImpl4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/NonAnonymousRespProcessor.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/NonAnonymousRespProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/NonAnonymousRespProcessor2.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/NonAnonymousRespProcessor2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/anonymous/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/delimiter/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/eprinwsdl/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/eprinwsdl/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/eprinwsdl/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/eprinwsdl/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/eprinwsdl/TestImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/eprinwsdl/TestImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/AddNumbersClient1.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/AddNumbersClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/oneway/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/providertest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/providertest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/providertest/ProviderTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/providertest/ProviderTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/refps/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/refps/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/refps/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/refps/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/AddNumbersImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/AddNumbersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/requiredfalse/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/ClientSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/ClientSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl2.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl21.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl21.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl3.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl31.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/RespectBindingFeatureTestImpl31.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/respectbindingfeature/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/typesubstitution/CarDealerImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/typesubstitution/CarDealerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/typesubstitution/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsa/w2j/document/literal/typesubstitution/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2201/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2201/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2204/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2204/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2210/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2210/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2716/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/document/literal/R2716/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1000/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1000/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1001/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1001/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1002/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1002/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1003/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1003/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1010/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1010/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1124/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1124/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1126/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R1126/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2001/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2001/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2002/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2002/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2003/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2003/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2004/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2004/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2005/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2005/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2007/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2007/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2022/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2022/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2023/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2023/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2101/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2101/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2102/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2102/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2105/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2105/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2110/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2110/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2111/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2111/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2112/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2112/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2203/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2203/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2205/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2205/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2206/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2206/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2207/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2207/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2301/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2301/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2303/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2303/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2304/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2304/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2305/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2305/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2306/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2306/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2401/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2401/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2701/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2701/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2702/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2702/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2705/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2705/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2710/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2710/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2717/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2717/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2718/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2718/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2720/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2720/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2721/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2721/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2723/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2723/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2724/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2724/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2725/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2725/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2726/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2726/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2749/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2749/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2754/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2754/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2801/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R2801/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R4003/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/j2w/rpc/literal/R4003/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/utils/DescriptionUtils.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/utils/DescriptionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/utils/SOAPUtils.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/utils/SOAPUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R1141/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R1141/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R1141/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R1141/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2030/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2030/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2707/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2707/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2709/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2709/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712ClientOne.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712ClientOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712ClientTwo.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712ClientTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712TestOneImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712TestOneImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712TestTwoImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2712/W2JDLR2712TestTwoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2747/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2747/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2748/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R2748/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R4002/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R4002/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R4003/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/R4003/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swareftest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swareftest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swareftest/SwaRefTestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swareftest/SwaRefTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestClient1.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestClient2.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestClient2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestImpl2.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/document/literal/swatest/SwaTestImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/R1005ConformanceChecker.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/R1005ConformanceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/W2JRLR1005Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1005/W2JRLR1005Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/R1006ConformanceChecker.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/R1006ConformanceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/W2JRLR1006Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1006/W2JRLR1006Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/R1007ConformanceChecker.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/R1007ConformanceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/W2JRLR1007Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1007/W2JRLR1007Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1011/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1011/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1011/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1011/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1012/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1012/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1012/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1012/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/R1014ConformanceChecker.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/R1014ConformanceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/W2JRLR1014Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1014/W2JRLR1014Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1015/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1015/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/W2JRLR1016Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/W2JRLR1016Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/XMLLangHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1016/XMLLangHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1027/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1027/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1027/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1027/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1027/W2JRLR1027Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1027/W2JRLR1027Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1141/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1141/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1141/HelloImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R1141/HelloImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/W2JRLR11XXTestOneImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/W2JRLR11XXTestOneImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/W2JRLR11XXTestTwoImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R11XX/W2JRLR11XXTestTwoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2009/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2009/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2009/W2JRLR2009Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2009/W2JRLR2009Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2009/W2JRLR2009TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2009/W2JRLR2009TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2010/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2010/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2010/W2JRLR2010Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2010/W2JRLR2010Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2010/W2JRLR2010TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2010/W2JRLR2010TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2011/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2011/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2011/W2JRLR2011TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2011/W2JRLR2011TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2030/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2030/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2105/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2105/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/R2113ConformanceChecker.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/R2113ConformanceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/W2JRLR2113Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2113/W2JRLR2113Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2114/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2114/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2114/W2JRLR2114TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2114/W2JRLR2114TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2706/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2706/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2707/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2707/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2709/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2709/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2714/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2714/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2714/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2714/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2714/W2JRLR2714Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2714/W2JRLR2714Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2728/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2728/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2729/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2729/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2738/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2738/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2738/W2JRLR2738Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2738/W2JRLR2738Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2738/W2JRLR2738TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2738/W2JRLR2738TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/R2739Handler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/R2739Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/W2JRLR2739Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2739/W2JRLR2739Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R273X/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R273X/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R273X/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R273X/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2744/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2744/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2744/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2744/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2745/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2745/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2745/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2745/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2747/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2747/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2748/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2748/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2751/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2751/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2751/W2JRLR2751Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2751/W2JRLR2751Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2751/W2JRLR2751TestImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2751/W2JRLR2751TestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/R2753Handler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/R2753Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/SimpleEndpointImpl.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/SimpleEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/W2JRLR2753Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R2753/W2JRLR2753Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R4001/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R4001/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R4002/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R4002/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R4003/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R4003/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R97XX/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R97XX/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R97XX/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/R97XX/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/Client.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/ServerSOAPHandler.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/ServerSOAPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/SwaTestClient1.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/SwaTestClient1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/SwaTestClient2.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/SwaTestClient2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/SwaTestImpl1.java
+++ b/src/com/sun/ts/tests/jaxws/wsi/w2j/rpc/literal/swatest/SwaTestImpl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Done by comparing the file contents from the `9.0.0` tag against current contents. For any files that had the exact same contents, sans copyright, the old file was restored as-is.

This is so we can see what has actually changed between the EE 9.0 and current 9.1 branches.  480 files were updated in copyright only.  We should either update all files or no files.
