### PR TITLE
unique index schema creation check also for add constraint unique

### DIFF
--- a/src/com/sun/ts/tests/jpa/se/schemaGeneration/annotations/index/Client.java
+++ b/src/com/sun/ts/tests/jpa/se/schemaGeneration/annotations/index/Client.java
@@ -177,6 +177,15 @@ public class Client extends PMClientBase {
         "CREATE UNIQUE INDEX SCHEMAGENSIMPLE_SVALUE3 ON SCHEMAGENSIMPLE (SVALUE3)");
     pass1d = pass1d || findDataInFile(f1, expected);
 
+    expected.clear();
+    expected.add("ALTER TABLE SCHEMAGENSIMPLE");
+    expected.add("ADD");
+    expected.add("CONSTRAINT");
+    expected.add("SCHEMAGENSIMPLE_SVALUE3");
+    expected.add("UNIQUE");
+
+    pass1d = pass1d || findDataInFile(f1, expected);
+
     pass2a = findDataInFile(f2, "DROP TABLE SCHEMAGENSIMPLE");
     /*
      * Index can be dropped using ALTER TABLE AS WELL Bug 27422087: Some


### PR DESCRIPTION
**Fixes Issue**
See https://github.com/eclipse-ee4j/jpa-api/issues/361

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
The change checks the unique index is created also using the DLL `ALTER TABLE ... ADD CONSTRAINT... UNIQUE`

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
