### PR TITLE
Update Jakarta application or module declared permissions schemas

### DIFF
--- a/src/com/sun/ts/tests/common/connector/whitebox/permissiondd/permissions.xml
+++ b/src/com/sun/ts/tests/common/connector/whitebox/permissiondd/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,8 @@
 <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-        https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
-    version="9">
+        https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+    version="10">
   <permission>
     <class-name>jakarta.xml.ws.WebServicePermission</class-name>
     <name>CTSPermission1_name</name>

--- a/src/com/sun/ts/tests/ejb30/sec/permsxml/permissions.xml
+++ b/src/com/sun/ts/tests/ejb30/sec/permsxml/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,8 @@
 <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-      https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
-    version="9">
+      https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+    version="10">
   <permission>
     <class-name>java.security.SecurityPermission</class-name>
     <name>CTSPermission1_name</name>

--- a/src/com/sun/ts/tests/securityapi/ham/sam/obtainbean/permissions.xml
+++ b/src/com/sun/ts/tests/securityapi/ham/sam/obtainbean/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,8 @@
 
 <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
-             version="9">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+             version="10">
         <permission>
            <class-name>java.security.SecurityPermission</class-name>   
            <name>getProperty.authconfigprovider.factory</name>                     

--- a/src/com/sun/ts/tests/securityapi/idstore/customhandler/permissions.xml
+++ b/src/com/sun/ts/tests/securityapi/idstore/customhandler/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,8 @@
 
 <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
-             version="9">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+             version="10">
         <permission>
            <class-name>java.lang.RuntimePermission</class-name>
            <name>getenv.COLUMNS</name>

--- a/src/com/sun/ts/tests/securityapi/idstore/idstorepermission/permissions.xml
+++ b/src/com/sun/ts/tests/securityapi/idstore/idstorepermission/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,8 @@
 
 <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
-             version="9">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+             version="10">
         <permission>
            <class-name>java.lang.RuntimePermission</class-name>
            <name>getenv.COLUMNS</name>

--- a/src/com/sun/ts/tests/servlet/ee/spec/security/permissiondd/permissions.xml
+++ b/src/com/sun/ts/tests/servlet/ee/spec/security/permissiondd/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,8 @@
 <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-        https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
-    version="9">
+        https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+    version="10">
   <permission>
     <class-name>java.security.SecurityPermission</class-name>
     <name>CTSPermission1_name</name>


### PR DESCRIPTION
Signed-off-by: Suhrid Karthik <suhridk@gmail.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/751

**Related Issue(s)**
None

**Describe the change**
Changed existing EE9 permissions_9.xsd schema references to EE10 permissions_10.xsd and updated copyright year for changed files

**Additional context**
None

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
