### PR TITLE
Messaging tests for repeatable annotations

### DIFF
--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/Client.java
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/Client.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,26 +46,61 @@ import jakarta.jms.TopicConnectionFactory;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-    @JMSDestinationDefinition(description = "Define Queue AppClientMyTestQueue", interfaceName = "jakarta.jms.Queue", name = "java:global/env/AppClientMyTestQueue", destinationName = "AppClientMyTestQueue"),
+@JMSDestinationDefinition(
+      description="Define Queue AppClientMyTestQueue",
+      interfaceName="jakarta.jms.Queue",
+      name="java:global/env/AppClientMyTestQueue",
+      destinationName="AppClientMyTestQueue"
+ )
 
-    @JMSDestinationDefinition(description = "Define Topic AppClientMyTestTopic", interfaceName = "jakarta.jms.Topic", name = "java:app/env/AppClientMyTestTopic", destinationName = "AppClientMyTestTopic")
+@JMSDestinationDefinition(
+      description="Define Topic AppClientMyTestTopic",
+      interfaceName="jakarta.jms.Topic",
+      name="java:app/env/AppClientMyTestTopic",
+      destinationName="AppClientMyTestTopic"
+ )
 
-})
 
-// -------------------------------------------
+//-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
-// -------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-    @JMSConnectionFactoryDefinition(description = "Define ConnectionFactory AppClientMyTestConnectionFactory", interfaceName = "jakarta.jms.ConnectionFactory", name = "java:global/AppClientMyTestConnectionFactory", user = "j2ee", password = "j2ee"),
+//-------------------------------------------
+@JMSConnectionFactoryDefinition(
+      description="Define ConnectionFactory AppClientMyTestConnectionFactory",
+      interfaceName="jakarta.jms.ConnectionFactory",
+      name="java:global/AppClientMyTestConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define QueueConnectionFactory AppClientMyTestQueueConnectionFactory", interfaceName = "jakarta.jms.QueueConnectionFactory", name = "java:app/AppClientMyTestQueueConnectionFactory", user = "j2ee", password = "j2ee"),
+@JMSConnectionFactoryDefinition(
+      description="Define QueueConnectionFactory AppClientMyTestQueueConnectionFactory",
+      interfaceName="jakarta.jms.QueueConnectionFactory",
+      name="java:app/AppClientMyTestQueueConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define TopicConnectionFactory AppClientMyTestTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:module/AppClientMyTestTopicConnectionFactory", user = "j2ee", password = "j2ee"),
+@JMSConnectionFactoryDefinition(
+      description="Define TopicConnectionFactory AppClientMyTestTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:module/AppClientMyTestTopicConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define Durable TopicConnectionFactory AppClientMyTestDurableTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory", user = "j2ee", password = "j2ee", clientId = "MyClientID", properties = {
-        "Property1=10",
-        "Property2=20" }, transactional = false, maxPoolSize = 30, minPoolSize = 20) })
+
+@JMSConnectionFactoryDefinition(
+      description="Define Durable TopicConnectionFactory AppClientMyTestDurableTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory",
+      user = "j2ee",
+      password = "j2ee",
+      clientId = "MyClientID",
+      properties = { "Property1=10", "Property2=20" },
+      transactional = false,
+      maxPoolSize = 30,
+      minPoolSize = 20
+ )
 
 public class Client extends EETest {
   private static final long serialVersionUID = 1L;

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/EjbClient.java
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/EjbClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,26 +46,59 @@ import jakarta.jms.TopicConnectionFactory;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-    @JMSDestinationDefinition(description = "Define Queue EJBMyTestQueue", interfaceName = "jakarta.jms.Queue", name = "java:global/env/EJBMyTestQueue", destinationName = "EJBMyTestQueue"),
+  @JMSDestinationDefinition(
+	description="Define Queue EJBMyTestQueue",
+	interfaceName="jakarta.jms.Queue",
+	name="java:global/env/EJBMyTestQueue",
+    	destinationName="EJBMyTestQueue"
+   )
 
-    @JMSDestinationDefinition(description = "Define Topic EJBMyTestTopic", interfaceName = "jakarta.jms.Topic", name = "java:app/env/EJBMyTestTopic", destinationName = "EJBMyTestTopic")
+  @JMSDestinationDefinition(
+	description="Define Topic EJBMyTestTopic",
+	interfaceName="jakarta.jms.Topic",
+	name="java:app/env/EJBMyTestTopic",
+	destinationName="EJBMyTestTopic"
+   )
 
-})
-
-// -------------------------------------------
+//-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
-// -------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-    @JMSConnectionFactoryDefinition(description = "Define ConnectionFactory EJBMyTestConnectionFactory", interfaceName = "jakarta.jms.ConnectionFactory", name = "java:global/EJBMyTestConnectionFactory", user = "j2ee", password = "j2ee"),
+//-------------------------------------------
+  @JMSConnectionFactoryDefinition(
+	description="Define ConnectionFactory EJBMyTestConnectionFactory",
+	interfaceName="jakarta.jms.ConnectionFactory",
+    	name="java:global/EJBMyTestConnectionFactory",
+	user = "j2ee",
+	password = "j2ee"
+   )
 
-    @JMSConnectionFactoryDefinition(description = "Define QueueConnectionFactory EJBMyTestQueueConnectionFactory", interfaceName = "jakarta.jms.QueueConnectionFactory", name = "java:app/EJBMyTestQueueConnectionFactory", user = "j2ee", password = "j2ee"),
+  @JMSConnectionFactoryDefinition(
+	description="Define QueueConnectionFactory EJBMyTestQueueConnectionFactory",
+	interfaceName="jakarta.jms.QueueConnectionFactory",
+    	name="java:app/EJBMyTestQueueConnectionFactory",
+	user = "j2ee",
+	password = "j2ee"
+   )
 
-    @JMSConnectionFactoryDefinition(description = "Define TopicConnectionFactory EJBMyTestTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:module/EJBMyTestTopicConnectionFactory", user = "j2ee", password = "j2ee"),
+  @JMSConnectionFactoryDefinition(
+	description="Define TopicConnectionFactory EJBMyTestTopicConnectionFactory",
+	interfaceName="jakarta.jms.TopicConnectionFactory",
+    	name="java:module/EJBMyTestTopicConnectionFactory",
+	user = "j2ee",
+	password = "j2ee"
+   )
 
-    @JMSConnectionFactoryDefinition(description = "Define Durable TopicConnectionFactory EJBMyTestDurableTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:comp/env/jms/EJBMyTestDurableTopicConnectionFactory", user = "j2ee", password = "j2ee", clientId = "MyClientID", properties = {
-        "Property1=10",
-        "Property2=20" }, transactional = false, maxPoolSize = 30, minPoolSize = 20) })
+  @JMSConnectionFactoryDefinition(
+	description="Define Durable TopicConnectionFactory EJBMyTestDurableTopicConnectionFactory",
+	interfaceName="jakarta.jms.TopicConnectionFactory",
+    	name="java:comp/env/jms/EJBMyTestDurableTopicConnectionFactory",
+	user = "j2ee",
+	password = "j2ee",
+	clientId = "MyClientID",
+	properties = { "Property1=10", "Property2=20" },
+	transactional = false,
+	maxPoolSize = 30,
+	minPoolSize = 20
+   )
 
 @Stateful(name = "JMSResourceDefsEjbClientBean")
 @Remote({ EjbClientIF.class })

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/MyBean.java
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/MyBean.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,26 +25,59 @@ import jakarta.jms.JMSDestinationDefinitions;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-    @JMSDestinationDefinition(description = "Define Queue JSPMyTestQueue", interfaceName = "jakarta.jms.Queue", name = "java:global/env/JSPMyTestQueue", destinationName = "JSPMyTestQueue"),
+@JMSDestinationDefinition(
+      description="Define Queue JSPMyTestQueue",
+      interfaceName="jakarta.jms.Queue",
+      name="java:global/env/JSPMyTestQueue",
+      destinationName="JSPMyTestQueue"
+ )
 
-    @JMSDestinationDefinition(description = "Define Topic JSPMyTestTopic", interfaceName = "jakarta.jms.Topic", name = "java:app/env/JSPMyTestTopic", destinationName = "JSPMyTestTopic")
+@JMSDestinationDefinition(
+      description="Define Topic JSPMyTestTopic",
+      interfaceName="jakarta.jms.Topic",
+      name="java:app/env/JSPMyTestTopic",
+      destinationName="JSPMyTestTopic"
+ )
 
-})
-
-// -------------------------------------------
+//-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
-// -------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-    @JMSConnectionFactoryDefinition(description = "Define ConnectionFactory JSPMyTestConnectionFactory", interfaceName = "jakarta.jms.ConnectionFactory", name = "java:global/JSPMyTestConnectionFactory", user = "j2ee", password = "j2ee"),
+//-------------------------------------------
+@JMSConnectionFactoryDefinition(
+      description="Define ConnectionFactory JSPMyTestConnectionFactory",
+      interfaceName="jakarta.jms.ConnectionFactory",
+      name="java:global/JSPMyTestConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define QueueConnectionFactory JSPMyTestQueueConnectionFactory", interfaceName = "jakarta.jms.QueueConnectionFactory", name = "java:app/JSPMyTestQueueConnectionFactory", user = "j2ee", password = "j2ee"),
+@JMSConnectionFactoryDefinition(
+      description="Define QueueConnectionFactory JSPMyTestQueueConnectionFactory",
+      interfaceName="jakarta.jms.QueueConnectionFactory",
+      name="java:app/JSPMyTestQueueConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define TopicConnectionFactory JSPMyTestTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:module/JSPMyTestTopicConnectionFactory", user = "j2ee", password = "j2ee"),
+@JMSConnectionFactoryDefinition(
+      description="Define TopicConnectionFactory JSPMyTestTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:module/JSPMyTestTopicConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define Durable TopicConnectionFactory JSPMyTestDurableTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:comp/env/jms/JSPMyTestDurableTopicConnectionFactory", user = "j2ee", password = "j2ee", clientId = "MyClientID", properties = {
-        "Property1=10",
-        "Property2=20" }, transactional = false, maxPoolSize = 30, minPoolSize = 20) })
+@JMSConnectionFactoryDefinition(
+      description="Define Durable TopicConnectionFactory JSPMyTestDurableTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:comp/env/jms/JSPMyTestDurableTopicConnectionFactory",
+      user = "j2ee",
+      password = "j2ee",
+      clientId = "MyClientID",
+      properties = { "Property1=10", "Property2=20" },
+      transactional = false,
+      maxPoolSize = 30,
+      minPoolSize = 20
+ )
 
 public class MyBean {
   public MyBean() {

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/ServletClient.java
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/ServletClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,26 +49,59 @@ import jakarta.servlet.http.HttpServletResponse;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-    @JMSDestinationDefinition(description = "Define Queue ServletMyTestQueue", interfaceName = "jakarta.jms.Queue", name = "java:global/env/ServletMyTestQueue", destinationName = "ServletMyTestQueue"),
+@JMSDestinationDefinition(
+      description="Define Queue ServletMyTestQueue",
+      interfaceName="jakarta.jms.Queue",
+      name="java:global/env/ServletMyTestQueue",
+      destinationName="ServletMyTestQueue"
+ )
 
-    @JMSDestinationDefinition(description = "Define Topic ServletMyTestTopic", interfaceName = "jakarta.jms.Topic", name = "java:app/env/ServletMyTestTopic", destinationName = "ServletMyTestTopic")
+@JMSDestinationDefinition(
+      description="Define Topic ServletMyTestTopic",
+      interfaceName="jakarta.jms.Topic",
+      name="java:app/env/ServletMyTestTopic",
+      destinationName="ServletMyTestTopic"
+ )
 
-})
-
-// -------------------------------------------
+//-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
-// -------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-    @JMSConnectionFactoryDefinition(description = "Define ConnectionFactory ServletMyTestConnectionFactory", interfaceName = "jakarta.jms.ConnectionFactory", name = "java:global/ServletMyTestConnectionFactory", user = "j2ee", password = "j2ee"),
+//-------------------------------------------
+@JMSConnectionFactoryDefinition(
+      description="Define ConnectionFactory ServletMyTestConnectionFactory",
+      interfaceName="jakarta.jms.ConnectionFactory",
+      name="java:global/ServletMyTestConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define QueueConnectionFactory ServletMyTestQueueConnectionFactory", interfaceName = "jakarta.jms.QueueConnectionFactory", name = "java:app/ServletMyTestQueueConnectionFactory", user = "j2ee", password = "j2ee"),
+@JMSConnectionFactoryDefinition(
+      description="Define QueueConnectionFactory ServletMyTestQueueConnectionFactory",
+      interfaceName="jakarta.jms.QueueConnectionFactory",
+      name="java:app/ServletMyTestQueueConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define TopicConnectionFactory ServletMyTestTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:module/ServletMyTestTopicConnectionFactory", user = "j2ee", password = "j2ee"),
+@JMSConnectionFactoryDefinition(
+      description="Define TopicConnectionFactory ServletMyTestTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:module/ServletMyTestTopicConnectionFactory",
+      user = "j2ee",
+      password = "j2ee"
+ )
 
