### PR TITLE
Allow TCK run using Glassfish 6 and JakartaEE 9 standalone TCK bundles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,9 @@ spec:
     string(name: 'GF_VERSION_URL', 
            defaultValue: '', 
            description: 'URL required for downloading GlassFish version details' )
-	string(name: 'OLD_GF_BUNDLE_URL', 
+    choice(name: 'GF_TOPLEVEL_DIR', choices: 'glassfish7\nglassfish6', 
+           description: 'Glassfish parent folder to identify between versions 6 & 7 of Glassfish' )
+	  string(name: 'OLD_GF_BUNDLE_URL', 
            defaultValue: '', 
            description: 'URL required for downloading Old GlassFish Full/Web profile bundle' )
     string(name: 'TCK_BUNDLE_BASE_URL', 

--- a/docker/cajtck.sh
+++ b/docker/cajtck.sh
@@ -55,6 +55,12 @@ echo "TS_HOME $TS_HOME"
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/concurrencytck.sh
+++ b/docker/concurrencytck.sh
@@ -39,6 +39,7 @@ if [ -z "$GF_TOPLEVEL_DIR" ]; then
   export GF_TOPLEVEL_DIR=glassfish7
 fi
 
+
 ##### installRI.sh starts here #####
 echo "Download and install GlassFish 7.0.0 ..."
 if [ -z "${GF_BUNDLE_URL}" ]; then
@@ -55,6 +56,12 @@ chmod -R 777 $TS_HOME
 rm -f $TS_HOME/dist/com/sun/ts/tests/concurrency/spec/ContextService/contextPropagate/ContextPropagate_web.war
 
 cd $TS_HOME/bin
+
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
 
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}

--- a/docker/connectortck.sh
+++ b/docker/connectortck.sh
@@ -56,6 +56,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/eltck.sh
+++ b/docker/eltck.sh
@@ -59,6 +59,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jacctck.sh
+++ b/docker/jacctck.sh
@@ -55,6 +55,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jaspictck.sh
+++ b/docker/jaspictck.sh
@@ -59,6 +59,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jaxrstck.sh
+++ b/docker/jaxrstck.sh
@@ -54,6 +54,12 @@ echo "TS_HOME $TS_HOME"
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jaxrstck/README
+++ b/docker/jaxrstck/README
@@ -6,9 +6,9 @@ https://github.com/eclipse-ee4j/jaxrs-api repository.
 
 1. Install Java11+ , set JAVAHOME
 2. Install Maven 3.6+ set M2_HOME
-3. SET PATH : add /glassfish6/glassfish/bin as to start the glassfish domain in some environments, 
+3. SET PATH : add /${glassfish.toplevel.dir}/glassfish/bin as to start the glassfish domain in some environments, 
 add M2_HOME/bin, JAVA_HOME/bin
-eg: export PATH=$ANT_HOME/bin:$M2_HOME/bin:$JAVA_HOME/bin:<path to current directory>/target/glassfish6/glassfish/bin:$PATH
+eg: export PATH=$ANT_HOME/bin:$M2_HOME/bin:$JAVA_HOME/bin:<path to current directory>/target/${glassfish.toplevel.dir}/glassfish/bin:$PATH
 
 4. Download the latest Eclipse Jakarta REST TCK zip bundle that contains the tck jar.
 (If the jar is available from maven this step is not required as it will be resolved when dependencies are downloaded)

--- a/docker/jaxrstck/pom.xml
+++ b/docker/jaxrstck/pom.xml
@@ -31,6 +31,7 @@
         <glassfish.container.version>6.1.0</glassfish.container.version>
         <jakarta.platform.version>9.1.0</jakarta.platform.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
+        <glassfish.toplevel.dir>glassfish6</glassfish.toplevel.dir>
     </properties>
 
     <dependencyManagement>
@@ -145,7 +146,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <workingDirectory>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin</workingDirectory>
                             <executable>asadmin</executable>
                             <arguments>
                                 <argument>start-domain</argument>
@@ -159,7 +160,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <workingDirectory>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin</workingDirectory>
                             <executable>asadmin</executable>
                             <arguments>
                                 <argument>set</argument>
@@ -174,7 +175,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <workingDirectory>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin</workingDirectory>
                             <executable>asadmin</executable>
                             <arguments>
                                 <argument>--passwordfile</argument>
@@ -193,7 +194,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <workingDirectory>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin</workingDirectory>
                             <executable>asadmin</executable>
                             <arguments>
                                 <argument>--passwordfile</argument>
@@ -212,7 +213,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <workingDirectory>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin</workingDirectory>
                             <executable>asadmin</executable>
                             <arguments>
                                 <argument>list-file-users</argument>
@@ -226,7 +227,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <workingDirectory>${project.build.directory}/glassfish6/glassfish/bin</workingDirectory>
+                            <workingDirectory>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin</workingDirectory>
                             <executable>asadmin</executable>
                             <arguments>
                                 <argument>stop-domain</argument>
@@ -247,15 +248,15 @@
                         </goals>
                         <configuration>
                             <additionalClasspathElements>
-                                <additionalClasspathElement>${project.build.directory}/glassfish6/glassfish/modules/jersey-server.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${project.build.directory}/glassfish6/glassfish/modules/jersey-container-grizzly2-http.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${project.build.directory}/glassfish6/glassfish/modules/jersey-media-sse.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${project.build.directory}/glassfish6/glassfish/modules/jersey-media-json-binding.jar</additionalClasspathElement>
-                                <additionalClasspathElement>${project.build.directory}/glassfish6/glassfish/modules/jersey-media-sse.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jersey-server.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jersey-container-grizzly2-http.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jersey-media-sse.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jersey-media-json-binding.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jersey-media-sse.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <dependenciesToScan>jakarta.ws.rs:jakarta.ws.rs-tck</dependenciesToScan>
                             <systemPropertyVariables>
-                                <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>
                                 <webServerHost>localhost</webServerHost>
                                 <webServerPort>8080</webServerPort>
@@ -267,7 +268,7 @@
                                 <porting.ts.url.class.1>jakarta.ws.rs.tck.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
                             </systemPropertyVariables>
                             <environmentVariables>
-                                <GLASSFISH_HOME>${project.build.directory}/glassfish6</GLASSFISH_HOME>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                             </environmentVariables>
                         </configuration>
                     </execution>

--- a/docker/jaxwstck.sh
+++ b/docker/jaxwstck.sh
@@ -56,6 +56,12 @@ echo "TS_HOME $TS_HOME"
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jmstck.sh
+++ b/docker/jmstck.sh
@@ -54,6 +54,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jpatck.sh
+++ b/docker/jpatck.sh
@@ -55,6 +55,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jsftck.sh
+++ b/docker/jsftck.sh
@@ -53,6 +53,12 @@ echo "TS_HOME $TS_HOME"
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jsonbtck.sh
+++ b/docker/jsonbtck.sh
@@ -54,6 +54,12 @@ echo "TS_HOME $TS_HOME"
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jsonptck.sh
+++ b/docker/jsonptck.sh
@@ -54,6 +54,12 @@ echo "TS_HOME $TS_HOME"
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jsptck.sh
+++ b/docker/jsptck.sh
@@ -55,6 +55,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jstltck.sh
+++ b/docker/jstltck.sh
@@ -55,6 +55,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/jtatck.sh
+++ b/docker/jtatck.sh
@@ -59,6 +59,12 @@ echo "TS_HOME $TS_HOME"
 
 cd ${TS_HOME}/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -48,6 +48,12 @@ if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
     export GF_VI_TOPLEVEL_DIR=${GF_TOPLEVEL_DIR}
 fi
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f $TS_HOME/bin/ts.jte.jdk11 ];then
+    cp $TS_HOME/bin/ts.jte.jdk11 $TS_HOME/bin/ts.jte
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -39,13 +39,13 @@ fi
 export TS_HOME=${CTS_HOME}/jakartaeetck/
 
 if [ -z "${GF_RI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish7 for GF_RI_TOPLEVEL_DIR"
-    export GF_RI_TOPLEVEL_DIR=glassfish7
+    echo "Using GF_TOPLEVEL_DIR(glassfish7 or glassfish6) for GF_RI_TOPLEVEL_DIR"
+    export GF_RI_TOPLEVEL_DIR=${GF_TOPLEVEL_DIR}
 fi
 
 if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
-    echo "Using glassfish7 for GF_VI_TOPLEVEL_DIR"
-    export GF_VI_TOPLEVEL_DIR=glassfish7
+    echo "Using GF_TOPLEVEL_DIR(glassfish7 or glassfish6) for GF_VI_TOPLEVEL_DIR"
+    export GF_VI_TOPLEVEL_DIR=${GF_TOPLEVEL_DIR}
 fi
 
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then

--- a/docker/saajtck.sh
+++ b/docker/saajtck.sh
@@ -56,6 +56,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/securityapitck.sh
+++ b/docker/securityapitck.sh
@@ -61,6 +61,12 @@ rm -f $TS_HOME/lib/jax-qname.jar
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/servlettck.sh
+++ b/docker/servlettck.sh
@@ -55,6 +55,12 @@ echo "TS_HOME $TS_HOME"
 chmod -R 777 $TS_HOME
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/docker/websockettck.sh
+++ b/docker/websockettck.sh
@@ -55,6 +55,12 @@ chmod -R 777 $TS_HOME
 
 cd $TS_HOME/bin
 
+if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]];then
+  if [ -f ts.jte.jdk11 ];then
+    cp ts.jte.jdk11 ts.jte 
+  fi
+fi
+
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   export JAVA_HOME=${JDK17_HOME}
 fi

--- a/src/com/sun/ts/lib/harness/TSScript.java
+++ b/src/com/sun/ts/lib/harness/TSScript.java
@@ -234,7 +234,7 @@ public class TSScript extends com.sun.javatest.Script {
       pTestProps.put("current.keywords", keywords);
       String version = (String)System.getProperties().get("java.version");
       if (!version.startsWith("1.")) {
-        pTestProps.put("jimage.dir", propMgr.getProperty("jimage.dir"));
+        pTestProps.put("jimage.dir", propMgr.getProperty("jimage.dir", ""));
       }
 
       // so we know what kind of test this is


### PR DESCRIPTION
**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/837

**Related Issue(s)**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/794

**Describe the change**
The change does the below:
- Add glassfish parent folder as a variable that can be set via CI jobs. This is to enable test runs with Glassfish 6 & Glassfish 7 bundles.
- If the JakartaEE 9 TCK bundles are used to run the tests in JDK11, the ts.jte.jdk11 files in tck/bin folders will be used as the test run configuration

