### PR TITLE
Make sure TSSV Logger gets initialized

### DIFF
--- a/src/com/sun/ts/tests/jaspic/tssv/config/TSAuthConfigProviderServlet.java
+++ b/src/com/sun/ts/tests/jaspic/tssv/config/TSAuthConfigProviderServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,7 +41,7 @@ import jakarta.security.auth.message.config.ServerAuthConfig;
  */
 public class TSAuthConfigProviderServlet
     implements jakarta.security.auth.message.config.AuthConfigProvider {
-  private static TSLogger logger = TSLogger.getTSLogger(JASPICData.LOGGER_NAME);
+  private static TSLogger logger;
 
   private HashMap serverAuthConfigMap = new HashMap();
 
@@ -131,9 +131,9 @@ public class TSAuthConfigProviderServlet
       CallbackHandler handler) throws AuthException {
 
     logger.log(Level.INFO,
-        "WARNING:  shouldnt get into ClientAuthConfig() for servlet profile");
+        "WARNING:  shouldn't get into ClientAuthConfig() for servlet profile");
 
-    // shouldnt get in here for servlet profile
+    // shouldn't get in here for servlet profile
     return (ClientAuthConfig) null;
   }
 

--- a/src/com/sun/ts/tests/jaspic/tssv/config/TSAuthConfigProviderStandalone.java
+++ b/src/com/sun/ts/tests/jaspic/tssv/config/TSAuthConfigProviderStandalone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,7 +51,7 @@ public class TSAuthConfigProviderStandalone
   // this is a default string used for Persistent Registration description
   public static String DESC_KEY = "description_key";
 
-  private static TSLogger logger = TSLogger.getTSLogger(JASPICData.LOGGER_NAME);
+  private static TSLogger logger;
 
   private HashMap serverAuthConfigMap = new HashMap();
 


### PR DESCRIPTION
Signed-off-by: Jean-Louis Monteiro <jlmonteiro@tomitribe.com>

When the 2 args constructor is used which is the case when using an ACF other than the TS one.
More details available in the ticket https://github.com/eclipse-ee4j/authentication/issues/116