### PR TITLE
JSONB TCK user guide update

### DIFF
--- a/user_guides/jsonb/src/main/jbake/content/config.inc
+++ b/user_guides/jsonb/src/main/jbake/content/config.inc
@@ -50,7 +50,7 @@ environment variables:
   a.  Set the `jsonb.classes` property to the jar file(s) that contain
   the {TechnologyShortName} implementation. +
   For example, if you were using the {TechnologyFullName} {TechnologyVersion} RI, you would set
-  this property to `jsonb.classes=jakarta.json.bind-{TechnologyVersion}.jar`.
+  this property to `jsonb.classes=yasson-{TechnologyVersion}.jar`.
   b. It is also needed to add all of the runtime dependencies required by the implementation.
   Add these dependencies as another entries to the `jsonb.classes` property. Use
   proper separator between the entries (`;` on Windows, `:` on UNIX/Linux).

--- a/user_guides/jsonb/src/main/jbake/content/config.inc
+++ b/user_guides/jsonb/src/main/jbake/content/config.inc
@@ -39,7 +39,7 @@ slashes as a path separator instead.
 
 
 1.  Set the following environment variables in your shell environment:
-  a.  `JAVA_HOME` to the directory in which Java SE 8 is installed
+  a.  `JAVA_HOME` to the directory in which Java SE 8 or Java SE 11 is installed
   b.  `TS_HOME` to the directory in which the {TechnologyShortName} TCK
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
@@ -51,6 +51,9 @@ environment variables:
   the {TechnologyShortName} implementation. +
   For example, if you were using the {TechnologyFullName} {TechnologyVersion} RI, you would set
   this property to `jsonb.classes=jakarta.json.bind-{TechnologyVersion}.jar`.
+  b. It is also needed to add all of the runtime dependencies required by the implementation.
+  Add these dependencies as another entries to the `jsonb.classes` property. Use
+  proper separator between the entries (`;` on Windows, `:` on UNIX/Linux).
 
 [[GCLHU]][[configuring-your-environment-to-repackage-and-run-the-tck-against-the-vendor-implementation]]
 
@@ -81,7 +84,7 @@ slashes as a path separator instead.
 
 
 1.  Set the following environment variables in your shell environment:
-  a.  `JAVA_HOME` to the directory in which Java SE 8 is installed
+  a.  `JAVA_HOME` to the directory in which Java SE 8 or Java SE 11 is installed
   b.  `TS_HOME` to the directory in which the {TechnologyShortName} TCK
   {TechnologyVersion} software is installed
   c.  `PATH` to include the following directories: `JAVA_HOME/bin`,
@@ -91,6 +94,9 @@ Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `jsonb.classes` property to the jar file(s) that contain
   the {TechnologyShortName} implementation.
+  b. It is also needed to add all of the runtime dependencies required by the implementation.
+  Add these dependencies as another entries to the `jsonb.classes` property. Use
+  proper separator between the entries (`;` on Windows, `:` on UNIX/Linux).
 
 
 [[GHGDG]][[publishing-the-test-applications]]


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request for a Platform TCK change
title: 'User guide Jakarta JSONB TCK (JSONB 2.0)'
labels: ''
assignees: ''

---

**Fixes Issue**
N/A

**Related Issue(s)**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/694

**Describe the change**
Java SE 11 was not mentioned as JAVA_HOME option.
Explicitly clarified the need to have impl runtime dependencies and where to add them.
Changed the default RI name in example

**Additional context**
N/A

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman
