### PR TITLE
Update Copyright year for beans schema reference updates to EE10

### DIFF
--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxrs/platform/managedbean299/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/platform/managedbean299/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
+++ b/src/com/sun/ts/tests/jaxrs/spec/resourceconstructor/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jms/ee20/cditests/resources/beans.xml
+++ b/src/com/sun/ts/tests/jms/ee20/cditests/resources/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jsf/spec/flows/common/beans.xml
+++ b/src/com/sun/ts/tests/jsf/spec/flows/common/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/beans.xml
+++ b/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/beans.xml
+++ b/src/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/com/sun/ts/tests/websocket/platform/cdi/beans.xml
+++ b/src/com/sun/ts/tests/websocket/platform/cdi/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Signed-off-by: Suhrid Karthik <suhridk@gmail.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/751

**Related Issue(s)**
None

**Describe the change**
Update the copyright year for beans schema references that were updated to EE10

**Additional context**
PR https://github.com/eclipse-ee4j/jakartaee-tck/pull/801 had changed existing EE9 beans_3_0.xsd schema references to EE10 beans_4_0.xsd. This PR updates the copyright year for those files.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
