### PR TITLE
Jsonb-api TCK test changes need backport to the jakartaee-tck

### DIFF
--- a/src/com/sun/ts/tests/jsonb/SimpleMappingTester.java
+++ b/src/com/sun/ts/tests/jsonb/SimpleMappingTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -40,9 +41,11 @@ public class SimpleMappingTester<T> {
   private final Jsonb jsonb = JsonbBuilder.create();
 
   private final Class<T> typeClass;
+  private final Class<? super T> serializationType;
 
-  public SimpleMappingTester(Class<T> typeClass) {
-    this.typeClass = typeClass;
+  public SimpleMappingTester(Class<T> typeClass, Class<? super T> serializationType) {
+      this.typeClass = Objects.requireNonNull(typeClass);
+      this.serializationType = Objects.requireNonNull(serializationType);
   }
 
   public Status test(T value, String expectedRepresentationPattern,
@@ -113,7 +116,7 @@ public class SimpleMappingTester<T> {
   }
 
   private Status testMarshallingByType(T value, String expectedRepresentation) {
-    String jsonString = jsonb.toJson(value, TypeContainer.class);
+    String jsonString = jsonb.toJson(value, serializationType);
     if (jsonString.matches(expectedRepresentation)) {
       return Status.passed("OK");
     } else {

--- a/src/com/sun/ts/tests/jsonb/defaultmapping/basictypes/BasicJavaTypesMappingTest.java
+++ b/src/com/sun/ts/tests/jsonb/defaultmapping/basictypes/BasicJavaTypesMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ package com.sun.ts.tests.jsonb.defaultmapping.basictypes;
 
 import static com.sun.ts.tests.jsonb.MappingTester.combine;
 
+import com.sun.ts.tests.jsonb.TypeContainer;
 import java.math.BigDecimal;
 import java.util.Properties;
 
@@ -245,7 +246,7 @@ public class BasicJavaTypesMappingTest extends ServiceEETest {
    * java.math.BigDecimal using String constructor
    */
   public Status testNumberMapping() throws Fault {
-    return new SimpleMappingTester<>(NumberContainer.class).test(
+      return new SimpleMappingTester<>(NumberContainer.class, TypeContainer.class).test(
         new NumberContainer(), "\\{\\s*\"instance\"\\s*:\\s*0[\\.0]?+\\s*}",
         "{ \"instance\" : 0 }", new NumberContainer() {
           {

--- a/src/com/sun/ts/tests/jsonb/defaultmapping/jsonptypes/JSONPTypesMappingTest.java
+++ b/src/com/sun/ts/tests/jsonb/defaultmapping/jsonptypes/JSONPTypesMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -440,6 +440,25 @@ public class JSONPTypesMappingTest extends ServiceEETest {
           "Failed to unmarshal object with JsonNumber attribute value.");
     }
 
+    return Status.passed("OK");
+  }
+  
+  /*
+   * @testName: testNullDeserializedToJsonValueNull
+   *
+   * @assertion_ids: JSONB:SPEC:JSB-3.20
+   *
+   * @test_Strategy: Assert that null is properly deserialized to the JsonValue.NULL
+   */
+  public Status testNullDeserializedToJsonValueNull() throws Fault {
+    JsonValueContainer unmarshalledValue = jsonb.fromJson("{ \"instance\" : null }", JsonValueContainer.class);
+    if (JsonValue.NULL != unmarshalledValue.getInstance()) {
+        throw new Fault("Failed to unmarshal null value to the JsonValue.NULL");
+    }
+    unmarshalledValue = jsonb.fromJson("{}", JsonValueContainer.class);
+    if (unmarshalledValue.getInstance() != null) {
+        throw new Fault("Failed to unmarshal object with JsonNumber attribute value.");
+    }
     return Status.passed("OK");
   }
 }

--- a/src/com/sun/ts/tests/jsonb/defaultmapping/specifictypes/SpecificTypesMappingTest.java
+++ b/src/com/sun/ts/tests/jsonb/defaultmapping/specifictypes/SpecificTypesMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,9 @@
  */
 
 package com.sun.ts.tests.jsonb.defaultmapping.specifictypes;
+
+
+import com.sun.ts.tests.jsonb.TypeContainer;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -158,7 +161,7 @@ public class SpecificTypesMappingTest extends ServiceEETest {
     simpleContainer.setStringInstance("String Value");
     container.setInstance(Optional.of(simpleContainer));
 
-    return new SimpleMappingTester<>(OptionalTypeContainer.class).test(
+    return new SimpleMappingTester<>(OptionalTypeContainer.class, TypeContainer.class).test(
         container,
         "\\{\\s*\"instance\"\\s*:\\s*\\{\\s*\"stringInstance\"\\s*:\\s*\"String Value\"\\s*}\\s*}",
         "{ \"instance\" : { \"stringInstance\" : \"String Value\" } }",
@@ -178,7 +181,7 @@ public class SpecificTypesMappingTest extends ServiceEETest {
   public Status testEmptyOptionalMapping() throws Fault {
     OptionalContainer optionalContainer = new OptionalContainer();
     optionalContainer.setInstance(Optional.empty());
-    return new SimpleMappingTester<>(OptionalContainer.class).test(
+    return new SimpleMappingTester<>(OptionalContainer.class, TypeContainer.class).test(
         optionalContainer, "\\{\\s*}", "{ \"instance\" : null }",
         optionalContainer);
   }
@@ -197,7 +200,7 @@ public class SpecificTypesMappingTest extends ServiceEETest {
   public Status testEmptyOptionalArrayMapping() throws Fault {
     OptionalArrayContainer optionalContainer = new OptionalArrayContainer();
     optionalContainer.setInstance(new Optional[] { Optional.empty() });
-    return new SimpleMappingTester<>(OptionalArrayContainer.class).test(
+    return new SimpleMappingTester<>(OptionalArrayContainer.class, TypeContainer.class).test(
         optionalContainer, "\\{\\s*\"instance\"\\s*:\\s*\\[\\s*null\\s*]\\s*}",
         "{ \"instance\" : [ null ] }", optionalContainer);
   }
@@ -229,7 +232,7 @@ public class SpecificTypesMappingTest extends ServiceEETest {
   public Status testEmptyOptionalIntMapping() throws Fault {
     OptionalIntContainer optionalContainer = new OptionalIntContainer();
     optionalContainer.setInstance(OptionalInt.empty());
-    return new SimpleMappingTester<>(OptionalIntContainer.class).test(
+    return new SimpleMappingTester<>(OptionalIntContainer.class, TypeContainer.class).test(
         optionalContainer, "\\{\\s*}", "{ \"instance\" : null }",
         optionalContainer);
   }
@@ -261,7 +264,7 @@ public class SpecificTypesMappingTest extends ServiceEETest {
   public Status testEmptyOptionalLongMapping() throws Fault {
     OptionalLongContainer optionalContainer = new OptionalLongContainer();
     optionalContainer.setInstance(OptionalLong.empty());
-    return new SimpleMappingTester<>(OptionalLongContainer.class).test(
+    return new SimpleMappingTester<>(OptionalLongContainer.class, TypeContainer.class).test(
         optionalContainer, "\\{\\s*}", "{ \"instance\" : null }",
         optionalContainer);
   }
@@ -293,7 +296,7 @@ public class SpecificTypesMappingTest extends ServiceEETest {
   public Status testEmptyOptionalDoubleMapping() throws Fault {
     OptionalDoubleContainer optionalContainer = new OptionalDoubleContainer();
     optionalContainer.setInstance(OptionalDouble.empty());
-    return new SimpleMappingTester<>(OptionalDoubleContainer.class).test(
+    return new SimpleMappingTester<>(OptionalDoubleContainer.class, TypeContainer.class).test(
         optionalContainer, "\\{\\s*}", "{ \"instance\" : null }",
         optionalContainer);
   }

--- a/src/com/sun/ts/tests/jsonb/defaultmapping/untyped/UntypedMappingTest.java
+++ b/src/com/sun/ts/tests/jsonb/defaultmapping/untyped/UntypedMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -127,7 +127,7 @@ public class UntypedMappingTest extends ServiceEETest {
    * java.util.List<Object>
    */
   public Status testArrayMapping() throws Fault {
-    return new SimpleMappingTester<>(List.class).test(
+      return new SimpleMappingTester<>(List.class, List.class).test(
         Arrays.asList("Test String"), "\\[\\s*\"Test String\"s*\\]",
         "[ \"Test String\" ]", Arrays.asList("Test String"));
   }


### PR DESCRIPTION
**Fixes Issue**
https://github.com/eclipse-ee4j/jsonb-api/issues/281

**Related Issue(s)**
https://github.com/eclipse-ee4j/jsonb-api/issues/181
https://github.com/eclipse-ee4j/jsonb-api/issues/267

**Describe the change**
- Deserialization from null to JsonValue
- UntypedMappingTest.testArrayMapping tck test should fail

**Additional context**

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
