### PR TITLE
update userguide with ts.jte.jdk11 details

### DIFF
--- a/user_guides/Template/src/main/jbake/content/config.inc
+++ b/user_guides/Template/src/main/jbake/content/config.inc
@@ -64,7 +64,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `<ANT_HOME>/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI is running. +
@@ -239,7 +240,8 @@ Information,"] for information about repackaging the
   {TechnologyShortName} {TechnologyVersion} VI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `<ANT_HOME>/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   your Web server is running that is configured with the Vendor

--- a/user_guides/caj/src/main/jbake/content/config.inc
+++ b/user_guides/caj/src/main/jbake/content/config.inc
@@ -43,8 +43,9 @@ slashes as a path separator instead.
   b.  `TS_HOME` to the directory in which the {TechnologyShortName} TCK
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
-  +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+  +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`  
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `local.classes`
   property to point to a Jakarta Annotations CI classes/jars that contain the

--- a/user_guides/concurrency/src/main/jbake/content/config.inc
+++ b/user_guides/concurrency/src/main/jbake/content/config.inc
@@ -44,7 +44,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI is running. +
@@ -157,7 +158,8 @@ Information,"] for information about repackaging the
   {TechnologyShortName} {TechnologyVersion} VI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   your Web server is running that is configured with the Vendor
@@ -192,7 +194,8 @@ The porting package interface, `TSURLInterface.java`, obtains URL
 strings for web resources in an implementation-specific manner. API
 documentation for the `TSURLInterface.java` porting package interface is
 available in the {TechnologyShortName} TCK documentation bundle.
-4.  Edit your `<TS_HOME>/bin/ts.jte` file and set the porting.ts.url.class.1
+4.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the porting.ts.url.class.1
 property to point to your porting implementation class used for obtaining URLs.
 The default setting for the CI porting implementation is
 `com.sun.ts.lib.implementation.sun.common.SunRIURL.`

--- a/user_guides/connector/src/main/jbake/content/config.inc
+++ b/user_guides/connector/src/main/jbake/content/config.inc
@@ -46,7 +46,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI is running. +

--- a/user_guides/el/src/main/jbake/content/config.inc
+++ b/user_guides/el/src/main/jbake/content/config.inc
@@ -44,7 +44,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  `el.classes` to the Expression Language API and implementation
   classes that are under test +

--- a/user_guides/jacc/src/main/jbake/content/config.inc
+++ b/user_guides/jacc/src/main/jbake/content/config.inc
@@ -44,7 +44,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `jacc.home` property to the installation directory of Jakarta EE
   8 CI.
@@ -100,7 +101,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `jacc.home` property to the installation directory of Jakarta EE
   9 CI.

--- a/user_guides/jakartaee/src/main/jbake/content/config.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/config.adoc
@@ -1013,6 +1013,7 @@ as well.
 5.4.8.1 To Configure Your Environment to Run the Jakarta RESTful Web Services Tests Against the Jakarta EE 9 CI
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
 Edit your `<TS_HOME>/bin/ts.jte` file and set the following environment
 variables:
 
@@ -1064,6 +1065,7 @@ the tests, you need to repackage the WAR files that contain the Jakarta RESTful 
 tests and the VI-specific Servlet class that will be deployed on the
 vendor's Jakarta EE 9-compliant application server.
 
+Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
 Edit your `<TS_HOME>/bin/ts.jte` file and set the following properties:
 
 .  Set the `jaxrs_impl_lib` property to point to the JAR file that

--- a/user_guides/jakartaee/src/main/jbake/content/using.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/using.adoc
@@ -91,7 +91,8 @@ targets for the Jakarta EE 9 Platform TCK test suite
 1.  Set the `TS_HOME` environment variable to the directory in which the
 Jakarta EE 9 Platform TCK is installed.
 2.  Change to the `<TS_HOME>/bin` directory.
-3.  Ensure that the `ts.jte` file contains information relevant to your
+3.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte for JakartaEE 9.1.
+Ensure that the `ts.jte` file contains information relevant to your
 setup. +
 Refer to link:config.html#GBFVV[Chapter 5, "Setup and Configuration,"]
 for detailed configuration instructions.

--- a/user_guides/jaspic/src/main/jbake/content/config.inc
+++ b/user_guides/jaspic/src/main/jbake/content/config.inc
@@ -61,7 +61,8 @@ property in the `ts.jte` file to `standalone`.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  `pathsep` to the type of path separator used by your operating
   system +

--- a/user_guides/jaxrs/src/main/jbake/content/config.inc
+++ b/user_guides/jaxrs/src/main/jbake/content/config.inc
@@ -64,7 +64,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI is running. +
@@ -239,7 +240,8 @@ Information,"] for information about repackaging the
   {TechnologyShortName} {TechnologyVersion} VI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   your Web server is running that is configured with the Vendor

--- a/user_guides/jaxws/src/main/jbake/content/config.adoc
+++ b/user_guides/jaxws/src/main/jbake/content/config.adoc
@@ -429,7 +429,8 @@ installation is `C:\JakartaEE9`, you must specify it as `C:\\JakartaEE9` or
   b.  `TS_HOME` to the directory in which the {TechnologyShortName} TCK 3.0 software is
   installed
   c.  `ANT_HOME` should be set in your environment.
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the hostname where the web
   server for the Vendor Implementation is running. +

--- a/user_guides/jms/src/main/jbake/content/config.inc
+++ b/user_guides/jms/src/main/jbake/content/config.inc
@@ -50,7 +50,8 @@ installed
 * `JMS_HOME` to the directory in which the {TechnologyShortName} {TechnologyVersion} CI has been installed
 * `PATH` to include the following directories: `JAVA_HOME/bin`,
 `JMS_HOME/bin`, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 properties:
 * `jms.home` to the directory in which you installed your {TechnologyShortName} {TechnologyVersion}
 implementation

--- a/user_guides/jpa/src/main/jbake/content/config.inc
+++ b/user_guides/jpa/src/main/jbake/content/config.inc
@@ -44,7 +44,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set `jpa.classes` to include all of the necessary JAR files that
   pertain to your implementation.

--- a/user_guides/jsf/src/main/jbake/content/config.inc
+++ b/user_guides/jsf/src/main/jbake/content/config.inc
@@ -34,7 +34,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `<ANT_HOME>/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI is running. +

