### PR TITLE
fix missing pictures in pdf guide

### DIFF
--- a/user_guides/jakartaee/pom.xml
+++ b/user_guides/jakartaee/pom.xml
@@ -134,6 +134,28 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <!-- copy imgs so pdf processor can find them -->
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/book</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/jbake/assets</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <configuration>
@@ -189,7 +211,7 @@
                     </execution>
                 </executions>
             </plugin>
-	    </plugins>
+        </plugins>
 
         <pluginManagement>
             <plugins>
@@ -197,6 +219,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.doc</groupId>


### PR DESCRIPTION
Fixes problem @edbratt found in platform pdf guide (see https://github.com/eclipse-ee4j/jakartaee-tck/pull/628#issuecomment-815209841)