### PR TITLE
remove unneeded jakarta.resource.spi.SecurityException from SigTestDriver as that shouldn't be excluded

### DIFF
--- a/src/com/sun/ts/tests/signaturetest/SigTestDriver.java
+++ b/src/com/sun/ts/tests/signaturetest/SigTestDriver.java
@@ -77,7 +77,6 @@ public class SigTestDriver extends SignatureTestDriver {
           "java.lang.InterruptedException",
           "java.lang.CloneNotSupportedException",
           "java.lang.Throwable",
-          "jakarta.resource.spi.SecurityException",
           "java.lang.Thread",
           "java.lang.Enum"
   };


### PR DESCRIPTION
Address https://github.com/eclipse-ee4j/jakartaee-tck/pull/720#discussion_r616244685

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow

I verified locally with WildFly:
```
[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java#signatureTest_from_appclient
[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java#signatureTest_from_ejb
[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java#signatureTest_from_jsp
[javatest.batch] PASSED........com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java#signatureTest_from_servlet

```