### PR TITLE
Use a transaction scoped EntityManager to set/get FlushMode

### DIFF
--- a/src/com/sun/ts/tests/jpa/core/enums/Client.java
+++ b/src/com/sun/ts/tests/jpa/core/enums/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/core/enums/Client.java
+++ b/src/com/sun/ts/tests/jpa/core/enums/Client.java
@@ -34,6 +34,7 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.FlushModeType;
@@ -975,6 +976,8 @@ public class Client extends PMClientBase {
   public void setgetFlushModeEntityManagerTest() throws Fault {
     boolean pass = true;
     try {
+      EntityTransaction t = getEntityTransaction();
+      t.begin();
       EntityManager em = getEntityManager();
       TestUtil.logTrace("Checking Default mode");
       FlushModeType fmt = em.getFlushMode();
@@ -1005,6 +1008,15 @@ public class Client extends PMClientBase {
     } catch (Exception e) {
       TestUtil.logErr("Caught exception: ", e);
       pass = false;
+
+    } finally {
+      try {
+        if (getEntityTransaction().isActive()) {
+          getEntityTransaction().rollback();
+        }
+      } catch (Exception fe) {
+        TestUtil.logErr("Unexpected exception rolling back TX:", fe);
+      }
     }
 
     if (!pass)


### PR DESCRIPTION
Signed-off-by: Jean-Louis Monteiro <jlmonteiro@tomitribe.com>

This PR fixes the set/get test for FlushMode
In short the EntityManager is not bound to a Transaction so the set and get of the FlushMode happens on a different instance.

More details available on this issue https://github.com/eclipse-ee4j/jpa-api/issues/300


