### PR TITLE
Update Jakarta Contexts and Dependency Injection (CDI) beans schemas

### DIFF
--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
@@ -18,7 +18,7 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="none">
 </beans>

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
@@ -18,7 +18,7 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="none">
 </beans>

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
@@ -18,7 +18,7 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="none">
 </beans>

--- a/src/com/sun/ts/tests/jaxrs/platform/managedbean299/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/managedbean299/beans.xml
@@ -18,5 +18,5 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
 </beans>

--- a/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
@@ -18,7 +18,7 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="none">
 </beans>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/resources/beans.xml
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/resources/beans.xml
@@ -17,5 +17,5 @@
 -->
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
 </beans>

--- a/src/com/sun/ts/tests/jsf/spec/flows/common/beans.xml
+++ b/src/com/sun/ts/tests/jsf/spec/flows/common/beans.xml
@@ -20,5 +20,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
         https://jakarta.ee/xml/ns/jakartaee 
-        https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+        https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
 </beans>

--- a/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/beans.xml
+++ b/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/beans.xml
@@ -18,5 +18,5 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
 </beans>

--- a/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/beans.xml
+++ b/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/beans.xml
@@ -18,5 +18,5 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
 </beans>

--- a/src/com/sun/ts/tests/websocket/platform/cdi/beans.xml
+++ b/src/com/sun/ts/tests/websocket/platform/cdi/beans.xml
@@ -18,5 +18,5 @@
 
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
 </beans>


### PR DESCRIPTION
Signed-off-by: Suhrid Karthik <suhridk@gmail.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/751

**Related Issue(s)**
None

**Describe the change**
Changed existing EE9 beans_3_0.xsd schema references to EE10 beans_4_0.xsd

**Additional context**
Will create separate PRs to update other EE10 references

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
