### PR TITLE
Websocket TCK fix - add back webclient/log folder

### DIFF
--- a/src/com/sun/ts/tests/common/webclient/WebTestCase.java
+++ b/src/com/sun/ts/tests/common/webclient/WebTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,6 +34,8 @@ import com.sun.ts.tests.common.webclient.http.HttpRequest;
 import com.sun.ts.tests.common.webclient.http.HttpResponse;
 import com.sun.ts.tests.common.webclient.validation.ValidationFactory;
 import com.sun.ts.tests.common.webclient.validation.ValidationStrategy;
+// used to force the class to be compiled
+import com.sun.ts.tests.common.webclient.validation.TokenizedValidator;
 
 /**
  * A TestCase implementation for HTTP-based testing. This allows the user to set

--- a/src/com/sun/ts/tests/common/webclient/http/HttpRequest.java
+++ b/src/com/sun/ts/tests/common/webclient/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,6 +39,8 @@ import org.apache.commons.httpclient.protocol.DefaultProtocolSocketFactory;
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 import org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory;
+// this import is used to force this class to get compiled
+import com.sun.ts.tests.common.webclient.log.WebLog;
 
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.common.webclient.Util;


### PR DESCRIPTION
**Fixes Issue**
None created yet.

**Describe the change**
The src/com/sun/ts/tests/common/webclient/log folder was missing from websocket TCK as one of the previous commits (https://github.com/eclipse-ee4j/jakartaee-tck/pull/582/commits/6169ab96570a25023d88239fbbfb8769672b4bed) accidentally removed the compilation of the same folder. This change adds back the option where these folders were compiled by adding "empty" imports.

@jansupol 

