### PR TITLE
avoid cleaning of default values for sigtestclasspath and jdbc.classes in ts.jte

### DIFF
--- a/release/tools/jsp.xml
+++ b/release/tools/jsp.xml
@@ -78,8 +78,11 @@
 				<property name="impl.deploy.timeout.multiplier" value="" />
 				<property name="jspservlet.classes" value="" />
 				<property name="jstl.classes" value="" />
-                                <property name="el.classes" value="" />
-				<property name="sigTestClasspath" value="" />
+                <property name="el.classes" value="" />
+                <!-- retain default sigtestclasspath for GF 8 run -->
+                <!--
+            	<property name="sigTestClasspath" value="" />
+                -->
 			</props.sanitizer>
 		</target>
 

--- a/release/tools/jstl.xml
+++ b/release/tools/jstl.xml
@@ -91,10 +91,16 @@
 			<property name="jstl.db.driver" value="" />
 			<property name="jstl.db.user" value="" />
 			<property name="jstl.db.password" value="" />
+			<!-- retain default jdbc.classes for GF 8 run -->
+			<!--
 			<property name="jdbc.classes" value="" />
+			-->
 			<property name="jspservlet.classes" value="" />
 			<property name="jstl.classes" value="" />
+			<!-- retain default sigtestclasspath for GF 8 run -->
+			<!--
 			<property name="sigTestClasspath" value="" />
+			-->
 		</props.sanitizer>
 	</target>
 


### PR DESCRIPTION
default value for sigtestclasspath and jdbc.classes set in ts.jte is cleared by props.sanitizer, this is resulting in JDK 8 + GF 6.0 combination with  JSTL TCK & JSP TCK to fail.(CI run - https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/master/1417/)

Fix run -
GF 6.1 + JDK 11 + Standalone TCK - https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/jdk8-fix/6/testReport/
GF 6.0 + JDK 8 + Standalone TCK - https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-guru/job/jdk8-fix/3/testReport/

Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>
