### PR TITLE
Update JmsTool for Messaging 3.1

### DIFF
--- a/src/com/sun/ts/tests/jms/common/JmsTool.java
+++ b/src/com/sun/ts/tests/jms/common/JmsTool.java
@@ -138,11 +138,11 @@ public class JmsTool {
 
   public static final int COMMON_FACTORY = 17;
 
-  public static final String JMS_VERSION = "3.0";
+  public static final String JMS_VERSION = "3.1";
 
   public static final int JMS_MAJOR_VERSION = 3;
 
-  public static final int JMS_MINOR_VERSION = 0;
+  public static final int JMS_MINOR_VERSION = 1;
 
   // JNDI names for JMS objects (Standalone mode)
   public static final String TCKTESTQUEUENAME = "MY_QUEUE";


### PR DESCRIPTION
**Fixes Issue**
None reported yet.

**Related Issue(s)**
- #549 
should Messaging 3.1 be ever released.

**Describe the change**
Update constants to expect from new Messaging release.



CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
