### PR TITLE
signature test generation should include new jakarta.websocket-client-api.jar artifact

### DIFF
--- a/docker/build_signatures.sh
+++ b/docker/build_signatures.sh
@@ -88,6 +88,7 @@ $JAKARTA_JARS/jakarta.servlet.jsp.jstl-api.jar${pathsep}\
 $JAKARTA_JARS/jakarta.transaction-api.jar${pathsep}\
 $JAKARTA_JARS/jakarta.validation-api.jar${pathsep}\
 $JAKARTA_JARS/jakarta.websocket-api.jar${pathsep}\
+$JAKARTA_JARS/jakarta.websocket-client-api.jar${pathsep}\
 $JAKARTA_JARS/jakarta.ws.rs-api.jar${pathsep}\
 $JAKARTA_JARS/jakarta.xml.bind-api.jar${pathsep}\
 $JAKARTA_JARS/webservices-api.jar${pathsep}\

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -224,6 +224,12 @@
     </dependency>
     <dependency>
         <groupId>jakarta.websocket</groupId>
+        <artifactId>jakarta.websocket-client-api</artifactId>
+        <version>${websocket-api.version}</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.websocket</groupId>
         <artifactId>jakarta.websocket-api</artifactId>
         <version>${websocket-api.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

We should regenerate TCK signature map files after merging this change and https://github.com/eclipse-ee4j/jakartaee-tck/pull/802

This change will address the following failure (copied from https://ci.eclipse.org/jakartaee-tck/job/10/job/build-signatures/14/console):
```
Fatal error: class jakarta.websocket.WebSocketContainer not found
Fatal error: class jakarta.websocket.EndpointConfig not found
Warning: class jakarta.websocket.Endpoint not found. Please, add required jar or directory to the classpath.
Warning: class jakarta.websocket.Extension not found. Please, add required jar or directory to the classpath.
Warning: class jakarta.websocket.Decoder not found. Please, add required jar or directory to the classpath.
Warning: class jakarta.websocket.Encoder not found. Please, add required jar or directory to the classpath.
Warning: class jakarta.websocket.HandshakeResponse not found. Please, add required jar or directory to the classpath.
Selected by -Package: 9 classes
Written to sigfile: 11 classes(and 2 inner classes)
STATUS:Failed.7 errors
```