### PR TITLE
Update Jakarta application deployment descriptor schemas

### DIFF
--- a/src/com/sun/ts/tests/appclient/deploy/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>appclient_dep_compat12_13</display-name>
   <module>
     <java>appclient_dep_compat12_13_client.jar</java>

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat12_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat12_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat12_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat13_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat13_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat13_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/compat14_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>appclient_dep_compat14_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application.xml
+++ b/src/com/sun/ts/tests/appclient/deploy/metadatacomplete/testapp/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <ejb>testApp_ejb.jar</ejb>
   </module>

--- a/src/com/sun/ts/tests/assembly/altDD/application.xml
+++ b/src/com/sun/ts/tests/assembly/altDD/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/altDD/application.xml
+++ b/src/com/sun/ts/tests/assembly/altDD/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_altDD</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/classpath/appclient/application.xml
+++ b/src/com/sun/ts/tests/assembly/classpath/appclient/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/classpath/appclient/application.xml
+++ b/src/com/sun/ts/tests/assembly/classpath/appclient/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
 <display-name>assembly_classpath_appclient</display-name>
 <module>

--- a/src/com/sun/ts/tests/assembly/classpath/ejb/application.xml
+++ b/src/com/sun/ts/tests/assembly/classpath/ejb/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/classpath/ejb/application.xml
+++ b/src/com/sun/ts/tests/assembly/classpath/ejb/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
 <display-name>assembly_classpath_ejb</display-name>
 <module>

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_cocktail_compat12_13</display-name>
   <module>
     <java>assembly_compat_cocktail_compat12_13_another_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_13/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_cocktail_compat12_14</display-name>
   <module>
     <java>assembly_compat_cocktail_compat12_14_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat12_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_cocktail_compat12_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat13_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_cocktail_compat13_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/cocktail/compat14_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_cocktail_compat14_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_13/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_13/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_single_compat12_13</display-name>
   <module>
     <java>assembly_compat_single_compat12_13_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_single_compat12_14</display-name>
   <module>
     <java>assembly_compat_single_compat12_14_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_single_compat12_50</display-name>
   <description>Application description</description>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_single_compat13_14</display-name>
   <module>
     <java>assembly_compat_single_compat13_14_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat13_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 
   <display-name>assembly_compat_single_compat13_50</display-name>
   <description>Application description</description>

--- a/src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/single/compat14_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 
   <display-name>assembly_compat_single_compat14_50</display-name>
   <description>Application description</description>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_13/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_standalone_jar_compat12_13</display-name>
   <module>
     <java>assembly_compat_standalone_jar_compat12_13_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_jar_compat12_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat12_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 
   <display-name>assembly_compat_standalone_jar_compat12_50</display-name>
   <description>Application description</description>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_jar_compat13_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat13_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_jar_compat13_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/jar/compat14_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_jar_compat14_50</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_13/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_13/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_13/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>assembly_compat_standalone_war_compat12_13</display-name>
   <module>
     <java>assembly_compat_standalone_war_compat12_13_client.jar</java>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_war_compat12_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 
   <description>Application description</description>
   <display-name>assembly_compat_standalone_war_compat12_50</display-name>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat12_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat13_14/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat13_14/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat13_14/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application version="9" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>assembly_compat_standalone_war_compat13_14</display-name>
   <module>

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
+++ b/src/com/sun/ts/tests/assembly/compat/standalone/war/compat14_50/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 
   <description>Application description</description>
   <display-name>assembly_compat_standalone_war_compat14_50</display-name>

--- a/src/com/sun/ts/tests/connector/resourceDefs/ejb/application.xml
+++ b/src/com/sun/ts/tests/connector/resourceDefs/ejb/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/connector/resourceDefs/ejb/application.xml
+++ b/src/com/sun/ts/tests/connector/resourceDefs/ejb/application.xml
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <initialize-in-order>true</initialize-in-order>
 
   

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/application.xml.template
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/application.xml.template
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/application.xml.template
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/appclientejb/application.xml.template
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <java>ejb3_assembly_appres_appclientejb_client.jar</java>
   </module>

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/warejb/application.xml.template
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/warejb/application.xml.template
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/warejb/application.xml.template
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/warejb/application.xml.template
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <web>
       <web-uri>ejb3_assembly_appres_warejb_web.war</web-uri>

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/warmbean/application.xml.template
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/warmbean/application.xml.template
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/appres/warmbean/application.xml.template
+++ b/src/com/sun/ts/tests/ejb30/assembly/appres/warmbean/application.xml.template
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <web>
       <web-uri>ejb3_assembly_appres_warmbean_web.war</web-uri>

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/application.xml
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <application-name>renamed2</application-name>
   <initialize-in-order>true</initialize-in-order>
 

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/ejbwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/ejbwar/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/ejbwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/ejbwar/application.xml
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <initialize-in-order>true</initialize-in-order>
 
   <module>

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/warejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/warejb/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/initorder/warejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/initorder/warejb/application.xml
@@ -18,7 +18,7 @@
 -->
 
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+  version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <application-name>renamed</application-name>
   <initialize-in-order>true</initialize-in-order>
   <module>

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <module>
 <java>ejb3_assembly_librarydirectory_custom_client.jar</java>
 </module>

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/custom/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/librarydirectory/disable/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <module>
 <java>ejb3_assembly_librarydirectory_disable_client.jar</java>
 </module>

--- a/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
+++ b/src/com/sun/ts/tests/ejb30/assembly/metainfandlibdir/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <module>
 <web>
 <web-uri>ejb3_assembly_metainfandlibdir_web.war</web-uri>

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/jarwar/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <java>mdb_dest_jarwar_client.jar</java>
   </module>

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/mdb/dest/topic/jarwar/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <java>mdb_dest_topic_jarwar_client.jar</java>
   </module>

