### PR TITLE
Fix the referenced jar-file element to match the jar files created in the build.xml

### DIFF
--- a/src/com/sun/ts/tests/jpa/ee/packaging/jar/persistence.xml
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/jar/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/jar/persistence.xml
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/jar/persistence.xml
@@ -27,8 +27,8 @@
         <jta-data-source>jdbc/DB1</jta-data-source>
         <mapping-file>myMappingFile.xml</mapping-file>
         <mapping-file>myMappingFile2.xml</mapping-file>
-        <jar-file>jpa_ee_packaging_jar_jarfile1.jar/</jar-file>
-        <jar-file>jpa_ee_packaging_jar_jarfile2.jar/</jar-file>
+        <jar-file>jpa_ee_packaging_jar1.jar/</jar-file>
+        <jar-file>jpa_ee_packaging_jar2.jar/</jar-file>
     </persistence-unit>
     <persistence-unit name="CTS-EM2" transaction-type="JTA">
         <description>Persistence Unit for CTS EE Package Tests</description>


### PR DESCRIPTION
Signed-off-by: Jean-Louis Monteiro <jlmonteiro@tomitribe.com>

This PR fixes the <jar-file> element of the persistence.xml to match the jar names created by the build.xml

They currently don't match which results in an undefined behaviour.
See https://github.com/eclipse-ee4j/jpa-api/issues/299 for more details

Glassfish seems to warn and ignore, but it's not portable.
In Apache TomEE it fails for instance.