-    @JMSConnectionFactoryDefinition(description = "Define Durable TopicConnectionFactory ServletMyTestDurableTopicConnectionFactory", interfaceName = "jakarta.jms.TopicConnectionFactory", name = "java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory", user = "j2ee", password = "j2ee", clientId = "MyClientID", properties = {
-        "Property1=10",
-        "Property2=20" }, transactional = false, maxPoolSize = 30, minPoolSize = 20) })
+@JMSConnectionFactoryDefinition(
+      description="Define Durable TopicConnectionFactory ServletMyTestDurableTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory",
+      user = "j2ee",
+      password = "j2ee",
+      clientId = "MyClientID",
+      properties = { "Property1=10", "Property2=20" },
+      transactional = false,
+      maxPoolSize = 30,
+      minPoolSize = 20
+ )
 
 @WebServlet("/ServletTest")
 public class ServletClient extends HttpServlet {

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/Client.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/Client.java.src
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,18 +17,31 @@
 
 package com.sun.ts.tests.jms.ee20.resourcedefs.annotations;
 
-import com.sun.ts.lib.util.*;
-import com.sun.ts.lib.porting.*;
-import com.sun.ts.lib.harness.*;
-import com.sun.ts.tests.jms.common.*;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Properties;
+
 import com.sun.javatest.Status;
+import com.sun.ts.lib.harness.EETest;
+import com.sun.ts.lib.porting.TSURL;
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
 
 import jakarta.ejb.EJB;
-import jakarta.jms.*;
-import javax.naming.InitialContext;
-import java.net.*;
-import java.util.Properties;
-import java.util.Iterator;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSConnectionFactoryDefinition;
+import jakarta.jms.JMSConnectionFactoryDefinitions;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSDestinationDefinition;
+import jakarta.jms.JMSDestinationDefinitions;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnectionFactory;
 
 //-------------------------------------
 // JMS Destination Resource Definitions
@@ -89,658 +103,704 @@ import java.util.Iterator;
  )
 
 public class Client extends EETest {
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    // JMS objects
-    protected transient ConnectionFactory	dcf = null;
-    protected transient ConnectionFactory	cf = null;
-    protected transient ConnectionFactory	cfra = null;
-    protected transient QueueConnectionFactory 	qcf = null;
-    protected transient TopicConnectionFactory 	tcf = null;
-    protected transient TopicConnectionFactory 	dtcf = null;
-    protected transient Topic 			topic = null;
-    protected transient Topic 			topica = null;
-    protected transient Queue 			queue = null;
-    protected transient JMSContext              context = null;
-    protected transient JMSConsumer             consumerQ = null;
-    protected transient JMSProducer             producerQ = null;
-    protected transient JMSConsumer             consumerT = null;
-    protected transient JMSProducer             producerT = null;
-    protected boolean			        queueTest = false;
+  // JMS objects
+  protected transient ConnectionFactory dcf = null;
 
-    // Harness req's
-    protected Properties              		props = null;
+  protected transient ConnectionFactory cf = null;
 
-    // properties read from ts.jte file
-    protected long                            	timeout;
-    protected String                          	user;
-    protected String                          	password;
-    protected String                          	mode;
+  protected transient ConnectionFactory cfra = null;
 
-    // The webserver defaults (overidden by harness properties)
-    private static final String PROTOCOL = "http";
-    private static final String HOSTNAME = "localhost";
-    private static final int PORTNUM  = 8000;
+  protected transient QueueConnectionFactory qcf = null;
 
-    private TSURL ctsurl = new TSURL();
-    private String hostname = HOSTNAME;
-    private int portnum = PORTNUM;
+  protected transient TopicConnectionFactory tcf = null;
 
-    // URL properties used by the test
-    private URL url = null;
-    private transient URLConnection urlConn = null;
+  protected transient TopicConnectionFactory dtcf = null;
 
-    private String SERVLET = "/resourcedefs_annotations_web/ServletTest";
+  protected transient Topic topic = null;
 
-    private String JSP = "/resourcedefs_annotations_web/JspClient.jsp";
+  protected transient Topic topica = null;
 
-    @EJB(name="ejb/JMSResourceDefsEjbClientBean")
-    static EjbClientIF ejbclient;
+  protected transient Queue queue = null;
 
-    public static void main(String[] args)
-    {
-        Client theTests = new Client();
-        Status s = theTests.run(args, System.out, System.err);
-        s.exit();
+  protected transient JMSContext context = null;
+
+  protected transient JMSConsumer consumerQ = null;
+
+  protected transient JMSProducer producerQ = null;
+
+  protected transient JMSConsumer consumerT = null;
+
+  protected transient JMSProducer producerT = null;
+
+  protected boolean queueTest = false;
+
+  // Harness req's
+  protected Properties props = null;
+
+  // properties read from ts.jte file
+  protected long timeout;
+
+  protected String user;
+
+  protected String password;
+
+  protected String mode;
+
+  // The webserver defaults (overidden by harness properties)
+  private static final String PROTOCOL = "http";
+
+  private static final String HOSTNAME = "localhost";
+
+  private static final int PORTNUM = 8000;
+
+  private TSURL ctsurl = new TSURL();
+
+  private String hostname = HOSTNAME;
+
+  private int portnum = PORTNUM;
+
+  // URL properties used by the test
+  private URL url = null;
+
+  private transient URLConnection urlConn = null;
+
+  private String SERVLET = "/resourcedefs_annotations_web/ServletTest";
+
+  private String JSP = "/resourcedefs_annotations_web/JspClient.jsp";
+
+  @EJB(name = "ejb/JMSResourceDefsEjbClientBean")
+  static EjbClientIF ejbclient;
+
+  public static void main(String[] args) {
+    Client theTests = new Client();
+    Status s = theTests.run(args, System.out, System.err);
+    s.exit();
+  }
+
+  /* Test setup */
+
+  /*
+   * @class.setup_props: jms_timeout; user; password; platform.mode;
+   * webServerHost; webServerPort;
+   */
+  public void setup(String[] args, Properties p) throws Fault {
+    props = p;
+    boolean pass = true;
+    try {
+      // get props
+      timeout = Integer.parseInt(p.getProperty("jms_timeout"));
+      user = p.getProperty("user");
+      password = p.getProperty("password");
+      mode = p.getProperty("platform.mode");
+      hostname = p.getProperty("webServerHost");
+
+      // check props for errors
+      if (timeout < 1) {
+        throw new Exception(
+            "'jms_timeout' (milliseconds) in ts.jte must be > 0");
+      }
+      if (user == null) {
+        throw new Exception("'user' in ts.jte must not be null ");
+      }
+      if (password == null) {
+        throw new Exception("'password' in ts.jte must not be null ");
+      }
+      if (mode == null) {
+        throw new Exception("'platform.mode' in ts.jte must not be null");
+      }
+      if (hostname == null) {
+        throw new Exception("'webServerHost' in ts.jte must not be null");
+      }
+      try {
+        portnum = Integer.parseInt(p.getProperty("webServerPort"));
+      } catch (Exception e) {
+        throw new Exception("'webServerPort' in ts.jte must be a number");
+      }
+      if (ejbclient == null) {
+        throw new Fault("setup failed: ejbclient injection failure");
+      }
+    } catch (Exception e) {
+      throw new Fault("setup failed:", e);
+    }
+    TestUtil.logMsg("setup ok");
+  }
+
+  /*
+   * cleanup() is called after each test
+   * 
+   * @exception Fault
+   */
+  public void cleanup() throws Fault {
+    TestUtil.logMsg("cleanup ok");
+  }
+
+  /*
+   * Lookup JMS Connection Factory and Destination Objects
+   */
+  private void doLookupJMSObjects() throws Exception {
+    try {
+      TestUtil.logMsg(
+          "Lookup JMS factories defined in @JMSConnectionFactoryDefinitions");
+      TestUtil.logMsg(
+          "Lookup JMS destinations defined in @JMSDestinationDefinitions");
+      TSNamingContext namingctx = new TSNamingContext();
+      TestUtil.logMsg("Lookup java:comp/DefaultJMSConnectionFactory");
+      dcf = (ConnectionFactory) namingctx
+          .lookup("java:comp/DefaultJMSConnectionFactory");
+      TestUtil.logMsg("Lookup java:global/AppClientMyTestConnectionFactory");
+      cf = (ConnectionFactory) namingctx
+          .lookup("java:global/AppClientMyTestConnectionFactory");
+      TestUtil.logMsg("Lookup java:app/AppClientMyTestQueueConnectionFactory");
+      qcf = (QueueConnectionFactory) namingctx
+          .lookup("java:app/AppClientMyTestQueueConnectionFactory");
+      TestUtil
+          .logMsg("Lookup java:module/AppClientMyTestTopicConnectionFactory");
+      tcf = (TopicConnectionFactory) namingctx
+          .lookup("java:module/AppClientMyTestTopicConnectionFactory");
+      TestUtil.logMsg(
+          "Lookup java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory");
+      dtcf = (TopicConnectionFactory) namingctx.lookup(
+          "java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory");
+      TestUtil.logMsg("Lookup java:global/env/AppClientMyTestQueue");
+      queue = (Queue) namingctx.lookup("java:global/env/AppClientMyTestQueue");
+      TestUtil.logMsg("Lookup java:app/env/AppClientMyTestTopic");
+      topic = (Topic) namingctx.lookup("java:app/env/AppClientMyTestTopic");
+
+      TestUtil.logMsg("Create JMSContext, JMSProducer's and JMSConsumer's");
+      context = cf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
+      producerQ = context.createProducer();
+      consumerQ = context.createConsumer(queue);
+      producerT = context.createProducer();
+      consumerT = context.createConsumer(topic);
+    } catch (Exception e) {
+      throw new Exception("doLookupJMSObjects failed:", e);
+    }
+  }
+
+  /*
+   * doCleanup()
+   */
+  private void doCleanup() throws Exception {
+    try {
+      if (queueTest && consumerQ != null) {
+        TestUtil.logMsg("Flush any messages left on Queue");
+        Message rmsg = consumerQ.receive(timeout);
+        while (rmsg != null) {
+          rmsg = consumerQ.receiveNoWait();
+          if (rmsg == null) {
+            rmsg = consumerQ.receiveNoWait();
+          }
+        }
+        consumerQ.close();
+      }
+      if (consumerT != null)
+        consumerT.close();
+      TestUtil.logMsg("Close JMSContext Objects");
+      if (context != null)
+        context.close();
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw new Exception("doCleanup failed!", e);
+    }
+  }
+
+  /*
+   * @testName: sendAndRecvQueueTestFromAppClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Queue.
+   *
+   */
+  public void sendAndRecvQueueTestFromAppClient() throws Fault {
+    boolean pass = true;
+    String message = "Where are you!";
+    try {
+      doLookupJMSObjects();
+      queueTest = true;
+      // send and receive TextMessage
+      TestUtil.logMsg(
+          "Creating TextMessage via JMSContext.createTextMessage(String)");
+      TextMessage expTextMessage = context.createTextMessage(message);
+      TestUtil.logMsg("Set some values in TextMessage");
+      expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME",
+          "sendAndRecvQueueTestFromAppClient");
+      TestUtil.logMsg(
+          "Sending TextMessage via JMSProducer.send(Destination, Message)");
+      producerQ.send(queue, expTextMessage);
+      TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
+      TextMessage actTextMessage = (TextMessage) consumerQ.receive(timeout);
+      if (actTextMessage == null) {
+        throw new Fault("Did not receive TextMessage");
+      }
+      TestUtil.logMsg("Check the value in TextMessage");
+      if (actTextMessage.getText().equals(expTextMessage.getText())) {
+        TestUtil.logMsg("TextMessage is correct");
+      } else {
+        TestUtil.logErr(
+            "TextMessage is incorrect expected " + expTextMessage.getText()
+                + ", received " + actTextMessage.getText());
+        pass = false;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw new Fault("sendAndRecvQueueTestFromAppClient", e);
+    } finally {
+      try {
+        doCleanup();
+      } catch (Exception e) {
+        throw new Fault("doCleanup failed: ", e);
+      }
     }
 
-    /*  Test setup */
+    if (!pass) {
+      throw new Fault("sendAndRecvQueueTestFromAppClient failed");
+    }
+  }
 
-    /*
-     *   @class.setup_props: jms_timeout; user; password; platform.mode; 
-     *			     webServerHost; webServerPort;
-     */
-    public void setup(String[] args, Properties p) throws Fault {
-	props = p;
-        boolean pass = true;
-	try {
-            // get props
-            timeout = Integer.parseInt(p.getProperty("jms_timeout"));
-            user = p.getProperty("user");
-            password = p.getProperty("password");
-            mode = p.getProperty("platform.mode");
-	    hostname = p.getProperty("webServerHost");
-
-            // check props for errors
-            if (timeout < 1) {
-                throw new Exception("'jms_timeout' (milliseconds) in ts.jte must be > 0");
-            }
-            if (user == null ) {
-                throw new Exception("'user' in ts.jte must not be null ");
-            }
-            if (password == null ) {
-                throw new Exception("'password' in ts.jte must not be null ");
-            }
-            if (mode == null) {
-                throw new Exception("'platform.mode' in ts.jte must not be null");
-            }
-            if (hostname == null) {
-                throw new Exception("'webServerHost' in ts.jte must not be null");
-            }
-            try {
-                portnum = Integer.parseInt(p.getProperty("webServerPort"));
-            } catch (Exception e) {
-                throw new Exception("'webServerPort' in ts.jte must be a number");
-            }
-	    if(ejbclient == null) {
-	        throw new Fault("setup failed: ejbclient injection failure");
-	    } 
-	} catch (Exception e ) {
-	    throw new Fault("setup failed:", e );
-	}
-	TestUtil.logMsg("setup ok" );
+  /*
+   * @testName: sendAndRecvTopicTestFromAppClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Topic.
+   *
+   */
+  public void sendAndRecvTopicTestFromAppClient() throws Fault {
+    boolean pass = true;
+    String message = "Where are you!";
+    try {
+      doLookupJMSObjects();
+      queueTest = false;
+      // send and receive TextMessage
+      TestUtil.logMsg(
+          "Creating TextMessage via JMSContext.createTextMessage(String)");
+      TextMessage expTextMessage = context.createTextMessage(message);
+      TestUtil.logMsg("Set some values in TextMessage");
+      expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME",
+          "sendAndRecvTopicTestFromAppClient");
+      TestUtil.logMsg(
+          "Sending TextMessage via JMSProducer.send(Destination, Message)");
+      producerT.send(topic, expTextMessage);
+      TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
+      TextMessage actTextMessage = (TextMessage) consumerT.receive(timeout);
+      if (actTextMessage == null) {
+        throw new Fault("Did not receive TextMessage");
+      }
+      TestUtil.logMsg("Check the value in TextMessage");
+      if (actTextMessage.getText().equals(expTextMessage.getText())) {
+        TestUtil.logMsg("TextMessage is correct");
+      } else {
+        TestUtil.logErr(
+            "TextMessage is incorrect expected " + expTextMessage.getText()
+                + ", received " + actTextMessage.getText());
+        pass = false;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw new Fault("sendAndRecvTopicTestFromAppClient", e);
+    } finally {
+      try {
+        doCleanup();
+      } catch (Exception e) {
+        throw new Fault("doCleanup failed: ", e);
+      }
     }
 
-    /*
-     * cleanup() is called after each test
-     * 
-     * @exception Fault
-     */
-    public void cleanup() throws Fault {
-	TestUtil.logMsg("cleanup ok" );
+    if (!pass) {
+      throw new Fault("sendAndRecvTopicTestFromAppClient failed");
+    }
+  }
+
+  /*
+   * @testName: sendAndRecvQueueTestFromServletClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Queue.
+   *
+   */
+  public void sendAndRecvQueueTestFromServletClient() throws Fault {
+    boolean pass = true;
+    try {
+      TestUtil.logMsg("-------------------------------------");
+      TestUtil.logMsg("sendAndRecvQueueTestFromServletClient");
+      TestUtil.logMsg("-------------------------------------");
+      url = ctsurl.getURL("http", hostname, portnum, SERVLET);
+      TestUtil.logMsg("Servlet URL: " + url);
+      props.setProperty("TEST", "sendAndRecvQueueTestFromServletClient");
+      urlConn = TestUtil.sendPostData(props, url);
+      Properties p = TestUtil.getResponseProperties(urlConn);
+      String passStr = p.getProperty("TESTRESULT");
+      if (passStr.equals("fail")) {
+        pass = false;
+        TestUtil
+            .logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
+        TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
+      } else {
+        TestUtil
+            .logMsg("JMSConnectionFactoryDefinitions test passed from Servlet");
+        TestUtil.logMsg("JMSDestinationDefinitions test passed from Servlet");
+      }
+    } catch (Exception e) {
+      TestUtil
+          .logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
+      TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
+      pass = false;
     }
 
-    /*
-     * Lookup JMS Connection Factory and Destination Objects
-     */
-    private void doLookupJMSObjects() throws Exception {
-	try {
-	    TestUtil.logMsg("Lookup JMS factories defined in @JMSConnectionFactoryDefinitions");
-	    TestUtil.logMsg("Lookup JMS destinations defined in @JMSDestinationDefinitions");
-	    TSNamingContext namingctx = new TSNamingContext();
-	    TestUtil.logMsg("Lookup java:comp/DefaultJMSConnectionFactory");
-            dcf = (ConnectionFactory) 
-		namingctx.lookup("java:comp/DefaultJMSConnectionFactory");
-	    TestUtil.logMsg("Lookup java:global/AppClientMyTestConnectionFactory");
-            cf = (ConnectionFactory) 
-		namingctx.lookup("java:global/AppClientMyTestConnectionFactory");
-	    TestUtil.logMsg("Lookup java:app/AppClientMyTestQueueConnectionFactory");
-            qcf = (QueueConnectionFactory) 
-		namingctx.lookup("java:app/AppClientMyTestQueueConnectionFactory");
-	    TestUtil.logMsg("Lookup java:module/AppClientMyTestTopicConnectionFactory");
-            tcf = (TopicConnectionFactory) 
-		namingctx.lookup("java:module/AppClientMyTestTopicConnectionFactory");
-	    TestUtil.logMsg("Lookup java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory");
-            dtcf = (TopicConnectionFactory) 
-		namingctx.lookup("java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory");
-	    TestUtil.logMsg("Lookup java:global/env/AppClientMyTestQueue");
-            queue = (Queue) namingctx.lookup("java:global/env/AppClientMyTestQueue");
-	    TestUtil.logMsg("Lookup java:app/env/AppClientMyTestTopic");
-            topic = (Topic) namingctx.lookup("java:app/env/AppClientMyTestTopic");
+    if (!pass) {
+      throw new Fault("sendAndRecvQueueTestFromServletClient failed");
+    }
+  }
 
-	    TestUtil.logMsg("Create JMSContext, JMSProducer's and JMSConsumer's");
-            context = cf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
-	    producerQ = context.createProducer();
-	    consumerQ = context.createConsumer(queue);
-	    producerT = context.createProducer();
-	    consumerT = context.createConsumer(topic);
-	} catch (Exception e ) {
-	    throw new Exception("doLookupJMSObjects failed:", e );
-	}
+  /*
+   * @testName: sendAndRecvTopicTestFromServletClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Topic.
+   *
+   */
+  public void sendAndRecvTopicTestFromServletClient() throws Fault {
+    boolean pass = true;
+    try {
+      TestUtil.logMsg("-------------------------------------");
+      TestUtil.logMsg("sendAndRecvTopicTestFromServletClient");
+      TestUtil.logMsg("-------------------------------------");
+      url = ctsurl.getURL("http", hostname, portnum, SERVLET);
+      TestUtil.logMsg("Servlet URL: " + url);
+      props.setProperty("TEST", "sendAndRecvTopicTestFromServletClient");
+      urlConn = TestUtil.sendPostData(props, url);
+      Properties p = TestUtil.getResponseProperties(urlConn);
+      String passStr = p.getProperty("TESTRESULT");
+      if (passStr.equals("fail")) {
+        pass = false;
+        TestUtil
+            .logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
+        TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
+      } else {
+        TestUtil
+            .logMsg("JMSConnectionFactoryDefinitions test passed from Servlet");
+        TestUtil.logMsg("JMSDestinationDefinitions test passed from Servlet");
+      }
+    } catch (Exception e) {
+      TestUtil
+          .logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
+      TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
+      pass = false;
     }
 
+    if (!pass) {
+      throw new Fault("sendAndRecvTopicTestFromServletClient failed");
+    }
+  }
 
-    /*
-     * doCleanup()
-     */
-    private void doCleanup() throws Exception {
-        try {
-            if(queueTest && consumerQ != null) {
-                TestUtil.logMsg("Flush any messages left on Queue");
-		Message rmsg = consumerQ.receive(timeout);
-                while (rmsg != null) {
-                    rmsg = consumerQ.receiveNoWait();
-                    if (rmsg == null) {
-                        rmsg = consumerQ.receiveNoWait();
-                    }
-		}
-	        consumerQ.close();
-             }
-	    if(consumerT != null)
-	        consumerT.close();
-	    TestUtil.logMsg("Close JMSContext Objects");
-            if(context != null)
-                context.close();
-	} catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-	    throw new Exception("doCleanup failed!", e);
-	}
+  /*
+   * @testName: sendAndRecvQueueTestFromJspClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Queue.
+   *
+   */
+  public void sendAndRecvQueueTestFromJspClient() throws Fault {
+    boolean pass = true;
+    try {
+      TestUtil.logMsg("---------------------------------");
+      TestUtil.logMsg("sendAndRecvQueueTestFromJspClient");
+      TestUtil.logMsg("---------------------------------");
+      url = ctsurl.getURL("http", hostname, portnum, JSP);
+      TestUtil.logMsg("Jsp URL: " + url);
+      props.setProperty("TEST", "sendAndRecvQueueTestFromJspClient");
+      urlConn = TestUtil.sendPostData(props, url);
+      Properties p = TestUtil.getResponseProperties(urlConn);
+      String passStr = p.getProperty("TESTRESULT");
+      if (passStr.equals("fail")) {
+        pass = false;
+        TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
+        TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
+      } else {
+        TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Jsp");
+        TestUtil.logMsg("JMSDestinationDefinitions test passed from Jsp");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
+      TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
+      pass = false;
     }
 
-    /*
-     * @testName:      sendAndRecvQueueTestFromAppClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348; 
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Queue.
-     *
-     */
-    public void sendAndRecvQueueTestFromAppClient() throws Fault {
-	boolean pass = true;
-	String message = "Where are you!";
-        try {
-	    doLookupJMSObjects();
-	    queueTest = true;
-            // send and receive TextMessage
-            TestUtil.logMsg("Creating TextMessage via JMSContext.createTextMessage(String)");
-            TextMessage expTextMessage = context.createTextMessage(message);
-            TestUtil.logMsg("Set some values in TextMessage");
-            expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME", "sendAndRecvQueueTestFromAppClient");
-	    TestUtil.logMsg("Sending TextMessage via JMSProducer.send(Destination, Message)");
-            producerQ.send(queue, expTextMessage);
-            TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
-            TextMessage actTextMessage = (TextMessage) consumerQ.receive(timeout);
-            if (actTextMessage == null) {
-                throw new Fault("Did not receive TextMessage");
-            }
-            TestUtil.logMsg("Check the value in TextMessage");
-	    if(actTextMessage.getText().equals(expTextMessage.getText())) {
-		TestUtil.logMsg("TextMessage is correct");
-	    } else {
-		TestUtil.logErr("TextMessage is incorrect expected " + expTextMessage.getText() 
-			+ ", received " + actTextMessage.getText());
-		pass = false;
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            throw new Fault("sendAndRecvQueueTestFromAppClient", e);
-        } finally {
-	    try {
-	        doCleanup();
-	    } catch(Exception e) {
-		throw new Fault("doCleanup failed: ", e);
-	    }
-	}
+    if (!pass) {
+      throw new Fault("sendAndRecvQueueTestFromJspClient failed");
+    }
+  }
 
-        if (!pass) {
-            throw new Fault("sendAndRecvQueueTestFromAppClient failed");
-        }
+  /*
+   * @testName: sendAndRecvTopicTestFromJspClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Topic.
+   *
+   */
+  public void sendAndRecvTopicTestFromJspClient() throws Fault {
+    boolean pass = true;
+    try {
+      TestUtil.logMsg("---------------------------------");
+      TestUtil.logMsg("sendAndRecvTopicTestFromJspClient");
+      TestUtil.logMsg("---------------------------------");
+      url = ctsurl.getURL("http", hostname, portnum, JSP);
+      TestUtil.logMsg("Jsp URL: " + url);
+      props.setProperty("TEST", "sendAndRecvTopicTestFromJspClient");
+      urlConn = TestUtil.sendPostData(props, url);
+      Properties p = TestUtil.getResponseProperties(urlConn);
+      String passStr = p.getProperty("TESTRESULT");
+      if (passStr.equals("fail")) {
+        pass = false;
+        TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
+        TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
+      } else {
+        TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Jsp");
+        TestUtil.logMsg("JMSDestinationDefinitions test passed from Jsp");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
+      TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
+      pass = false;
     }
 
-    /*
-     * @testName:      sendAndRecvTopicTestFromAppClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Topic.
-     *
-     */
-    public void sendAndRecvTopicTestFromAppClient() throws Fault {
-	boolean pass = true;
-	String message = "Where are you!";
-        try {
-	    doLookupJMSObjects();
-	    queueTest = false;
-            // send and receive TextMessage
-            TestUtil.logMsg("Creating TextMessage via JMSContext.createTextMessage(String)");
-            TextMessage expTextMessage = context.createTextMessage(message);
-            TestUtil.logMsg("Set some values in TextMessage");
-            expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME", "sendAndRecvTopicTestFromAppClient");
-	    TestUtil.logMsg("Sending TextMessage via JMSProducer.send(Destination, Message)");
-            producerT.send(topic, expTextMessage);
-            TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
-            TextMessage actTextMessage = (TextMessage) consumerT.receive(timeout);
-            if (actTextMessage == null) {
-                throw new Fault("Did not receive TextMessage");
-            }
-            TestUtil.logMsg("Check the value in TextMessage");
-	    if(actTextMessage.getText().equals(expTextMessage.getText())) {
-		TestUtil.logMsg("TextMessage is correct");
-	    } else {
-		TestUtil.logErr("TextMessage is incorrect expected " + expTextMessage.getText() 
-			+ ", received " + actTextMessage.getText());
-		pass = false;
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            throw new Fault("sendAndRecvTopicTestFromAppClient", e);
-        } finally {
-	    try {
-	        doCleanup();
-	    } catch(Exception e) {
-		throw new Fault("doCleanup failed: ", e);
-	    }
-        } 
+    if (!pass) {
+      throw new Fault("sendAndRecvTopicTestFromJspClient failed");
+    }
+  }
 
-        if (!pass) {
-            throw new Fault("sendAndRecvTopicTestFromAppClient failed");
-        }
+  /*
+   * @testName: sendAndRecvQueueTestFromEjbClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Queue.
+   *
+   */
+  public void sendAndRecvQueueTestFromEjbClient() throws Fault {
+    boolean pass = true;
+    try {
+      ejbclient.init(props);
+      TestUtil.logMsg("---------------------------------");
+      TestUtil.logMsg("sendAndRecvQueueTestFromEjbClient");
+      TestUtil.logMsg("---------------------------------");
+      boolean passEjb = ejbclient.echo("sendAndRecvQueueTestFromEjbClient");
+      if (!passEjb) {
+        pass = false;
+        TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
+        TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
+      } else {
+        TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Ejb");
+        TestUtil.logMsg("JMSDestinationDefinitions test passed from Ejb");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
+      TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
+      pass = false;
     }
 
-    /*
-     * @testName:      sendAndRecvQueueTestFromServletClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Queue.
-     *
-     */
-    public void sendAndRecvQueueTestFromServletClient() throws Fault {
-	boolean pass = true;
-        try {
-	    TestUtil.logMsg("-------------------------------------");
-            TestUtil.logMsg("sendAndRecvQueueTestFromServletClient");
-	    TestUtil.logMsg("-------------------------------------");
-            url = ctsurl.getURL("http", hostname, portnum, SERVLET);
-            TestUtil.logMsg("Servlet URL: "+url);
-            props.setProperty("TEST", "sendAndRecvQueueTestFromServletClient");
-            urlConn = TestUtil.sendPostData(props, url);
-            Properties p = TestUtil.getResponseProperties(urlConn);
-            String passStr = p.getProperty("TESTRESULT");
-            if(passStr.equals("fail")) {
-                pass = false;
-                TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
-                TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
-	    } else {
-                TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Servlet");
-                TestUtil.logMsg("JMSDestinationDefinitions test passed from Servlet");
-	    }
-        } catch(Exception e) {
-            TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
-            TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
-	    pass = false;
-        }
+    if (!pass) {
+      throw new Fault("sendAndRecvQueueTestFromEjbClient failed");
+    }
+  }
 
-        if (!pass) {
-            throw new Fault("sendAndRecvQueueTestFromServletClient failed");
-        }
+  /*
+   * @testName: sendAndRecvTopicTestFromEjbClient
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Send and receive a message to/from a Topic.
+   *
+   */
+  public void sendAndRecvTopicTestFromEjbClient() throws Fault {
+    boolean pass = true;
+    try {
+      ejbclient.init(props);
+      TestUtil.logMsg("---------------------------------");
+      TestUtil.logMsg("sendAndRecvTopicTestFromEjbClient");
+      TestUtil.logMsg("---------------------------------");
+      boolean passEjb = ejbclient.echo("sendAndRecvTopicTestFromEjbClient");
+      if (!passEjb) {
+        pass = false;
+        TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
+        TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
+      } else {
+        TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Ejb");
+        TestUtil.logMsg("JMSDestinationDefinitions test passed from Ejb");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
+      TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
+      pass = false;
     }
 
-    /*
-     * @testName:      sendAndRecvTopicTestFromServletClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Topic.
-     *
-     */
-    public void sendAndRecvTopicTestFromServletClient() throws Fault {
-	boolean pass = true;
-        try {
-	    TestUtil.logMsg("-------------------------------------");
-            TestUtil.logMsg("sendAndRecvTopicTestFromServletClient");
-	    TestUtil.logMsg("-------------------------------------");
-            url = ctsurl.getURL("http", hostname, portnum, SERVLET);
-            TestUtil.logMsg("Servlet URL: "+url);
-            props.setProperty("TEST", "sendAndRecvTopicTestFromServletClient");
-            urlConn = TestUtil.sendPostData(props, url);
-            Properties p = TestUtil.getResponseProperties(urlConn);
-            String passStr = p.getProperty("TESTRESULT");
-            if(passStr.equals("fail")) {
-                pass = false;
-                TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
-                TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
-	    } else {
-                TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Servlet");
-                TestUtil.logMsg("JMSDestinationDefinitions test passed from Servlet");
-	    }
-        } catch(Exception e) {
-            TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Servlet");
-            TestUtil.logErr("JMSDestinationDefinitions test failed from Servlet");
-	    pass = false;
-        }
+    if (!pass) {
+      throw new Fault("sendAndRecvTopicTestFromEjbClient failed");
+    }
+  }
 
-        if (!pass) {
-            throw new Fault("sendAndRecvTopicTestFromServletClient failed");
-        }
+  /*
+   * @testName: checkClientIDOnDurableConnFactoryTest
+   *
+   * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
+   * JMS:JAVADOC:1330; JMS:JAVADOC:1331; JMS:JAVADOC:1332; JMS:JAVADOC:1333;
+   * JMS:JAVADOC:1334; JMS:JAVADOC:1335; JMS:JAVADOC:1336; JMS:JAVADOC:1338;
+   * JMS:JAVADOC:1339; JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344;
+   * JMS:JAVADOC:1345; JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
+   * JMS:JAVADOC:1451; JMS:JAVADOC:1452;
+   *
+   * @test_Strategy: Check client id setting on durable connection factory
+   *
+   */
+  public void checkClientIDOnDurableConnFactoryTest() throws Fault {
+    boolean pass = true;
+    JMSContext context = null;
+    try {
+      queueTest = false;
+      doLookupJMSObjects();
+      TestUtil.logMsg(
+          "==============================================================");
+      TestUtil.logMsg(
+          "Verify admin configured client id is MyClientID from AppClient");
+      TestUtil.logMsg(
+          "==============================================================");
+      TestUtil
+          .logMsg("Create JMSContext from durable topic connection factory");
+      TestUtil.logMsg(
+          "Check the client id which is configured as MyClientID in the "
+              + "JMSConnectionFactoryDefinition annotation");
+      context = dtcf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
+      String clientid = context.getClientID();
+      if (clientid == null) {
+        TestUtil.logErr("Client ID value is null (expected MyClientID)");
+        pass = false;
+      } else if (clientid.equals("MyClientID")) {
+        TestUtil.logMsg("Client ID value is correct (MyClientID)");
+      } else {
+        TestUtil
+            .logErr("Client ID value is incorrect (expected MyClientID, got "
+                + clientid + ")");
+        pass = false;
+      }
+      context.close();
+      context = null;
+      try {
+        doCleanup();
+      } catch (Exception e) {
+        TestUtil.logErr("Error in cleanup");
+      }
+      TestUtil.logMsg(
+          "==================================================================");
+      TestUtil.logMsg(
+          "Verify admin configured client id is MyClientID from ServletClient");
+      TestUtil.logMsg(
+          "==================================================================");
+      url = ctsurl.getURL("http", hostname, portnum, SERVLET);
+      TestUtil.logMsg("Servlet URL: " + url);
+      props.setProperty("TEST", "checkClientIDTestFromServletClient");
+      urlConn = TestUtil.sendPostData(props, url);
+      Properties p = TestUtil.getResponseProperties(urlConn);
+      String passStr = p.getProperty("TESTRESULT");
+      if (passStr.equals("fail")) {
+        pass = false;
+        TestUtil.logErr("Check ClientID test failed from Servlet");
+      } else {
+        TestUtil.logMsg("Check ClientID test passed from Servlet");
+      }
+      TestUtil.logMsg(
+          "==============================================================");
+      TestUtil.logMsg(
+          "Verify admin configured client id is MyClientID from JspClient");
+      TestUtil.logMsg(
+          "==============================================================");
+      url = ctsurl.getURL("http", hostname, portnum, JSP);
+      TestUtil.logMsg("Jsp URL: " + url);
+      props.setProperty("TEST", "checkClientIDTestFromJspClient");
+      urlConn = TestUtil.sendPostData(props, url);
+      p = TestUtil.getResponseProperties(urlConn);
+      passStr = p.getProperty("TESTRESULT");
+      if (passStr.equals("fail")) {
+        pass = false;
+        TestUtil.logErr("Check ClientID test failed from Jsp");
+      } else {
+        TestUtil.logMsg("Check ClientID test passed from Jsp");
+      }
+      TestUtil.logMsg(
+          "==============================================================");
+      TestUtil.logMsg(
+          "Verify admin configured client id is MyClientID from EjbClient");
+      TestUtil.logMsg(
+          "==============================================================");
+      boolean passEjb = ejbclient.echo("checkClientIDTestFromEjbClient");
+      if (!passEjb) {
+        pass = false;
+        TestUtil.logErr("Check ClientID test failed from Ejb");
+      } else {
+        TestUtil.logMsg("Check ClientID test passed from Ejb");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw new Fault("checkClientIDOnDurableConnFactoryTest", e);
+    } finally {
+      try {
+        if (context != null)
+          context.close();
+        doCleanup();
+      } catch (Exception e) {
+        TestUtil.logErr("Error cleanup " + e);
+      }
     }
 
-    /*
-     * @testName:      sendAndRecvQueueTestFromJspClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Queue.
-     *
-     */
-    public void sendAndRecvQueueTestFromJspClient() throws Fault {
-	boolean pass = true;
-        try {
-	    TestUtil.logMsg("---------------------------------");
-            TestUtil.logMsg("sendAndRecvQueueTestFromJspClient");
-	    TestUtil.logMsg("---------------------------------");
-            url = ctsurl.getURL("http", hostname, portnum, JSP);
-            TestUtil.logMsg("Jsp URL: "+url);
-            props.setProperty("TEST", "sendAndRecvQueueTestFromJspClient");
-            urlConn = TestUtil.sendPostData(props, url);
-            Properties p = TestUtil.getResponseProperties(urlConn);
-            String passStr = p.getProperty("TESTRESULT");
-            if(passStr.equals("fail")) {
-                pass = false;
-                TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
-                TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
-	    } else {
-                TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Jsp");
-                TestUtil.logMsg("JMSDestinationDefinitions test passed from Jsp");
-	    }
-        } catch(Exception e) {
-            TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
-            TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
-	    pass = false;
-        }
-
-        if (!pass) {
-            throw new Fault("sendAndRecvQueueTestFromJspClient failed");
-        }
+    if (!pass) {
+      throw new Fault("checkClientIDOnDurableConnFactoryTest failed");
     }
-
-    /*
-     * @testName:      sendAndRecvTopicTestFromJspClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Topic.
-     *
-     */
-    public void sendAndRecvTopicTestFromJspClient() throws Fault {
-	boolean pass = true;
-        try {
-	    TestUtil.logMsg("---------------------------------");
-            TestUtil.logMsg("sendAndRecvTopicTestFromJspClient");
-	    TestUtil.logMsg("---------------------------------");
-            url = ctsurl.getURL("http", hostname, portnum, JSP);
-            TestUtil.logMsg("Jsp URL: "+url);
-            props.setProperty("TEST", "sendAndRecvTopicTestFromJspClient");
-            urlConn = TestUtil.sendPostData(props, url);
-            Properties p = TestUtil.getResponseProperties(urlConn);
-            String passStr = p.getProperty("TESTRESULT");
-            if(passStr.equals("fail")) {
-                pass = false;
-                TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
-                TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
-	    } else {
-                TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Jsp");
-                TestUtil.logMsg("JMSDestinationDefinitions test passed from Jsp");
-	    }
-        } catch(Exception e) {
-            TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Jsp");
-            TestUtil.logErr("JMSDestinationDefinitions test failed from Jsp");
-	    pass = false;
-        }
-
-        if (!pass) {
-            throw new Fault("sendAndRecvTopicTestFromJspClient failed");
-        }
-    }
-
-    /*
-     * @testName:      sendAndRecvQueueTestFromEjbClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Queue.
-     *
-     */
-    public void sendAndRecvQueueTestFromEjbClient() throws Fault {
-	boolean pass = true;
-        try {
-	    ejbclient.init(props);
-	    TestUtil.logMsg("---------------------------------");
-            TestUtil.logMsg("sendAndRecvQueueTestFromEjbClient");
-	    TestUtil.logMsg("---------------------------------");
-            boolean passEjb  = ejbclient.echo("sendAndRecvQueueTestFromEjbClient");
-            if(!passEjb) {
-                pass = false;
-                TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
-                TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
-	    } else {
-                TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Ejb");
-                TestUtil.logMsg("JMSDestinationDefinitions test passed from Ejb");
-	    }
-        } catch(Exception e) {
-            TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
-            TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
-	    pass = false;
-        }
-
-        if (!pass) {
-            throw new Fault("sendAndRecvQueueTestFromEjbClient failed");
-        }
-    }
-
-    /*
-     * @testName:      sendAndRecvTopicTestFromEjbClient
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Send and receive a message to/from a Topic.
-     *
-     */
-    public void sendAndRecvTopicTestFromEjbClient() throws Fault {
-	boolean pass = true;
-        try {
-	    ejbclient.init(props);
-	    TestUtil.logMsg("---------------------------------");
-            TestUtil.logMsg("sendAndRecvTopicTestFromEjbClient");
-	    TestUtil.logMsg("---------------------------------");
-            boolean passEjb  = ejbclient.echo("sendAndRecvTopicTestFromEjbClient");
-            if(!passEjb) {
-                pass = false;
-                TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
-                TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
-	    } else {
-                TestUtil.logMsg("JMSConnectionFactoryDefinitions test passed from Ejb");
-                TestUtil.logMsg("JMSDestinationDefinitions test passed from Ejb");
-	    }
-        } catch(Exception e) {
-            TestUtil.logErr("JMSConnectionFactoryDefinitions test failed from Ejb");
-            TestUtil.logErr("JMSDestinationDefinitions test failed from Ejb");
-	    pass = false;
-        }
-
-        if (!pass) {
-            throw new Fault("sendAndRecvTopicTestFromEjbClient failed");
-        }
-    }
-
-    /*
-     * @testName:      checkClientIDOnDurableConnFactoryTest
-     *
-     * @assertion_ids: JMS:JAVADOC:1324; JMS:JAVADOC:1325; JMS:JAVADOC:1327;
-     *		       JMS:JAVADOC:1330; JMS:JAVADOC:1331;
-     *		       JMS:JAVADOC:1332; JMS:JAVADOC:1333; JMS:JAVADOC:1334; JMS:JAVADOC:1335;
-     *		       JMS:JAVADOC:1336; JMS:JAVADOC:1338; JMS:JAVADOC:1339;
-     *		       JMS:JAVADOC:1342; JMS:JAVADOC:1343; JMS:JAVADOC:1344; JMS:JAVADOC:1345;
-     *		       JMS:JAVADOC:1346; JMS:JAVADOC:1347; JMS:JAVADOC:1348;
-     *		       JMS:JAVADOC:1451; JMS:JAVADOC:1452;
-     *
-     * @test_Strategy: Check client id setting on durable connection factory
-     *
-     */
-    public void checkClientIDOnDurableConnFactoryTest() throws Fault {
-	boolean pass = true;
-	JMSContext context = null;
-        try {
-	    queueTest = false;
-	    doLookupJMSObjects();
-	    TestUtil.logMsg("==============================================================");
-	    TestUtil.logMsg("Verify admin configured client id is MyClientID from AppClient");
-	    TestUtil.logMsg("==============================================================");
-	    TestUtil.logMsg("Create JMSContext from durable topic connection factory");
-	    TestUtil.logMsg("Check the client id which is configured as MyClientID in the " +
-			"JMSConnectionFactoryDefinition annotation");
-            context = dtcf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
-	    String clientid = context.getClientID();
-	    if(clientid == null) {
-		TestUtil.logErr("Client ID value is null (expected MyClientID)");
-		pass = false;
-	    } else if(clientid.equals("MyClientID")) {
-		TestUtil.logMsg("Client ID value is correct (MyClientID)");
-	    } else {
-		TestUtil.logErr("Client ID value is incorrect (expected MyClientID, got "+clientid+")");
-		pass = false;
-	    }
-	    context.close();
-	    context = null;
-            try{
-	        doCleanup();
-            }catch(Exception e){
-                TestUtil.logErr("Error in cleanup");
-            }
-	    TestUtil.logMsg("==================================================================");
-	    TestUtil.logMsg("Verify admin configured client id is MyClientID from ServletClient");
-	    TestUtil.logMsg("==================================================================");
-            url = ctsurl.getURL("http", hostname, portnum, SERVLET);
-            TestUtil.logMsg("Servlet URL: "+url);
-            props.setProperty("TEST", "checkClientIDTestFromServletClient");
-            urlConn = TestUtil.sendPostData(props, url);
-            Properties p = TestUtil.getResponseProperties(urlConn);
-            String passStr = p.getProperty("TESTRESULT");
-            if(passStr.equals("fail")) {
-                pass = false;
-                TestUtil.logErr("Check ClientID test failed from Servlet");
-	    } else {
-                TestUtil.logMsg("Check ClientID test passed from Servlet");
-	    }
-	    TestUtil.logMsg("==============================================================");
-	    TestUtil.logMsg("Verify admin configured client id is MyClientID from JspClient");
-	    TestUtil.logMsg("==============================================================");
-            url = ctsurl.getURL("http", hostname, portnum, JSP);
-            TestUtil.logMsg("Jsp URL: "+url);
-            props.setProperty("TEST", "checkClientIDTestFromJspClient");
-            urlConn = TestUtil.sendPostData(props, url);
-            p = TestUtil.getResponseProperties(urlConn);
-            passStr = p.getProperty("TESTRESULT");
-            if(passStr.equals("fail")) {
-                pass = false;
-                TestUtil.logErr("Check ClientID test failed from Jsp");
-	    } else {
-                TestUtil.logMsg("Check ClientID test passed from Jsp");
-	    }
-	    TestUtil.logMsg("==============================================================");
-	    TestUtil.logMsg("Verify admin configured client id is MyClientID from EjbClient");
-	    TestUtil.logMsg("==============================================================");
-            boolean passEjb  = ejbclient.echo("checkClientIDTestFromEjbClient");
-            if(!passEjb) {
-                pass = false;
-                TestUtil.logErr("Check ClientID test failed from Ejb");
-	    } else {
-                TestUtil.logMsg("Check ClientID test passed from Ejb");
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            throw new Fault("checkClientIDOnDurableConnFactoryTest", e);
-        } finally {
-	    try {
-		if(context != null)
-		    context.close();
-                doCleanup();
-	    } catch(Exception e) {
-                TestUtil.logErr("Error cleanup " +e ); 
-            }
-	}
-
-        if (!pass) {
-            throw new Fault("checkClientIDOnDurableConnFactoryTest failed");
-        }
-    }
+  }
 
 }

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/Client.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/Client.java.src
@@ -32,65 +32,61 @@ import java.util.Iterator;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-  @JMSDestinationDefinition(
-	description="Define Queue AppClientMyTestQueue",
-	interfaceName="jakarta.jms.Queue",
-	name="java:global/env/AppClientMyTestQueue",
-    	destinationName="AppClientMyTestQueue"
-   ),
+@JMSDestinationDefinition(
+      description="Define Queue AppClientMyTestQueue",
+      interfaceName="jakarta.jms.Queue",
+      name="java:global/env/AppClientMyTestQueue",
+      destinationName="AppClientMyTestQueue"
+ )
 
-  @JMSDestinationDefinition(
-	description="Define Topic AppClientMyTestTopic",
-	interfaceName="jakarta.jms.Topic",
-	name="java:app/env/AppClientMyTestTopic",
-	destinationName="AppClientMyTestTopic"
-   )
+@JMSDestinationDefinition(
+      description="Define Topic AppClientMyTestTopic",
+      interfaceName="jakarta.jms.Topic",
+      name="java:app/env/AppClientMyTestTopic",
+      destinationName="AppClientMyTestTopic"
+ )
 
-})
 
 //-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
 //-------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-  @JMSConnectionFactoryDefinition(
-	description="Define ConnectionFactory AppClientMyTestConnectionFactory",
-	interfaceName="jakarta.jms.ConnectionFactory",
-    	name="java:global/AppClientMyTestConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define ConnectionFactory AppClientMyTestConnectionFactory",
+      interfaceName="jakarta.jms.ConnectionFactory",
+      name="java:global/AppClientMyTestConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define QueueConnectionFactory AppClientMyTestQueueConnectionFactory",
-	interfaceName="jakarta.jms.QueueConnectionFactory",
-    	name="java:app/AppClientMyTestQueueConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define QueueConnectionFactory AppClientMyTestQueueConnectionFactory",
+      interfaceName="jakarta.jms.QueueConnectionFactory",
+      name="java:app/AppClientMyTestQueueConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define TopicConnectionFactory AppClientMyTestTopicConnectionFactory",
-	interfaceName="jakarta.jms.TopicConnectionFactory",
-    	name="java:module/AppClientMyTestTopicConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define TopicConnectionFactory AppClientMyTestTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:module/AppClientMyTestTopicConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
 
-  @JMSConnectionFactoryDefinition(
-	description="Define Durable TopicConnectionFactory AppClientMyTestDurableTopicConnectionFactory",
-	interfaceName="jakarta.jms.TopicConnectionFactory",
-    	name="java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory",
-	user = "@user@",
-	password = "@password@",
-	clientId = "MyClientID",
-	properties = { "Property1=10", "Property2=20" },
-	transactional = false,
-	maxPoolSize = 30,
-	minPoolSize = 20
-   )
-})
+@JMSConnectionFactoryDefinition(
+      description="Define Durable TopicConnectionFactory AppClientMyTestDurableTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:comp/env/jms/AppClientMyTestDurableTopicConnectionFactory",
+      user = "@user@",
+      password = "@password@",
+      clientId = "MyClientID",
+      properties = { "Property1=10", "Property2=20" },
+      transactional = false,
+      maxPoolSize = 30,
+      minPoolSize = 20
+ )
 
 public class Client extends EETest {
     private static final long serialVersionUID = 1L;

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/EjbClient.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/EjbClient.java.src
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,25 +17,32 @@
 
 package com.sun.ts.tests.jms.ee20.resourcedefs.annotations;
 
-import com.sun.ts.lib.util.*;
-import com.sun.ts.lib.porting.*;
-
 import java.util.Properties;
-import java.util.ArrayList;
+
+import com.sun.ts.lib.util.RemoteLoggingInitException;
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
 import jakarta.ejb.EJBException;
 import jakarta.ejb.Remote;
 import jakarta.ejb.Stateful;
-import jakarta.ejb.SessionContext;
 import jakarta.ejb.TransactionManagement;
 import jakarta.ejb.TransactionManagementType;
-import jakarta.jms.*;
-import jakarta.transaction.*;
-import javax.naming.*;
-import jakarta.inject.Inject;
-import jakarta.annotation.Resource;
-import jakarta.annotation.PostConstruct;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSConnectionFactoryDefinition;
+import jakarta.jms.JMSConnectionFactoryDefinitions;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSDestinationDefinition;
+import jakarta.jms.JMSDestinationDefinitions;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnectionFactory;
 
-import com.sun.ts.tests.jms.common.*;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
@@ -92,254 +100,287 @@ import com.sun.ts.tests.jms.common.*;
 	minPoolSize = 20
    )
 
-@Stateful(name="JMSResourceDefsEjbClientBean")
-@Remote({EjbClientIF.class})
+@Stateful(name = "JMSResourceDefsEjbClientBean")
+@Remote({ EjbClientIF.class })
 @TransactionManagement(TransactionManagementType.BEAN)
 public class EjbClient implements EjbClientIF {
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    // JMS objects
-    protected transient ConnectionFactory	cf = null;
-    protected transient ConnectionFactory	dcf = null;
-    protected transient ConnectionFactory	cfra = null;
-    protected transient QueueConnectionFactory 	qcf = null;
-    protected transient TopicConnectionFactory 	tcf = null;
-    protected transient TopicConnectionFactory 	dtcf = null;
-    protected transient Topic 			topic = null;
-    protected transient Topic 			topica = null;
-    protected transient Queue 			queue = null;
-    protected transient JMSContext              context = null;
-    protected transient JMSConsumer             consumerQ = null;
-    protected transient JMSProducer             producerQ = null;
-    protected transient JMSConsumer             consumerT = null;
-    protected transient JMSProducer             producerT = null;
-    protected boolean			        queueTest = false;
+  // JMS objects
+  protected transient ConnectionFactory cf = null;
 
-    // Harness req's
-    protected Properties              		props = null;
+  protected transient ConnectionFactory dcf = null;
 
-    // properties read from ts.jte file
-    protected long                            	timeout;
-    protected String                          	user;
-    protected String                          	password;
-    protected String                          	mode;
+  protected transient ConnectionFactory cfra = null;
 
-    /*
-     * doCleanup()
-     */
-    private void doCleanup() throws Exception {
-        try {
-            if(queueTest && consumerQ != null) {
-                TestUtil.logMsg("Flush any messages left on Queue");
-		Message rmsg = consumerQ.receive(timeout);
-                while (rmsg != null) {
-                    rmsg = consumerQ.receiveNoWait();
-                    if (rmsg == null) {
-                        rmsg = consumerQ.receiveNoWait();
-                    }
-		}
-	        consumerQ.close();
-             }
-	    if(consumerT != null)
-	        consumerT.close();
-	    TestUtil.logMsg("Close JMSContext Objects");
-            if(context != null)
-                context.close();
-	} catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-	    throw new Exception("doCleanup failed!", e);
-	}
-    }
+  protected transient QueueConnectionFactory qcf = null;
 
-    public void init(Properties p) {
-        try {
-            TestUtil.init(p);
-            // get props
-            timeout = Long.parseLong(p.getProperty("jms_timeout"));
-            user = p.getProperty("user");
-            password = p.getProperty("password");
-            mode = p.getProperty("platform.mode");
+  protected transient TopicConnectionFactory tcf = null;
 
-            // check props for errors
-            if (timeout < 1) {
-                throw new Exception("'jms_timeout' (milliseconds) in ts.jte must be > 0");
-            }
-            if (user == null ) {
-                throw new Exception("'user' in ts.jte must not be null ");
-            }
-            if (password == null ) {
-                throw new Exception("'password' in ts.jte must not be null ");
-            }
-            if (mode == null) {
-                throw new Exception("'platform.mode' in ts.jte must not be null");
-            }
-	    doLookupJMSObjects();
-        } catch (RemoteLoggingInitException e) {
-            TestUtil.printStackTrace(e);
-            throw new EJBException("init: failed");
-        } catch (Exception e) {
-            TestUtil.printStackTrace(e);
-            throw new EJBException("init: failed");
+  protected transient TopicConnectionFactory dtcf = null;
+
+  protected transient Topic topic = null;
+
+  protected transient Topic topica = null;
+
+  protected transient Queue queue = null;
+
+  protected transient JMSContext context = null;
+
+  protected transient JMSConsumer consumerQ = null;
+
+  protected transient JMSProducer producerQ = null;
+
+  protected transient JMSConsumer consumerT = null;
+
+  protected transient JMSProducer producerT = null;
+
+  protected boolean queueTest = false;
+
+  // Harness req's
+  protected Properties props = null;
+
+  // properties read from ts.jte file
+  protected long timeout;
+
+  protected String user;
+
+  protected String password;
+
+  protected String mode;
+
+  /*
+   * doCleanup()
+   */
+  private void doCleanup() throws Exception {
+    try {
+      if (queueTest && consumerQ != null) {
+        TestUtil.logMsg("Flush any messages left on Queue");
+        Message rmsg = consumerQ.receive(timeout);
+        while (rmsg != null) {
+          rmsg = consumerQ.receiveNoWait();
+          if (rmsg == null) {
+            rmsg = consumerQ.receiveNoWait();
+          }
         }
+        consumerQ.close();
+      }
+      if (consumerT != null)
+        consumerT.close();
+      TestUtil.logMsg("Close JMSContext Objects");
+      if (context != null)
+        context.close();
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw new Exception("doCleanup failed!", e);
+    }
+  }
+
+  public void init(Properties p) {
+    try {
+      TestUtil.init(p);
+      // get props
+      timeout = Long.parseLong(p.getProperty("jms_timeout"));
+      user = p.getProperty("user");
+      password = p.getProperty("password");
+      mode = p.getProperty("platform.mode");
+
+      // check props for errors
+      if (timeout < 1) {
+        throw new Exception(
+            "'jms_timeout' (milliseconds) in ts.jte must be > 0");
+      }
+      if (user == null) {
+        throw new Exception("'user' in ts.jte must not be null ");
+      }
+      if (password == null) {
+        throw new Exception("'password' in ts.jte must not be null ");
+      }
+      if (mode == null) {
+        throw new Exception("'platform.mode' in ts.jte must not be null");
+      }
+      doLookupJMSObjects();
+    } catch (RemoteLoggingInitException e) {
+      TestUtil.printStackTrace(e);
+      throw new EJBException("init: failed");
+    } catch (Exception e) {
+      TestUtil.printStackTrace(e);
+      throw new EJBException("init: failed");
+    }
+  }
+
+  public boolean echo(String testName) {
+    boolean pass = false;
+
+    if (testName.equals("sendAndRecvQueueTestFromEjbClient"))
+      pass = sendAndRecvQueueTestFromEjbClient();
+    else if (testName.equals("sendAndRecvTopicTestFromEjbClient"))
+      pass = sendAndRecvTopicTestFromEjbClient();
+    else if (testName.equals("checkClientIDTestFromEjbClient"))
+      pass = checkClientIDTestFromEjbClient();
+    try {
+      doCleanup();
+    } catch (Exception e) {
+      pass = false;
+    }
+    return pass;
+  }
+
+  /*
+   * Lookup JMS Connection Factory and Destination Objects
+   */
+  private void doLookupJMSObjects() throws Exception {
+    try {
+      TestUtil.logMsg(
+          "Lookup JMS factories defined in @JMSConnectionFactoryDefinitions");
+      TestUtil.logMsg(
+          "Lookup JMS destinations defined in @JMSDestinationDefinitions");
+      TSNamingContext namingctx = new TSNamingContext();
+      TestUtil.logMsg("Lookup java:comp/DefaultJMSConnectionFactory");
+      dcf = (ConnectionFactory) namingctx
+          .lookup("java:comp/DefaultJMSConnectionFactory");
+      TestUtil.logMsg("Lookup java:global/EJBMyTestConnectionFactory");
+      cf = (ConnectionFactory) namingctx
+          .lookup("java:global/EJBMyTestConnectionFactory");
+      TestUtil.logMsg("Lookup java:app/EJBMyTestQueueConnectionFactory");
+      qcf = (QueueConnectionFactory) namingctx
+          .lookup("java:app/EJBMyTestQueueConnectionFactory");
+      TestUtil.logMsg("Lookup java:module/EJBMyTestTopicConnectionFactory");
+      tcf = (TopicConnectionFactory) namingctx
+          .lookup("java:module/EJBMyTestTopicConnectionFactory");
+      TestUtil.logMsg(
+          "Lookup java:comp/env/jms/EJBMyTestDurableTopicConnectionFactory");
+      dtcf = (TopicConnectionFactory) namingctx
+          .lookup("java:comp/env/jms/EJBMyTestDurableTopicConnectionFactory");
+      TestUtil.logMsg("Lookup java:global/env/EJBMyTestQueue");
+      queue = (Queue) namingctx.lookup("java:global/env/EJBMyTestQueue");
+      TestUtil.logMsg("Lookup java:app/env/EJBMyTestTopic");
+      topic = (Topic) namingctx.lookup("java:app/env/EJBMyTestTopic");
+
+      TestUtil.logMsg("Create JMSContext, JMSProducer's and JMSConsumer's");
+      context = cf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
+      producerQ = context.createProducer();
+      consumerQ = context.createConsumer(queue);
+      producerT = context.createProducer();
+      consumerT = context.createConsumer(topic);
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw e;
+    }
+  }
+
+  public boolean sendAndRecvQueueTestFromEjbClient() {
+    boolean pass = true;
+    String message = "Where are you!";
+    try {
+      queueTest = true;
+      // send and receive TextMessage
+      TestUtil.logMsg(
+          "Creating TextMessage via JMSContext.createTextMessage(String)");
+      TextMessage expTextMessage = context.createTextMessage(message);
+      TestUtil.logMsg("Set some values in TextMessage");
+      expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME",
+          "sendAndRecvQueueTestFromEjbClient");
+      TestUtil.logMsg(
+          "Sending TextMessage via JMSProducer.send(Destination, Message)");
+      producerQ.send(queue, expTextMessage);
+      TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
+      TextMessage actTextMessage = (TextMessage) consumerQ.receive(timeout);
+      if (actTextMessage == null) {
+        TestUtil.logErr("Did not receive TextMessage");
+        pass = false;
+      } else {
+        TestUtil.logMsg("Check the value in TextMessage");
+        if (actTextMessage.getText().equals(expTextMessage.getText())) {
+          TestUtil.logMsg("TextMessage is correct");
+        } else {
+          TestUtil.logErr(
+              "TextMessage is incorrect expected " + expTextMessage.getText()
+                  + ", received " + actTextMessage.getText());
+          pass = false;
+        }
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      pass = false;
     }
 
-    public boolean echo(String testName) {
-	boolean pass = false;
+    return pass;
+  }
 
-	if(testName.equals("sendAndRecvQueueTestFromEjbClient"))
-            pass = sendAndRecvQueueTestFromEjbClient();
-	else if(testName.equals("sendAndRecvTopicTestFromEjbClient"))
-            pass = sendAndRecvTopicTestFromEjbClient();
-	else if(testName.equals("checkClientIDTestFromEjbClient"))
-            pass = checkClientIDTestFromEjbClient();
-	try {
-	    doCleanup();
-	} catch(Exception e) {
-	    pass = false;
-	}
-	return pass;
+  public boolean sendAndRecvTopicTestFromEjbClient() {
+    boolean pass = true;
+    String message = "Where are you!";
+    try {
+      queueTest = false;
+      // send and receive TextMessage
+      TestUtil.logMsg(
+          "Creating TextMessage via JMSContext.createTextMessage(String)");
+      TextMessage expTextMessage = context.createTextMessage(message);
+      TestUtil.logMsg("Set some values in TextMessage");
+      expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME",
+          "sendAndRecvTopicTestFromEjbClient");
+      TestUtil.logMsg(
+          "Sending TextMessage via JMSProducer.send(Destination, Message)");
+      producerT.send(topic, expTextMessage);
+      TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
+      TextMessage actTextMessage = (TextMessage) consumerT.receive(timeout);
+      if (actTextMessage == null) {
+        TestUtil.logErr("Did not receive TextMessage");
+        pass = false;
+      } else {
+        TestUtil.logMsg("Check the value in TextMessage");
+        if (actTextMessage.getText().equals(expTextMessage.getText())) {
+          TestUtil.logMsg("TextMessage is correct");
+        } else {
+          TestUtil.logErr(
+              "TextMessage is incorrect expected " + expTextMessage.getText()
+                  + ", received " + actTextMessage.getText());
+          pass = false;
+        }
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      pass = false;
     }
+    return pass;
+  }
 
-    /*
-     * Lookup JMS Connection Factory and Destination Objects
-     */
-    private void doLookupJMSObjects() throws Exception {
-	try {
-	    TestUtil.logMsg("Lookup JMS factories defined in @JMSConnectionFactoryDefinitions");
-	    TestUtil.logMsg("Lookup JMS destinations defined in @JMSDestinationDefinitions");
-	    TSNamingContext namingctx = new TSNamingContext();
-	    TestUtil.logMsg("Lookup java:comp/DefaultJMSConnectionFactory");
-            dcf = (ConnectionFactory) 
-		namingctx.lookup("java:comp/DefaultJMSConnectionFactory");
-	    TestUtil.logMsg("Lookup java:global/EJBMyTestConnectionFactory");
-            cf = (ConnectionFactory) 
-		namingctx.lookup("java:global/EJBMyTestConnectionFactory");
-	    TestUtil.logMsg("Lookup java:app/EJBMyTestQueueConnectionFactory");
-            qcf = (QueueConnectionFactory) 
-		namingctx.lookup("java:app/EJBMyTestQueueConnectionFactory");
-	    TestUtil.logMsg("Lookup java:module/EJBMyTestTopicConnectionFactory");
-            tcf = (TopicConnectionFactory) 
-		namingctx.lookup("java:module/EJBMyTestTopicConnectionFactory");
-	    TestUtil.logMsg("Lookup java:comp/env/jms/EJBMyTestDurableTopicConnectionFactory");
-            dtcf = (TopicConnectionFactory) 
-		namingctx.lookup("java:comp/env/jms/EJBMyTestDurableTopicConnectionFactory");
-	    TestUtil.logMsg("Lookup java:global/env/EJBMyTestQueue");
-            queue = (Queue) namingctx.lookup("java:global/env/EJBMyTestQueue");
-	    TestUtil.logMsg("Lookup java:app/env/EJBMyTestTopic");
-            topic = (Topic) namingctx.lookup("java:app/env/EJBMyTestTopic");
-
-	    TestUtil.logMsg("Create JMSContext, JMSProducer's and JMSConsumer's");
-            context = cf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
-	    producerQ = context.createProducer();
-	    consumerQ = context.createConsumer(queue);
-	    producerT = context.createProducer();
-	    consumerT = context.createConsumer(topic);
-	} catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-	    throw e;
-	}
+  public boolean checkClientIDTestFromEjbClient() {
+    boolean pass = true;
+    JMSContext context = null;
+    try {
+      queueTest = false;
+      doLookupJMSObjects();
+      TestUtil
+          .logMsg("Create JMSContext from durable topic connection factory");
+      TestUtil.logMsg(
+          "Check the client id which is configured as MyClientID in the "
+              + "JMSConnectionFactoryDefinition annotation");
+      context = dtcf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
+      String clientid = context.getClientID();
+      if (clientid == null) {
+        TestUtil.logErr("Client ID value is null (expected MyClientID)");
+        pass = false;
+      } else if (clientid.equals("MyClientID")) {
+        TestUtil.logMsg("Client ID value is correct (MyClientID)");
+      } else {
+        TestUtil
+            .logErr("Client ID value is incorrect (expected MyClientID, got "
+                + clientid + ")");
+        pass = false;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      pass = false;
+    } finally {
+      try {
+        if (context != null)
+          context.close();
+      } catch (Exception e) {
+      }
     }
-
-
-    public boolean sendAndRecvQueueTestFromEjbClient() {
-	boolean pass = true;
-	String message = "Where are you!";
-        try {
-	    queueTest = true;
-            // send and receive TextMessage
-            TestUtil.logMsg("Creating TextMessage via JMSContext.createTextMessage(String)");
-            TextMessage expTextMessage = context.createTextMessage(message);
-            TestUtil.logMsg("Set some values in TextMessage");
-            expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME", "sendAndRecvQueueTestFromEjbClient");
-	    TestUtil.logMsg("Sending TextMessage via JMSProducer.send(Destination, Message)");
-            producerQ.send(queue, expTextMessage);
-            TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
-            TextMessage actTextMessage = (TextMessage) consumerQ.receive(timeout);
-            if (actTextMessage == null) {
-                TestUtil.logErr("Did not receive TextMessage");
-		pass = false;
-            } else {
-                TestUtil.logMsg("Check the value in TextMessage");
-	        if(actTextMessage.getText().equals(expTextMessage.getText())) {
-		    TestUtil.logMsg("TextMessage is correct");
-	        } else {
-		    TestUtil.logErr("TextMessage is incorrect expected " + expTextMessage.getText() 
-			+ ", received " + actTextMessage.getText());
-		    pass = false;
-		}
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            pass = false;
-        } 
-
-	return pass;
-    }
-
-    public boolean sendAndRecvTopicTestFromEjbClient() {
-	boolean pass = true;
-	String message = "Where are you!";
-        try {
-	    queueTest = false;
-            // send and receive TextMessage
-            TestUtil.logMsg("Creating TextMessage via JMSContext.createTextMessage(String)");
-            TextMessage expTextMessage = context.createTextMessage(message);
-            TestUtil.logMsg("Set some values in TextMessage");
-            expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME", "sendAndRecvTopicTestFromEjbClient");
-	    TestUtil.logMsg("Sending TextMessage via JMSProducer.send(Destination, Message)");
-            producerT.send(topic, expTextMessage);
-            TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
-            TextMessage actTextMessage = (TextMessage) consumerT.receive(timeout);
-            if (actTextMessage == null) {
-                TestUtil.logErr("Did not receive TextMessage");
-		pass = false;
-            } else {
-                TestUtil.logMsg("Check the value in TextMessage");
-	        if(actTextMessage.getText().equals(expTextMessage.getText())) {
-		    TestUtil.logMsg("TextMessage is correct");
-	        } else {
-		    TestUtil.logErr("TextMessage is incorrect expected " + expTextMessage.getText() 
-			+ ", received " + actTextMessage.getText());
-		    pass = false;
-	        }
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            pass = false;
-        } 
-	return pass;
-    }
-
-    public boolean checkClientIDTestFromEjbClient() {
-	boolean pass = true;
-	JMSContext context = null;
-        try {
-	    queueTest = false;
-	    doLookupJMSObjects();
-	    TestUtil.logMsg("Create JMSContext from durable topic connection factory");
-	    TestUtil.logMsg("Check the client id which is configured as MyClientID in the " +
-			"JMSConnectionFactoryDefinition annotation");
-            context = dtcf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
-	    String clientid = context.getClientID();
-	    if(clientid == null) {
-		TestUtil.logErr("Client ID value is null (expected MyClientID)");
-		pass = false;
-	    } else if(clientid.equals("MyClientID")) {
-		TestUtil.logMsg("Client ID value is correct (MyClientID)");
-	    } else {
-		TestUtil.logErr("Client ID value is incorrect (expected MyClientID, got "+clientid+")");
-		pass = false;
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            pass = false;
-        } finally {
-	    try {
-		if(context != null)
-		    context.close();
-	    } catch(Exception e) {}
-	}
-	return pass;
-    }
+    return pass;
+  }
 
 }

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/EjbClient.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/EjbClient.java.src
@@ -38,13 +38,12 @@ import com.sun.ts.tests.jms.common.*;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
   @JMSDestinationDefinition(
 	description="Define Queue EJBMyTestQueue",
 	interfaceName="jakarta.jms.Queue",
 	name="java:global/env/EJBMyTestQueue",
     	destinationName="EJBMyTestQueue"
-   ),
+   )
 
   @JMSDestinationDefinition(
 	description="Define Topic EJBMyTestTopic",
@@ -53,19 +52,16 @@ import com.sun.ts.tests.jms.common.*;
 	destinationName="EJBMyTestTopic"
    )
 
-})
-
 //-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
 //-------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
   @JMSConnectionFactoryDefinition(
 	description="Define ConnectionFactory EJBMyTestConnectionFactory",
 	interfaceName="jakarta.jms.ConnectionFactory",
     	name="java:global/EJBMyTestConnectionFactory",
 	user = "@user@",
 	password = "@password@"
-   ),
+   )
 
   @JMSConnectionFactoryDefinition(
 	description="Define QueueConnectionFactory EJBMyTestQueueConnectionFactory",
@@ -73,7 +69,7 @@ import com.sun.ts.tests.jms.common.*;
     	name="java:app/EJBMyTestQueueConnectionFactory",
 	user = "@user@",
 	password = "@password@"
-   ),
+   )
 
   @JMSConnectionFactoryDefinition(
 	description="Define TopicConnectionFactory EJBMyTestTopicConnectionFactory",
@@ -81,7 +77,7 @@ import com.sun.ts.tests.jms.common.*;
     	name="java:module/EJBMyTestTopicConnectionFactory",
 	user = "@user@",
 	password = "@password@"
-   ),
+   )
 
   @JMSConnectionFactoryDefinition(
 	description="Define Durable TopicConnectionFactory EJBMyTestDurableTopicConnectionFactory",
@@ -95,8 +91,6 @@ import com.sun.ts.tests.jms.common.*;
 	maxPoolSize = 30,
 	minPoolSize = 20
    )
-})
-
 
 @Stateful(name="JMSResourceDefsEjbClientBean")
 @Remote({EjbClientIF.class})

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/MyBean.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/MyBean.java.src
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +17,10 @@
 
 package com.sun.ts.tests.jms.ee20.resourcedefs.annotations;
 
-import jakarta.jms.*;
+import jakarta.jms.JMSConnectionFactoryDefinition;
+import jakarta.jms.JMSConnectionFactoryDefinitions;
+import jakarta.jms.JMSDestinationDefinition;
+import jakarta.jms.JMSDestinationDefinitions;
 
 //-------------------------------------
 // JMS Destination Resource Definitions
@@ -76,6 +80,6 @@ import jakarta.jms.*;
  )
 
 public class MyBean {
-    public MyBean() {
-    }
+  public MyBean() {
+  }
 }

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/MyBean.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/MyBean.java.src
@@ -21,64 +21,59 @@ import jakarta.jms.*;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-  @JMSDestinationDefinition(
-	description="Define Queue JSPMyTestQueue",
-	interfaceName="jakarta.jms.Queue",
-	name="java:global/env/JSPMyTestQueue",
-    	destinationName="JSPMyTestQueue"
-   ),
+@JMSDestinationDefinition(
+      description="Define Queue JSPMyTestQueue",
+      interfaceName="jakarta.jms.Queue",
+      name="java:global/env/JSPMyTestQueue",
+      destinationName="JSPMyTestQueue"
+ )
 
-  @JMSDestinationDefinition(
-	description="Define Topic JSPMyTestTopic",
-	interfaceName="jakarta.jms.Topic",
-	name="java:app/env/JSPMyTestTopic",
-	destinationName="JSPMyTestTopic"
-   )
-
-})
+@JMSDestinationDefinition(
+      description="Define Topic JSPMyTestTopic",
+      interfaceName="jakarta.jms.Topic",
+      name="java:app/env/JSPMyTestTopic",
+      destinationName="JSPMyTestTopic"
+ )
 
 //-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
 //-------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-  @JMSConnectionFactoryDefinition(
-	description="Define ConnectionFactory JSPMyTestConnectionFactory",
-	interfaceName="jakarta.jms.ConnectionFactory",
-    	name="java:global/JSPMyTestConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define ConnectionFactory JSPMyTestConnectionFactory",
+      interfaceName="jakarta.jms.ConnectionFactory",
+      name="java:global/JSPMyTestConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define QueueConnectionFactory JSPMyTestQueueConnectionFactory",
-	interfaceName="jakarta.jms.QueueConnectionFactory",
-    	name="java:app/JSPMyTestQueueConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define QueueConnectionFactory JSPMyTestQueueConnectionFactory",
+      interfaceName="jakarta.jms.QueueConnectionFactory",
+      name="java:app/JSPMyTestQueueConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define TopicConnectionFactory JSPMyTestTopicConnectionFactory",
-	interfaceName="jakarta.jms.TopicConnectionFactory",
-    	name="java:module/JSPMyTestTopicConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define TopicConnectionFactory JSPMyTestTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:module/JSPMyTestTopicConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define Durable TopicConnectionFactory JSPMyTestDurableTopicConnectionFactory",
-	interfaceName="jakarta.jms.TopicConnectionFactory",
-    	name="java:comp/env/jms/JSPMyTestDurableTopicConnectionFactory",
-	user = "@user@",
-	password = "@password@",
-	clientId = "MyClientID",
-	properties = { "Property1=10", "Property2=20" },
-	transactional = false,
-	maxPoolSize = 30,
-	minPoolSize = 20
-   )
-})
+@JMSConnectionFactoryDefinition(
+      description="Define Durable TopicConnectionFactory JSPMyTestDurableTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:comp/env/jms/JSPMyTestDurableTopicConnectionFactory",
+      user = "@user@",
+      password = "@password@",
+      clientId = "MyClientID",
+      properties = { "Property1=10", "Property2=20" },
+      transactional = false,
+      maxPoolSize = 30,
+      minPoolSize = 20
+ )
 
 public class MyBean {
     public MyBean() {

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/ServletClient.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/ServletClient.java.src
@@ -36,65 +36,59 @@ import jakarta.annotation.Resource;
 //-------------------------------------
 // JMS Destination Resource Definitions
 //-------------------------------------
-@JMSDestinationDefinitions(value = {
-  @JMSDestinationDefinition(
-	description="Define Queue ServletMyTestQueue",
-	interfaceName="jakarta.jms.Queue",
-	name="java:global/env/ServletMyTestQueue",
-    	destinationName="ServletMyTestQueue"
-   ),
+@JMSDestinationDefinition(
+      description="Define Queue ServletMyTestQueue",
+      interfaceName="jakarta.jms.Queue",
+      name="java:global/env/ServletMyTestQueue",
+      destinationName="ServletMyTestQueue"
+ )
 
-  @JMSDestinationDefinition(
-	description="Define Topic ServletMyTestTopic",
-	interfaceName="jakarta.jms.Topic",
-	name="java:app/env/ServletMyTestTopic",
-	destinationName="ServletMyTestTopic"
-   )
-
-})
+@JMSDestinationDefinition(
+      description="Define Topic ServletMyTestTopic",
+      interfaceName="jakarta.jms.Topic",
+      name="java:app/env/ServletMyTestTopic",
+      destinationName="ServletMyTestTopic"
+ )
 
 //-------------------------------------------
 // JMS ConnectionFactory Resource Definitions
 //-------------------------------------------
-@JMSConnectionFactoryDefinitions(value = {
-  @JMSConnectionFactoryDefinition(
-	description="Define ConnectionFactory ServletMyTestConnectionFactory",
-	interfaceName="jakarta.jms.ConnectionFactory",
-    	name="java:global/ServletMyTestConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define ConnectionFactory ServletMyTestConnectionFactory",
+      interfaceName="jakarta.jms.ConnectionFactory",
+      name="java:global/ServletMyTestConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define QueueConnectionFactory ServletMyTestQueueConnectionFactory",
-	interfaceName="jakarta.jms.QueueConnectionFactory",
-    	name="java:app/ServletMyTestQueueConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define QueueConnectionFactory ServletMyTestQueueConnectionFactory",
+      interfaceName="jakarta.jms.QueueConnectionFactory",
+      name="java:app/ServletMyTestQueueConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-  @JMSConnectionFactoryDefinition(
-	description="Define TopicConnectionFactory ServletMyTestTopicConnectionFactory",
-	interfaceName="jakarta.jms.TopicConnectionFactory",
-    	name="java:module/ServletMyTestTopicConnectionFactory",
-	user = "@user@",
-	password = "@password@"
-   ),
+@JMSConnectionFactoryDefinition(
+      description="Define TopicConnectionFactory ServletMyTestTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:module/ServletMyTestTopicConnectionFactory",
+      user = "@user@",
+      password = "@password@"
+ )
 
-
-  @JMSConnectionFactoryDefinition(
-	description="Define Durable TopicConnectionFactory ServletMyTestDurableTopicConnectionFactory",
-	interfaceName="jakarta.jms.TopicConnectionFactory",
-    	name="java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory",
-	user = "@user@",
-	password = "@password@",
-	clientId = "MyClientID",
-	properties = { "Property1=10", "Property2=20" },
-	transactional = false,
-	maxPoolSize = 30,
-	minPoolSize = 20
-   )
-})
+@JMSConnectionFactoryDefinition(
+      description="Define Durable TopicConnectionFactory ServletMyTestDurableTopicConnectionFactory",
+      interfaceName="jakarta.jms.TopicConnectionFactory",
+      name="java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory",
+      user = "@user@",
+      password = "@password@",
+      clientId = "MyClientID",
+      properties = { "Property1=10", "Property2=20" },
+      transactional = false,
+      maxPoolSize = 30,
+      minPoolSize = 20
+ )
 
 @WebServlet("/ServletTest")
 public class ServletClient extends HttpServlet {

--- a/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/ServletClient.java.src
+++ b/src/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/files/ServletClient.java.src
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,22 +17,34 @@
 
 package com.sun.ts.tests.jms.ee20.resourcedefs.annotations;
 
-import com.sun.ts.lib.util.*;
-import com.sun.ts.lib.porting.*;
-import com.sun.ts.tests.jms.common.*;
-
-import java.io.*;
-import jakarta.servlet.*;
-import jakarta.servlet.http.*;
-import jakarta.servlet.annotation.WebServlet;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Enumeration;
 import java.util.Properties;
-import java.util.ArrayList;
-import jakarta.transaction.*;
-import javax.naming.*;
-import jakarta.jms.*;
-import jakarta.inject.Inject;
-import jakarta.annotation.Resource;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSConnectionFactoryDefinition;
+import jakarta.jms.JMSConnectionFactoryDefinitions;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSDestinationDefinition;
+import jakarta.jms.JMSDestinationDefinitions;
+import jakarta.jms.JMSProducer;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnectionFactory;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 //-------------------------------------
 // JMS Destination Resource Definitions
@@ -92,290 +105,319 @@ import jakarta.annotation.Resource;
 
 @WebServlet("/ServletTest")
 public class ServletClient extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    // JMS objects
-    protected transient ConnectionFactory	cf = null;
-    protected transient ConnectionFactory	dcf = null;
-    protected transient ConnectionFactory	cfra = null;
-    protected transient QueueConnectionFactory 	qcf = null;
-    protected transient TopicConnectionFactory 	tcf = null;
-    protected transient TopicConnectionFactory 	dtcf = null;
-    protected transient Topic 			topic = null;
-    protected transient Topic 			topica = null;
-    protected transient Queue 			queue = null;
-    protected transient JMSContext              context = null;
-    protected transient JMSConsumer             consumerQ = null;
-    protected transient JMSProducer             producerQ = null;
-    protected transient JMSConsumer             consumerT = null;
-    protected transient JMSProducer             producerT = null;
-    protected boolean			        queueTest = false;
+  // JMS objects
+  protected transient ConnectionFactory cf = null;
 
-    // Harness req's
-    protected Properties              		harnessProps = null;
+  protected transient ConnectionFactory dcf = null;
 
-    // properties read from ts.jte file
-    protected long                            	timeout;
-    protected String                          	user;
-    protected String                          	password;
-    protected String                          	mode;
+  protected transient ConnectionFactory cfra = null;
 
-    /*
-     * doCleanup()
-     */
-    private void doCleanup() throws Exception {
-        try {
-            if(queueTest && consumerQ != null) {
-                TestUtil.logMsg("Flush any messages left on Queue");
-		Message rmsg = consumerQ.receive(timeout);
-                while (rmsg != null) {
-                    rmsg = consumerQ.receiveNoWait();
-                    if (rmsg == null) {
-                        rmsg = consumerQ.receiveNoWait();
-                    }
-		}
-	        consumerQ.close();
-             }
-            if(consumerT != null)
-	        consumerT.close();
-	    TestUtil.logMsg("Close JMSContext Objects");
-            if(context != null)
-                context.close();
-	} catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-	    throw new Exception("doCleanup failed!", e);
-	}
+  protected transient QueueConnectionFactory qcf = null;
+
+  protected transient TopicConnectionFactory tcf = null;
+
+  protected transient TopicConnectionFactory dtcf = null;
+
+  protected transient Topic topic = null;
+
+  protected transient Topic topica = null;
+
+  protected transient Queue queue = null;
+
+  protected transient JMSContext context = null;
+
+  protected transient JMSConsumer consumerQ = null;
+
+  protected transient JMSProducer producerQ = null;
+
+  protected transient JMSConsumer consumerT = null;
+
+  protected transient JMSProducer producerT = null;
+
+  protected boolean queueTest = false;
+
+  // Harness req's
+  protected Properties harnessProps = null;
+
+  // properties read from ts.jte file
+  protected long timeout;
+
+  protected String user;
+
+  protected String password;
+
+  protected String mode;
+
+  /*
+   * doCleanup()
+   */
+  private void doCleanup() throws Exception {
+    try {
+      if (queueTest && consumerQ != null) {
+        TestUtil.logMsg("Flush any messages left on Queue");
+        Message rmsg = consumerQ.receive(timeout);
+        while (rmsg != null) {
+          rmsg = consumerQ.receiveNoWait();
+          if (rmsg == null) {
+            rmsg = consumerQ.receiveNoWait();
+          }
+        }
+        consumerQ.close();
+      }
+      if (consumerT != null)
+        consumerT.close();
+      TestUtil.logMsg("Close JMSContext Objects");
+      if (context != null)
+        context.close();
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw new Exception("doCleanup failed!", e);
+    }
+  }
+
+  public void init(ServletConfig config) throws ServletException {
+    super.init(config);
+  }
+
+  public void doGet(HttpServletRequest req, HttpServletResponse res)
+      throws ServletException, IOException {
+    boolean pass = true;
+    Properties p = new Properties();
+    res.setContentType("text/plain");
+    PrintWriter out = res.getWriter();
+
+    try {
+      String test = harnessProps.getProperty("TEST");
+      System.out.println("doGet: test to execute is: " + test);
+      if (test.equals("sendAndRecvQueueTestFromServletClient")) {
+        if (sendAndRecvQueueTestFromServletClient())
+          p.setProperty("TESTRESULT", "pass");
+        else
+          p.setProperty("TESTRESULT", "fail");
+      } else if (test.equals("sendAndRecvTopicTestFromServletClient")) {
+        if (sendAndRecvTopicTestFromServletClient())
+          p.setProperty("TESTRESULT", "pass");
+        else
+          p.setProperty("TESTRESULT", "fail");
+      } else if (test.equals("checkClientIDTestFromServletClient")) {
+        if (checkClientIDTestFromServletClient())
+          p.setProperty("TESTRESULT", "pass");
+        else
+          p.setProperty("TESTRESULT", "fail");
+      } else {
+        p.setProperty("TESTRESULT", "fail");
+      }
+      doCleanup();
+      p.list(out);
+    } catch (Exception e) {
+      TestUtil.logErr("doGet: Exception: " + e);
+      System.out.println("doGet: Exception: " + e);
+      p.setProperty("TESTRESULT", "fail");
+      p.list(out);
+    }
+    out.close();
+  }
+
+  public void doPost(HttpServletRequest req, HttpServletResponse res)
+      throws ServletException, IOException {
+    harnessProps = new Properties();
+    Enumeration enumlist = req.getParameterNames();
+    while (enumlist.hasMoreElements()) {
+      String name = (String) enumlist.nextElement();
+      String value = req.getParameter(name);
+      harnessProps.setProperty(name, value);
     }
 
-    public void init(ServletConfig config) throws ServletException
-    {
-	super.init(config);
+    try {
+      TestUtil.init(harnessProps);
+      // get props
+      timeout = Long.parseLong(harnessProps.getProperty("jms_timeout"));
+      user = harnessProps.getProperty("user");
+      password = harnessProps.getProperty("password");
+      mode = harnessProps.getProperty("platform.mode");
+
+      // check props for errors
+      if (timeout < 1) {
+        throw new Exception(
+            "'jms_timeout' (milliseconds) in ts.jte must be > 0");
+      }
+      if (user == null) {
+        throw new Exception("'user' in ts.jte must not be null ");
+      }
+      if (password == null) {
+        throw new Exception("'password' in ts.jte must not be null ");
+      }
+      if (mode == null) {
+        throw new Exception("'platform.mode' in ts.jte must not be null");
+      }
+      doLookupJMSObjects();
+    } catch (Exception e) {
+      System.out.println("doPost: Exception: " + e);
+      e.printStackTrace();
+      throw new ServletException("unable to initialize remote logging");
+    }
+    doGet(req, res);
+    harnessProps = null;
+  }
+
+  /*
+   * Lookup JMS Connection Factory and Destination Objects
+   */
+  private void doLookupJMSObjects() throws Exception {
+    try {
+      TestUtil.logMsg(
+          "Lookup JMS factories defined by @JMSConnectionFactoryDefinitions");
+      TestUtil.logMsg(
+          "Lookup JMS destinations defined by @JMSDestinationDefinitions");
+      TSNamingContext namingctx = new TSNamingContext();
+      TestUtil.logMsg("Lookup java:comp/DefaultJMSConnectionFactory");
+      dcf = (ConnectionFactory) namingctx
+          .lookup("java:comp/DefaultJMSConnectionFactory");
+      TestUtil.logMsg("Lookup java:global/ServletMyTestConnectionFactory");
+      cf = (ConnectionFactory) namingctx
+          .lookup("java:global/ServletMyTestConnectionFactory");
+      TestUtil.logMsg("Lookup java:app/ServletMyTestQueueConnectionFactory");
+      qcf = (QueueConnectionFactory) namingctx
+          .lookup("java:app/ServletMyTestQueueConnectionFactory");
+      TestUtil.logMsg("Lookup java:module/ServletMyTestTopicConnectionFactory");
+      tcf = (TopicConnectionFactory) namingctx
+          .lookup("java:module/ServletMyTestTopicConnectionFactory");
+      TestUtil.logMsg(
+          "Lookup java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory");
+      dtcf = (TopicConnectionFactory) namingctx.lookup(
+          "java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory");
+      TestUtil.logMsg("Lookup java:global/env/ServletMyTestQueue");
+      queue = (Queue) namingctx.lookup("java:global/env/ServletMyTestQueue");
+      TestUtil.logMsg("Lookup java:app/env/ServletMyTestTopic");
+      topic = (Topic) namingctx.lookup("java:app/env/ServletMyTestTopic");
+
+      TestUtil.logMsg("Create JMSContext, JMSProducer's and JMSConsumer's");
+      context = cf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
+      producerQ = context.createProducer();
+      consumerQ = context.createConsumer(queue);
+      producerT = context.createProducer();
+      consumerT = context.createConsumer(topic);
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      throw e;
+    }
+  }
+
+  public boolean sendAndRecvQueueTestFromServletClient() {
+    boolean pass = true;
+    String message = "Where are you!";
+    try {
+      queueTest = true;
+      // send and receive TextMessage
+      TestUtil.logMsg(
+          "Creating TextMessage via JMSContext.createTextMessage(String)");
+      TextMessage expTextMessage = context.createTextMessage(message);
+      TestUtil.logMsg("Set some values in TextMessage");
+      expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME",
+          "sendAndRecvQueueTestFromServletClient");
+      TestUtil.logMsg(
+          "Sending TextMessage via JMSProducer.send(Destination, Message)");
+      producerQ.send(queue, expTextMessage);
+      TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
+      TextMessage actTextMessage = (TextMessage) consumerQ.receive(timeout);
+      if (actTextMessage == null) {
+        TestUtil.logErr("Did not receive TextMessage");
+        pass = false;
+      } else {
+        TestUtil.logMsg("Check the value in TextMessage");
+        if (actTextMessage.getText().equals(expTextMessage.getText())) {
+          TestUtil.logMsg("TextMessage is correct");
+        } else {
+          TestUtil.logErr(
+              "TextMessage is incorrect expected " + expTextMessage.getText()
+                  + ", received " + actTextMessage.getText());
+          pass = false;
+        }
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      pass = false;
     }
 
-    public void doGet(HttpServletRequest req, HttpServletResponse res)
-                               throws ServletException, IOException
-    {
-	boolean pass = true;
-	Properties p = new Properties();
-	res.setContentType("text/plain");
-	PrintWriter out = res.getWriter();
+    return pass;
+  }
 
-	try {
-	    String test = harnessProps.getProperty("TEST");
-	    System.out.println("doGet: test to execute is: "+test);
-	    if(test.equals("sendAndRecvQueueTestFromServletClient")) {
-                if(sendAndRecvQueueTestFromServletClient())
-	            p.setProperty("TESTRESULT", "pass");
-		else
-	            p.setProperty("TESTRESULT", "fail");
-	    } else if(test.equals("sendAndRecvTopicTestFromServletClient")) {
-                if(sendAndRecvTopicTestFromServletClient())
-	            p.setProperty("TESTRESULT", "pass");
-		else
-	            p.setProperty("TESTRESULT", "fail");
-	    } else if(test.equals("checkClientIDTestFromServletClient")) {
-                if(checkClientIDTestFromServletClient())
-	            p.setProperty("TESTRESULT", "pass");
-		else
-	            p.setProperty("TESTRESULT", "fail");
-	    } else {
-	        p.setProperty("TESTRESULT", "fail");
-	    }
-	    doCleanup();
-	    p.list(out);
-	} catch (Exception e) {
-	    TestUtil.logErr("doGet: Exception: " + e);
-	    System.out.println("doGet: Exception: " + e);
-	    p.setProperty("TESTRESULT", "fail");
-	    p.list(out);
-	}
-	out.close();
+  public boolean sendAndRecvTopicTestFromServletClient() {
+    boolean pass = true;
+    String message = "Where are you!";
+    try {
+      queueTest = false;
+      // send and receive TextMessage
+      TestUtil.logMsg(
+          "Creating TextMessage via JMSContext.createTextMessage(String)");
+      TextMessage expTextMessage = context.createTextMessage(message);
+      TestUtil.logMsg("Set some values in TextMessage");
+      expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME",
+          "sendAndRecvTopicTestFromServletClient");
+      TestUtil.logMsg(
+          "Sending TextMessage via JMSProducer.send(Destination, Message)");
+      producerT.send(topic, expTextMessage);
+      TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
+      TextMessage actTextMessage = (TextMessage) consumerT.receive(timeout);
+      if (actTextMessage == null) {
+        TestUtil.logErr("Did not receive TextMessage");
+        pass = false;
+      } else {
+        TestUtil.logMsg("Check the value in TextMessage");
+        if (actTextMessage.getText().equals(expTextMessage.getText())) {
+          TestUtil.logMsg("TextMessage is correct");
+        } else {
+          TestUtil.logErr(
+              "TextMessage is incorrect expected " + expTextMessage.getText()
+                  + ", received " + actTextMessage.getText());
+          pass = false;
+        }
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      pass = false;
     }
+    return pass;
+  }
 
-    public void doPost(HttpServletRequest req, HttpServletResponse res)
-                               throws ServletException, IOException
-    {
-	harnessProps = new Properties();
-	Enumeration enumlist = req.getParameterNames();
-	while (enumlist.hasMoreElements()) {
-	    String name = (String) enumlist.nextElement();
-	    String value = req.getParameter(name);
-	    harnessProps.setProperty(name, value);
-	}
-
-	try {
-	    TestUtil.init(harnessProps);
-            // get props
-            timeout = Long.parseLong(harnessProps.getProperty("jms_timeout"));
-            user = harnessProps.getProperty("user");
-            password = harnessProps.getProperty("password");
-            mode = harnessProps.getProperty("platform.mode");
-
-            // check props for errors
-            if (timeout < 1) {
-                throw new Exception("'jms_timeout' (milliseconds) in ts.jte must be > 0");
-            }
-            if (user == null ) {
-                throw new Exception("'user' in ts.jte must not be null ");
-            }
-            if (password == null ) {
-                throw new Exception("'password' in ts.jte must not be null ");
-            }
-            if (mode == null) {
-                throw new Exception("'platform.mode' in ts.jte must not be null");
-            }
-	    doLookupJMSObjects();
-	} catch (Exception e) {
-	    System.out.println("doPost: Exception: " + e);
-	    e.printStackTrace();
-	    throw new ServletException("unable to initialize remote logging");
-	}
-	doGet(req, res);
-	harnessProps = null;
+  public boolean checkClientIDTestFromServletClient() {
+    boolean pass = true;
+    JMSContext context = null;
+    try {
+      queueTest = false;
+      TestUtil
+          .logMsg("Create JMSContext from durable topic connection factory");
+      TestUtil.logMsg(
+          "Check the client id which is configured as MyClientID in the "
+              + "JMSConnectionFactoryDefinition annotation");
+      context = dtcf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
+      String clientid = context.getClientID();
+      if (clientid == null) {
+        TestUtil.logErr("Client ID value is null (expected MyClientID)");
+        pass = false;
+      } else if (clientid.equals("MyClientID")) {
+        TestUtil.logMsg("Client ID value is correct (MyClientID)");
+      } else {
+        TestUtil
+            .logErr("Client ID value is incorrect (expected MyClientID, got "
+                + clientid + ")");
+        pass = false;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      pass = false;
+    } finally {
+      try {
+        if (context != null)
+          context.close();
+        doCleanup();
+      } catch (Exception e) {
+        TestUtil.logErr("Error in cleanup " + e);
+      }
     }
-
-    /*
-     * Lookup JMS Connection Factory and Destination Objects
-     */
-    private void doLookupJMSObjects() throws Exception {
-	try {
-	    TestUtil.logMsg("Lookup JMS factories defined by @JMSConnectionFactoryDefinitions");
-	    TestUtil.logMsg("Lookup JMS destinations defined by @JMSDestinationDefinitions");
-	    TSNamingContext namingctx = new TSNamingContext();
-	    TestUtil.logMsg("Lookup java:comp/DefaultJMSConnectionFactory");
-            dcf = (ConnectionFactory) 
-		namingctx.lookup("java:comp/DefaultJMSConnectionFactory");
-	    TestUtil.logMsg("Lookup java:global/ServletMyTestConnectionFactory");
-            cf = (ConnectionFactory) 
-		namingctx.lookup("java:global/ServletMyTestConnectionFactory");
-	    TestUtil.logMsg("Lookup java:app/ServletMyTestQueueConnectionFactory");
-            qcf = (QueueConnectionFactory) 
-		namingctx.lookup("java:app/ServletMyTestQueueConnectionFactory");
-	    TestUtil.logMsg("Lookup java:module/ServletMyTestTopicConnectionFactory");
-            tcf = (TopicConnectionFactory) 
-		namingctx.lookup("java:module/ServletMyTestTopicConnectionFactory");
-	    TestUtil.logMsg("Lookup java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory");
-            dtcf = (TopicConnectionFactory) 
-		namingctx.lookup("java:comp/env/jms/ServletMyTestDurableTopicConnectionFactory");
-	    TestUtil.logMsg("Lookup java:global/env/ServletMyTestQueue");
-            queue = (Queue) namingctx.lookup("java:global/env/ServletMyTestQueue");
-	    TestUtil.logMsg("Lookup java:app/env/ServletMyTestTopic");
-            topic = (Topic) namingctx.lookup("java:app/env/ServletMyTestTopic");
-
-	    TestUtil.logMsg("Create JMSContext, JMSProducer's and JMSConsumer's");
-            context = cf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
-	    producerQ = context.createProducer();
-	    consumerQ = context.createConsumer(queue);
-	    producerT = context.createProducer();
-	    consumerT = context.createConsumer(topic);
-	} catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-	    throw e;
-	}
-    }
-
-
-    public boolean sendAndRecvQueueTestFromServletClient() {
-	boolean pass = true;
-	String message = "Where are you!";
-        try {
-	    queueTest = true;
-            // send and receive TextMessage
-            TestUtil.logMsg("Creating TextMessage via JMSContext.createTextMessage(String)");
-            TextMessage expTextMessage = context.createTextMessage(message);
-            TestUtil.logMsg("Set some values in TextMessage");
-            expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME", "sendAndRecvQueueTestFromServletClient");
-	    TestUtil.logMsg("Sending TextMessage via JMSProducer.send(Destination, Message)");
-            producerQ.send(queue, expTextMessage);
-            TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
-            TextMessage actTextMessage = (TextMessage) consumerQ.receive(timeout);
-            if (actTextMessage == null) {
-                TestUtil.logErr("Did not receive TextMessage");
-		pass = false;
-            } else {
-                TestUtil.logMsg("Check the value in TextMessage");
-	        if(actTextMessage.getText().equals(expTextMessage.getText())) {
-		    TestUtil.logMsg("TextMessage is correct");
-	        } else {
-		    TestUtil.logErr("TextMessage is incorrect expected " + expTextMessage.getText() 
-			+ ", received " + actTextMessage.getText());
-		    pass = false;
-	        }
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            pass = false;
-        } 
-
-	return pass;
-    }
-
-    public boolean sendAndRecvTopicTestFromServletClient() {
-	boolean pass = true;
-	String message = "Where are you!";
-        try {
-	    queueTest = false;
-            // send and receive TextMessage
-            TestUtil.logMsg("Creating TextMessage via JMSContext.createTextMessage(String)");
-            TextMessage expTextMessage = context.createTextMessage(message);
-            TestUtil.logMsg("Set some values in TextMessage");
-            expTextMessage.setStringProperty("COM_SUN_JMS_TESTNAME", "sendAndRecvTopicTestFromServletClient");
-	    TestUtil.logMsg("Sending TextMessage via JMSProducer.send(Destination, Message)");
-            producerT.send(topic, expTextMessage);
-            TestUtil.logMsg("Receive TextMessage via JMSconsumer.receive(long)");
-            TextMessage actTextMessage = (TextMessage) consumerT.receive(timeout);
-            if (actTextMessage == null) {
-                TestUtil.logErr("Did not receive TextMessage");
-		pass = false;
-            } else {
-                TestUtil.logMsg("Check the value in TextMessage");
-	        if(actTextMessage.getText().equals(expTextMessage.getText())) {
-		    TestUtil.logMsg("TextMessage is correct");
-	        } else {
-		    TestUtil.logErr("TextMessage is incorrect expected " + expTextMessage.getText() 
-			+ ", received " + actTextMessage.getText());
-		    pass = false;
-		}
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            pass = false;
-        } 
-	return pass;
-    }
-
-    public boolean checkClientIDTestFromServletClient() {
-	boolean pass = true;
-	JMSContext context = null;
-        try {
-	    queueTest = false;
-	    TestUtil.logMsg("Create JMSContext from durable topic connection factory");
-	    TestUtil.logMsg("Check the client id which is configured as MyClientID in the " +
-			"JMSConnectionFactoryDefinition annotation");
-            context = dtcf.createContext(user, password, JMSContext.AUTO_ACKNOWLEDGE);
-	    String clientid = context.getClientID();
-	    if(clientid == null) {
-		TestUtil.logErr("Client ID value is null (expected MyClientID)");
-		pass = false;
-	    } else if(clientid.equals("MyClientID")) {
-		TestUtil.logMsg("Client ID value is correct (MyClientID)");
-	    } else {
-		TestUtil.logErr("Client ID value is incorrect (expected MyClientID, got "+clientid+")");
-		pass = false;
-	    }
-        } catch (Exception e) {
-	    TestUtil.logErr("Caught exception: " + e);
-            pass = false;
-        } finally {
-	    try {
-		if(context != null)
-		    context.close();
-                doCleanup();
-	    } catch(Exception e) {
-                TestUtil.logErr("Error in cleanup "+e);
-            }
-	}
-	return pass;
-    }
+    return pass;
+  }
 
 }


### PR DESCRIPTION
**Fixes Issue**
* https://github.com/jakartaee/messaging/issues/299
* https://github.com/jakartaee/messaging/issues/300

**Related Issue(s)**

**Describe the change**
Removed the wrapper annotations in existing tests and use repeatable annotations @JMSDestinationDefinition @JMSConnectionFactoryDefinition directly

**Additional context**
Also applied formatting from commit https://github.com/eclipse-ee4j/jakartaee-tck/commit/6169ab96570a25023d88239fbbfb8769672b4bed to the original .src files, which overwrite the *.java files during TCK build which were formatted by that commit.

To see the main change without formatting changes, checkout the first commit https://github.com/eclipse-ee4j/jakartaee-tck/commit/5ecd8750afb6ac690a644da85771cec8416bd4b3

I've verified that the tests are OK by compiling and running the Jakarta EE TCK against GF 7 (I built the whole TCK but only executed the modified tests). The tests passed after I added the [Jakarta EE 10 schemas](https://github.com/eclipse-ee4j/glassfish/pull/23812) to GF 7 milestone build. No change is required in the Messaging implementations to support the repeatable annotations.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
