### PR TITLE
#625 Fix 4 webservices12/sec failures due to TLS protocol

### DIFF
--- a/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/clientcert/Client.java
+++ b/src/com/sun/ts/tests/webservices12/sec/annotations/ejb/clientcert/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -68,6 +68,11 @@ public class Client extends EETest {
     try {
       hostname = props.getProperty("webServerHost");
       portnum = Integer.parseInt(props.getProperty("securedWebServicePort"));
+      String tlsVersion = p.getProperty("client.cert.test.jdk.tls.client.protocols");
+      if (tlsVersion != null) {
+        TestUtil.logMsg("client.cert.test.jdk.tls.client.protocols=" + tlsVersion);
+        System.setProperty("https.protocols", tlsVersion);		  
+      }
       urlString = ctsurl.getURLString(PROTOCOL, hostname, portnum,
           "/WSEjbClientCert/HelloService/Hello");
       HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {

--- a/src/com/sun/ts/tests/webservices12/sec/descriptors/ejb/certificate/Client.java
+++ b/src/com/sun/ts/tests/webservices12/sec/descriptors/ejb/certificate/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,6 +78,11 @@ public class Client extends EETest {
     try {
       hostname = p.getProperty("webServerHost");
       portnum = Integer.parseInt(p.getProperty("securedWebServicePort"));
+      String tlsVersion = p.getProperty("client.cert.test.jdk.tls.client.protocols");
+      if (tlsVersion != null) {
+        TestUtil.logMsg("client.cert.test.jdk.tls.client.protocols=" + tlsVersion);
+        System.setProperty("https.protocols", tlsVersion);		  
+      }
       urlString = ctsurl.getURLString(PROTOCOL, hostname, portnum,
           "/WSSecEjbCertificate/ejb");
       HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {


### PR DESCRIPTION
Use `client.cert.test.jdk.tls.client.protocols` to set `https.protocols` property

Tests:
```
com.sun.ts.tests.webservices12.sec.annotations.ejb.clientcert.Client.sayHelloDenyAll
com.sun.ts.tests.webservices12.sec.annotations.ejb.clientcert.Client.sayHelloPermitAll
com.sun.ts.tests.webservices12.sec.annotations.ejb.clientcert.Client.sayHelloProtected
com.sun.ts.tests.webservices12.sec.descriptors.ejb.certificate.Client.secEjbCertificate
```
The above four test are trying to display the login dialog and fail with:
```
test result: Failed. Test case throws exception: Can't connect to X11 window server using ':0.0' as the value of the DISPLAY variable.
````
Root Cause is the client-server negotiation with TLSv1.3 fails and fallbacks to login dialog. 