### PR TITLE
websocket tck build fix.

### DIFF
--- a/docker/build_standalone-tcks.sh
+++ b/docker/build_standalone-tcks.sh
@@ -148,7 +148,7 @@ for tck in ${TCK_LIST[@]}; do
     JAXWS_SPECIFIC_PROPS=""
   elif [ "websocket" == "$tck" ]
   then
-    TCK_SPECIFIC_PROPS="-Dwebsocket.classes=$JAKARTA_JARS/modules/jakarta.websocket-client-api.jar:$JAKARTA_JARS/modules/jakarta.websocket-api.jar:$JAKARTA_JARS/modules/jakarta.servlet-api.jar:$JAKARTA_JARS/modules/jakarta.inject-api.jar:$JAKARTA_JARS/modules/jakarta.enterprise.cdi-api.jar:$JAKARTA_JARS/modules/jakarta.activation-api.jar:$JAKARTA_JARS/modules/glassfish-corba-omgapi.jar"
+    TCK_SPECIFIC_PROPS="-Dwebsocket.classes=$JAKARTA_JARS/modules/jakarta.websocket-client-api.jar:$JAKARTA_JARS/modules/jakarta.websocket-api.jar:$JAKARTA_JARS/modules/jakarta.servlet-api.jar:$JAKARTA_JARS/modules/jakarta.inject-api.jar:$JAKARTA_JARS/modules/jakarta.enterprise.cdi-api.jar:$JAKARTA_JARS/modules/jakarta.activation-api.jar:$JAKARTA_JARS/modules/glassfish-corba-omgapi.jar:$JAKARTA_JARS/modules/jakarta.xml.bind-api.jar"
     DOC_SPECIFIC_PROPS=""
     JAXWS_SPECIFIC_PROPS=""
   elif [ "securityapi" == "$tck" ]


### PR DESCRIPTION
Signed-off-by: Gurunandan Rao <gurunandan.rao@oracle.com>

**Fixes Issue**
bind.dtds:
      [xjc] /home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/src/com/sun/ts/lib/implementation/sun/javaee/runtime/app is not found and thus excluded from the dependency check
      [xjc] Picked up JAVA_TOOL_OPTIONS: -Xmx6G
      [xjc] parsing a schema...
      [xjc] Exception in thread "main" java.lang.NoClassDefFoundError: jakarta/xml/bind/annotation/adapters/HexBinaryAdapter
      [xjc] 	at com.sun.tools.xjc.model.CBuiltinLeafInfo.<clinit>(CBuiltinLeafInfo.java:357)
      [xjc] 	at com.sun.tools.xjc.reader.dtd.TDTDReader.<clinit>(TDTDReader.java:412)
      [xjc] 	at com.sun.tools.xjc.ModelLoader.loadDTD(ModelLoader.java:239)
      [xjc] 	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:113)
      [xjc] 	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:76)
      [xjc] 	at com.sun.tools.xjc.Driver.run(Driver.java:324)
      [xjc] 	at com.sun.tools.xjc.Driver.run(Driver.java:191)
      [xjc] 	at com.sun.tools.xjc.Driver._main(Driver.java:114)
      [xjc] 	at com.sun.tools.xjc.Driver.access$000(Driver.java:52)
      [xjc] 	at com.sun.tools.xjc.Driver$1.run(Driver.java:73)
      [xjc] Caused by: java.lang.ClassNotFoundException: jakarta.xml.bind.annotation.adapters.HexBinaryAdapter
      [xjc] 	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
      [xjc] 	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
      [xjc] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
      [xjc] 	... 10 more
      [xjc] Command invoked: xjc /opt/jdk-11.0.2/bin/java -DenableExternalEntityProcessing=true -classpath /home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/jaxb-xjc.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/jaxb-core.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/jaxb-impl.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/tsharness.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/javatest.jar:/usr/share/ant/lib/ant.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/classes:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/jakarta.websocket-client-api.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/jakarta.websocket-api.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/jakarta.servlet-api.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/jakarta.inject-api.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/jakarta.enterprise.cdi-api.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/jakarta.activation-api.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/modules/glassfish-corba-omgapi.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/sigtest.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/commons-httpclient-3.1.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/commons-logging-1.1.3.jar:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/commons-codec-1.9.jar com.sun.tools.xjc.XJCFacade -d /home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/src -p com.sun.ts.lib.implementation.sun.javaee.runtime.app -dtd /home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/lib/dtds/sun-application_6_0-0.dtd -b file:/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/bin/xml/../../src/com/sun/ts/lib/implementation/sun/javaee/runtime/jaxb-cust.xml
      [xjc] failure in the XJC task. Use the Ant -verbose switch for more details

BUILD FAILED
/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/bin/xml/ts.top.import.xml:391: The following error occurred while executing this line:
/home/jenkins/agent/workspace/taee-tck-build-run_websocket-tck/bin/xml/ts.top.import.xml:691: xjc failed