--- a/src/com/sun/ts/tests/ejb30/common/template/application.xml
+++ b/src/com/sun/ts/tests/ejb30/common/template/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/common/template/application.xml
+++ b/src/com/sun/ts/tests/ejb30/common/template/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <display-name>@DISPLAY_NAME@</display-name>
   <module>
     <java>@CLIENT_JAR@</java>

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
+++ b/src/com/sun/ts/tests/ejb30/misc/metadataComplete/warejb/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <module>
     <web>
       <web-uri>misc_metadataComplete_warejb_web.war</web-uri>

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>clientviewClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/clientview/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>clientview</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>clientviewClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/interceptor/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>clientview</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>clientviewClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
+++ b/src/com/sun/ts/tests/ejb30/webservice/wscontext/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>clientview</display-name>
   <module>

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Simple example of application</display-name>
   <description>Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application2.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application2.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomfeature/contentRoot/application2.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Second Simple example of application</display-name>
   <description>Second Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Simple example of application</display-name>
   <description>Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication2.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication2.xml
+++ b/src/com/sun/ts/tests/jaxws/ee/w2j/document/literal/mtomtest/contentRoot/WSW2JDLMTOMTestapplication2.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Second Simple example of application</display-name>
   <description>Second Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>cditestsejbweb</display-name>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/mdb/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/mdb/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>cditestsmdb</display-name>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/cditests/mdb/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/mdb/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee20/cditests/usecases/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/usecases/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee20/cditests/usecases/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/usecases/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>cditestsusecases</display-name>
   <module>

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>resourcedefs_annotations</display-name>
   <module>

--- a/src/com/sun/ts/tests/jpa/ee/packaging/web/scope/application.xml
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/web/scope/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/packaging/web/scope/application.xml
+++ b/src/com/sun/ts/tests/jpa/ee/packaging/web/scope/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
     <module>
         <web>
             <web-uri>jpa_ee_packaging_web_scope_web.war</web-uri>

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/application.xml
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/application.xml
+++ b/src/com/sun/ts/tests/jpa/ee/propagation/cm/jta/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
     <module>
         <web>
             <web-uri>jpa_ee_propagation_cm_jta_web.war</web-uri>

--- a/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
+++ b/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
+++ b/src/com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpsessionx/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
 <display-name>servlet_spec_crosscontext</display-name>
 <module>

--- a/src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
 <display-name>servlet_ee_spec_crosscontext</display-name>
 <module>

--- a/src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/crosscontext/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/runAs/application.xml
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
     <display-name>servlet_ee_spec_security_runAs</display-name>
     <module>
         <java>servlet_ee_spec_security_runAs_client.jar</java>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest1Clnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest1/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest1</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear1
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest2Clnt1</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest2Clnt2</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.clientear2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbMultipleClientInjectionTest2/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbMultipleClientInjectionTest2</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbNoWebServiceRefInClientTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbNoWebServiceRefInClientTest</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbNoWebServiceRefInClientTest/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbSOAPHandlersTest2Clnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/annotations/WSEjbSOAPHandlersTest2/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefHCWithDDsTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefHCWithDDsTest/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefHCWithDDsTest</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefWithDDsTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
 <description>Application description</description>
   <display-name>WSEjbOverrideWSRefWithDDsTest</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
+++ b/src/com/sun/ts/tests/webservices12/ejb/descriptors/WSEjbOverrideWSRefWithDDsTest/application.xml.ejbear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Simple example of application</display-name>
   <description>Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application2.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application2.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBAnnotationsTest/contentRoot/application2.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Second Simple example of application</display-name>
   <description>Second Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Simple example of application</display-name>
   <description>Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application2.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application2.xml
+++ b/src/com/sun/ts/tests/webservices12/servlet/WSMTOMSBFullDDsTest/contentRoot/application2.xml
@@ -20,8 +20,8 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-             https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
-             version="9">
+             https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
   <display-name>Second Simple example of application</display-name>
   <description>Second Simple example</description>
   <module>

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefAndAddressingCombinedTest/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSEjbWSRefAndAddressingCombinedTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/ejb/annotations/WSEjbWSRefRespBindAndAddressingCombinedTest/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSEjbWSRefRespBindAndAddressingCombinedTestClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingAnnotations/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSAddressingFeaturesTestUsingAnnotationsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSAddressingFeaturesTestUsingDDs/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSAddressingFeaturesTestUsingDDsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingAnnotations/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSMTOMFeaturesTestUsingAnnotationsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSMTOMFeaturesTestUsingDDs/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSMTOMFeaturesTestUsingDDsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingAnnotations/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSRespBindAndAddressingTestUsingAnnotationsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSRespBindAndAddressingTestUsingDDsClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSRespBindAndAddressingTestUsingDDs/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookup/client/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSWSRefLookupClnt</display-name>
   <module>

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/application.xml.clientear
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/application.xml.clientear
+++ b/src/com/sun/ts/tests/webservices13/servlet/WSWebServiceRefLookupDDs/client/application.xml.clientear
@@ -17,7 +17,7 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="9" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
   <description>Application description</description>
   <display-name>WSWSRefLookupDDsClnt</display-name>
   <module>


### PR DESCRIPTION
Signed-off-by: Suhrid Karthik <suhridk@gmail.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/751

**Related Issue(s)**
None

**Describe the change**
Changed existing EE9 application_9.xsd schema references to EE10 application_10.xsd

**Additional context**
Will create separate PRs to update other EE10 references

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
