### PR TITLE
Fix PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,3 @@
----
-name: Pull Request
-about: Create a pull request for a Platform TCK change
-title: ''
-labels: ''
-assignees: ''
-
----
-
 **Fixes Issue**
 Specify the issue (link) that is solved with this pull request.
 


### PR DESCRIPTION
PR templates do not use issue template syntax.

With current template PR is often open in the form similar to this one, where the template is not altered nor obeyed by the PR author. It leaves unnecessary and ugly section repeating that this is pull request indeed.

I suppose something like
- #810
 is rather more expected.

---
name: Pull Request
about: Create a pull request for a Platform TCK change
title: ''
labels: ''
assignees: ''

---

**Fixes Issue**
None.

**Related Issue(s)**
None.

**Describe the change**
Fix the PR template to not include MD header.

**Additional context**
None.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
