### PR TITLE
include the TCK Process version referenced when the JPA TCK user guide was updated.

### DIFF
--- a/user_guides/jpa/src/main/jbake/content/rules.adoc
+++ b/user_guides/jpa/src/main/jbake/content/rules.adoc
@@ -279,7 +279,7 @@ include::rules.inc[]
 2.3 Test Appeals Process
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Refer to https://jakarta.ee/committees/specification/tckprocess as the definitive source for
+Refer to https://jakarta.ee/committees/specification/tckprocess (version 1.2) as the definitive source for
 the TCK rules.
 
 Jakarta has a well established process for managing challenges to its


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