--- a/user_guides/jsonb/src/main/jbake/content/config.inc
+++ b/user_guides/jsonb/src/main/jbake/content/config.inc
@@ -44,7 +44,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `jsonb.classes` property to the jar file(s) that contain
   the {TechnologyShortName} implementation. +
@@ -85,7 +86,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `jsonb.classes` property to the jar file(s) that contain
   the {TechnologyShortName} implementation.

--- a/user_guides/jsonp/src/main/jbake/content/config.adoc
+++ b/user_guides/jsonp/src/main/jbake/content/config.adoc
@@ -83,7 +83,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   e.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a. `jsonp.classes` to the JAR file(s) that contain your {TechnologyShortName} {TechnologyVersion}
   implementation classes +
@@ -141,7 +142,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   e.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a. `jsonp.classes` to the JAR file(s) that contain your {TechnologyShortName} {TechnologyVersion}
   implementation classes

--- a/user_guides/jsp/src/main/jbake/content/config.inc
+++ b/user_guides/jsp/src/main/jbake/content/config.inc
@@ -46,7 +46,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI (for example {TechnologyRI}) is running. +

--- a/user_guides/jstl/src/main/jbake/content/config.inc
+++ b/user_guides/jstl/src/main/jbake/content/config.inc
@@ -46,7 +46,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   CI (for example, {TechnologyRI}), is running. +

--- a/user_guides/jta/src/main/jbake/content/config.inc
+++ b/user_guides/jta/src/main/jbake/content/config.inc
@@ -46,7 +46,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  If you are testing an implementation within a Web container, set the
   `webServerHost` property to the name of the host on which your Web
@@ -119,7 +120,8 @@ will be run and determine to which Servlet–compliant Web server the
   {TechnologyShortName} {TechnologyVersion} VI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +`{TechnologyHomeEnv}/bin`+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  If you are testing an implementation within a Web container, set the
   `webServerHost` property to the name of the host on which your Web

--- a/user_guides/saaj/src/main/jbake/content/config.adoc
+++ b/user_guides/saaj/src/main/jbake/content/config.adoc
@@ -68,7 +68,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   Jakarta EE {JakartaEEVersion} CI is running. +
@@ -176,7 +177,8 @@ Information,"] for information about repackaging the
   {TechnologyShortName} {TechnologyVersion} VI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   your Web server is running that is configured with the Vendor
@@ -211,7 +213,8 @@ The porting package interface, `TSURLInterface.java`, obtains URL
 strings for web resources in an implementation-specific manner. API
 documentation for the `TSURLInterface.java` porting package interface is
 available in the {TechnologyShortName} TCK documentation bundle.
-4.  Edit your `<TS_HOME>/bin/ts.jte` file and set the porting.ts.url.class.1
+4.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the porting.ts.url.class.1
 property to point to your porting implementation class used for obtaining URLs.
 The default setting for the CI porting implementation is
 `com.sun.ts.lib.implementation.sun.common.SunRIURL.`

--- a/user_guides/securityapi/src/main/jbake/content/config.inc
+++ b/user_guides/securityapi/src/main/jbake/content/config.inc
@@ -44,7 +44,8 @@ slashes as a path separator instead.
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set `securityapi.classes` to include all necessary JAR files that
   pertain to your implementation.

--- a/user_guides/websocket/src/main/jbake/content/config.inc
+++ b/user_guides/websocket/src/main/jbake/content/config.inc
@@ -46,7 +46,8 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `<TS_HOME>/tools/ant/bin`
-2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
+Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  `webServerHost` to the name of the host on which your {TechnologyFullName} 
   {TechnologyVersion} implementation is running.


### PR DESCRIPTION

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/636

**Describe the change**
Added information in the useguide to copy the ts.jte.jdk11 as ts.jte when the TCK is run with Java set as JDK11.

