### PR TITLE
Fix Websocket TCK test run, add client api jar to CP

### DIFF
--- a/docker/websockettck.sh
+++ b/docker/websockettck.sh
@@ -77,7 +77,7 @@ if [[ "$PROFILE" == "web" || "$PROFILE" == "WEB" ]]; then
 fi
 
 if [ ! -z "$TCK_BUNDLE_BASE_URL" ]; then
-  sed -i 's#websocket.api=.*#websocket.api=${web.home}/modules/jakarta.websocket-api.jar${pathsep}${web.home}/modules/jakarta.servlet-api.jar${pathsep}${web.home}/modules/jakarta.enterprise.cdi-api.jar#g' ts.jte
+  sed -i 's#websocket.api=.*#websocket.api=${web.home}/modules/jakarta.websocket-api.jar${pathsep}${web.home}/modules/jakarta.websocket-client-api.jar${pathsep}${web.home}/modules/jakarta.servlet-api.jar${pathsep}${web.home}/modules/jakarta.enterprise.cdi-api.jar#g' ts.jte
 fi
 mkdir -p $TCK_HOME/${TCK_NAME}report/${TCK_NAME}
 mkdir -p $TCK_HOME/${TCK_NAME}work/${TCK_NAME}

--- a/install/websocket/bin/ts.jte
+++ b/install/websocket/bin/ts.jte
@@ -204,7 +204,7 @@ ClientThreads=2
 # @ts.classpath         -- Classes used to build the  Web Socket TCK tests
 # @ts.run.classpath     -- Classpath required to run Web Socket TCK tests
 ##########################################################################
-websocket.api=${web.home}/modules/jakarta.websocket-api.jar${pathsep}${web.home}/modules/jakarta.servlet-api.jar${pathsep}${web.home}/modules/jakarta.enterprise.cdi-api.jar
+websocket.api=${web.home}/modules/jakarta.websocket-api.jar${pathsep}${web.home}/modules/jakarta.websocket-client-api.jar${pathsep}${web.home}/modules/jakarta.servlet-api.jar${pathsep}${web.home}/modules/jakarta.enterprise.cdi-api.jar
 websocket.classes=${web.home}/modules/tyrus-websocket-core.jar${pathsep}${web.home}/modules/tyrus-client.jar${pathsep}${web.home}/modules/tyrus-core.jar${pathsep}${web.home}/modules/tyrus-container-grizzly.jar${pathsep}${web.home}/modules/glassfish-grizzly-extra-all.jar${pathsep}${web.home}/modules/nucleus-grizzly-all.jar${pathsep}${web.home}/modules/tyrus-server.jar${pathsep}${web.home}/modules/tyrus-container-servlet.jar${pathsep}${web.home}/modules/tyrus-container-grizzly-client.jar${pathsep}${web.home}/modules/tyrus-spi.jar
 
 ts.classpath=${websocket.api}${pathsep}${ts.harness.classpath}


### PR DESCRIPTION
**Fixes Issue**
Fix Websocket TCK test setup

**Describe the change**
Adds jakarta.websocket-client-api.jar to CP of test run.

NB: Can squash this PR while merging.
