### PR TITLE
el tck fix for sigtest failure

### DIFF
--- a/docker/eltck.sh
+++ b/docker/eltck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,9 +76,9 @@ if [[ "$PROFILE" == "web" || "$PROFILE" == "WEB" ]]; then
   echo "javaee.level=web"  >> ts.jte
 fi
 
-if [ ! -z "$TCK_BUNDLE_BASE_URL" ]; then
-  sed -i 's#sigTestClasspath=.*#sigTestClasspath=\$\{el.classes\}\$\{pathsep\}\$\{JAVA_HOME\}/lib/rt.jar#g' ts.jte
-fi
+#if [ ! -z "$TCK_BUNDLE_BASE_URL" ]; then
+#  sed -i 's#sigTestClasspath=.*#sigTestClasspath=\$\{el.classes\}\$\{pathsep\}\$\{JAVA_HOME\}/lib/rt.jar#g' ts.jte
+#fi
 
 mkdir -p $TCK_HOME/${TCK_NAME}report/${TCK_NAME}
 mkdir -p $TCK_HOME/${TCK_NAME}work/${TCK_NAME}

--- a/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.el.sig_4.0_se11
+++ b/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.el.sig_4.0_se11
@@ -1,8 +1,8 @@
 #Signature file v4.1
-#Version 4.0_se8
+#Version 4.0_se11
 
 #
-# Copyright (c) 2014, 2020 Oracle and/or its affiliates and others.
+# Copyright (c) 2014, 2021 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the


### PR DESCRIPTION
changes to avoid overwriting of sigTestClasspath, when TCK is downloaded(not case of build + run). 
ts.jdk11 line overwritten by eltck.sh script is https://github.com/eclipse-ee4j/jakartaee-tck/blob/master/install/el/bin/ts.jte.jdk11#L78

Also changes include signature file header correction.

CI run with GF 6.1 JDK 11 - https://ci.eclipse.org/jakartaee-tck/blue/organizations/jenkins/guru%2Fjakartaee-tck-guru/detail/el-tck-fix/3/pipeline/50
CI run with GF 6.0 JDK 8 - https://ci.eclipse.org/jakartaee-tck/blue/organizations/jenkins/guru%2Fjakartaee-tck-guru/detail/el-tck-fix/4/pipeline/
Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>

