### PR TITLE
Update taglibs for JSTL tests

### DIFF
--- a/src/web/jsf/spec/jstl/fntrim/fntrim.xhtml
+++ b/src/web/jsf/spec/jstl/fntrim/fntrim.xhtml
@@ -22,7 +22,7 @@
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:f="http://java.sun.com/jsf/core"
       xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function trim tag test</title>

--- a/src/web/jsf/spec/jstl/foreachtag/foreachtag_facelet.xhtml
+++ b/src/web/jsf/spec/jstl/foreachtag/foreachtag_facelet.xhtml
@@ -23,7 +23,7 @@
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:f="http://java.sun.com/jsf/core"
       xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:fn="jakarta.tags.functions">
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>Core JSTL c:foreach tag tests.</title>

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWONoWhenActionsTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWONoWhenActionsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWONoWhenActionsTest">
     <!-- If there are no when actions nested within a choose action

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOOtherwiseExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOOtherwiseExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOOtherwiseExcBodyContentTest">

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOOtherwiseNoParentTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOOtherwiseNoParentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
  <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOOtherwiseNoParentRTTest">
     <!-- If otherwise doesn't have choose an an immediate parent,

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenBeforeOtherwiseTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenBeforeOtherwiseTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenBeforeOtherwiseRTTest">
     <!-- When must appear before an otherwise action,

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenExcBodyContentTest">

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenNoParentTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenNoParentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenNoParentRTTest">
     <!-- A fatal translation error will occur if a when

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenTestReqAttrTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenTestReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenSelectReqAttrRTTest">
     <!-- RT: Validate that if the 'test' attribute is not present, a 

--- a/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenTypeTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/negativeCWOWhenTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenTypeTest">
     <%

--- a/src/web/jstl/spec/core/conditional/cwo/positiveCWOTest.jsp
+++ b/src/web/jstl/spec/core/conditional/cwo/positiveCWOTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveCWOTest">
 

--- a/src/web/jstl/spec/core/conditional/iftag/negativeIfExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/conditional/iftag/negativeIfExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeIfExcBodyContentTest">

--- a/src/web/jstl/spec/core/conditional/iftag/negativeIfTestTypeTest.jsp
+++ b/src/web/jstl/spec/core/conditional/iftag/negativeIfTestTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeTypeTestAttrTest">
     <%

--- a/src/web/jstl/spec/core/conditional/iftag/positiveIfBodyBehaviorTest.jsp
+++ b/src/web/jstl/spec/core/conditional/iftag/positiveIfBodyBehaviorTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveIfBodyBehaviorTest">

--- a/src/web/jstl/spec/core/conditional/iftag/positiveIfExportedVarTypeTest.jsp
+++ b/src/web/jstl/spec/core/conditional/iftag/positiveIfExportedVarTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveExportedVarTypeTest">

--- a/src/web/jstl/spec/core/conditional/iftag/positiveIfScopeTest.jsp
+++ b/src/web/jstl/spec/core/conditional/iftag/positiveIfScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveIfScopeTest">

--- a/src/web/jstl/spec/core/conditional/iftag/positiveIfTest.jsp
+++ b/src/web/jstl/spec/core/conditional/iftag/positiveIfTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveIfTest">

--- a/src/web/jstl/spec/core/general/catchtag/positiveCatchTest.jsp
+++ b/src/web/jstl/spec/core/general/catchtag/positiveCatchTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveCatchTest">

--- a/src/web/jstl/spec/core/general/catchtag/positiveCatchVarTest.jsp
+++ b/src/web/jstl/spec/core/general/catchtag/positiveCatchVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveCatchVarTest">

--- a/src/web/jstl/spec/core/general/outtag/negativeOutBodyContentExcTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/negativeOutBodyContentExcTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeOutBodyContentExcTest">

--- a/src/web/jstl/spec/core/general/outtag/positiveOutBodyBehaviorTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/positiveOutBodyBehaviorTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutBodyBehaviorTest">

--- a/src/web/jstl/spec/core/general/outtag/positiveOutDefaultAttributeTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/positiveOutDefaultAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutDefaultAttributeTest">

--- a/src/web/jstl/spec/core/general/outtag/positiveOutEscXmlDefaultTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/positiveOutEscXmlDefaultTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutEscXmlDefaultTest">

--- a/src/web/jstl/spec/core/general/outtag/positiveOutEscXmlTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/positiveOutEscXmlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutEscXmlTest">

--- a/src/web/jstl/spec/core/general/outtag/positiveOutReaderTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/positiveOutReaderTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ page import="java.io.StringReader"%>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <%
     StringReader reader = new StringReader("Test PASSED");

--- a/src/web/jstl/spec/core/general/outtag/positiveOutValueAttributeTest.jsp
+++ b/src/web/jstl/spec/core/general/outtag/positiveOutValueAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutValueAttributeTest">
     <% 

--- a/src/web/jstl/spec/core/general/remove/positiveRemoveScopeVarTest.jsp
+++ b/src/web/jstl/spec/core/general/remove/positiveRemoveScopeVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveRemoveScopeTest">

--- a/src/web/jstl/spec/core/general/set/negativeSetBodyContentExcTest.jsp
+++ b/src/web/jstl/spec/core/general/set/negativeSetBodyContentExcTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSetBodyContentExcTest">

--- a/src/web/jstl/spec/core/general/set/negativeSetTargetNullInvalidObjTest.jsp
+++ b/src/web/jstl/spec/core/general/set/negativeSetTargetNullInvalidObjTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSetTargetNullInvalidObjTest">

--- a/src/web/jstl/spec/core/general/set/positiveSetBodyBehaviorTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetBodyBehaviorTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetBodyBehaviorTest">

--- a/src/web/jstl/spec/core/general/set/positiveSetDeferredValueTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetDeferredValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/general/set/positiveSetNullValueTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetNullValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.HashMap,java.util.Map,com.sun.ts.tests.jstl.common.beans.SimpleBean" %>

--- a/src/web/jstl/spec/core/general/set/positiveSetPropertyTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetPropertyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.HashMap,java.util.Map,com.sun.ts.tests.jstl.common.beans.SimpleBean" %>

--- a/src/web/jstl/spec/core/general/set/positiveSetScopeTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetScopeTest">

--- a/src/web/jstl/spec/core/general/set/positiveSetTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetTest">

--- a/src/web/jstl/spec/core/iteration/foreach/negativeFEBeginTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/negativeFEBeginTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFEBeginTypeTest">

--- a/src/web/jstl/spec/core/iteration/foreach/negativeFEEndTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/negativeFEEndTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFEEndTypeTest">

--- a/src/web/jstl/spec/core/iteration/foreach/negativeFEExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/negativeFEExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFEExcBodyContentTest">

--- a/src/web/jstl/spec/core/iteration/foreach/negativeFEItemsTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/negativeFEItemsTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFEItemsTypeTest">

--- a/src/web/jstl/spec/core/iteration/foreach/negativeFEStepTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/negativeFEStepTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFEStepTypeTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveBodyBehaviorTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveBodyBehaviorTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBodyBehaviorTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest1.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest1.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest2.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest2.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest3.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest3.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachEndLTBeginTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachEndLTBeginTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <c:forEach items="${'one,two,three'}" begin="2" end="1">
     Test FAILED

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsBeginTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsBeginTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsBeginTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsCollectionTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsCollectionTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.*" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsCommaSepStringTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsCommaSepStringTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsCommaSepStringTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsEndTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsEndTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsEndTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsEnumerationTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsEnumerationTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Vector,java.util.Enumeration" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsIteratorTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsIteratorTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.HashSet,java.util.Iterator,java.util.ArrayList,java.util.Arrays" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsMapTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsMapTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.*" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsNullTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsNullTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsObjArrayTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsObjArrayTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsPrimArrayTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsPrimArrayTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsPrimArrayTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveItemsStepTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveItemsStepTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsStepTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveNoItemsIterationTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveNoItemsIterationTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveNoItemsIterationTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveVarStatusTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveVarStatusTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveVarStatusTest">

--- a/src/web/jstl/spec/core/iteration/foreach/positiveVarTest.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/iteration/fortokens/negativeFTBeginTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/negativeFTBeginTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFTBeginTypeTest">
     <c:set var="ab" value="ab"/>

--- a/src/web/jstl/spec/core/iteration/fortokens/negativeFTEndTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/negativeFTEndTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFTEndTypeTest">
     <c:set var="ab" value="ab"/>

--- a/src/web/jstl/spec/core/iteration/fortokens/negativeFTExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/negativeFTExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFTExcBodyContentTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/negativeFTStepTypeTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/negativeFTStepTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFTStepTypeTest">
     <c:set var="ab" value="ab"/>

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveBeginTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveBeginTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBeginTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveBodyBehaviorTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveBodyBehaviorTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBodyBehaviorTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveDelimsNullTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveDelimsNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveDelimsNullTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveEndTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveEndTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveEndTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensDeferredValueTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensDeferredValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 
 <%@ page import="java.util.ArrayList" %>

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensEndLTBeginTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensEndLTBeginTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <c:forTokens items="${'one,two,three'}" delims="," begin="2" end="1">
     Test FAILED

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveForTokensTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveItemsDelimsNullTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveItemsDelimsNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsDelimsNullTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveItemsNullTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveItemsNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsNullTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveStepTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveStepTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveStepTest">

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveVarStatusTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveVarStatusTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveVarStatusTest">

--- a/src/web/jstl/spec/core/iteration/loopstatus/positiveLoopTagStatusTest.jsp
+++ b/src/web/jstl/spec/core/iteration/loopstatus/positiveLoopTagStatusTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveLoopTagStatusTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportAbsResourceNon2xxTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportAbsResourceNon2xxTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportAbsResourceNon2xxTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportCtxInvalidValueTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportCtxInvalidValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportCtxInvalidValueTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportCtxUrlInvalidValueTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportCtxUrlInvalidValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportCtxUrlInvalidValueTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportRequestDispatcherNon2xxTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportRequestDispatcherNon2xxTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportRequestDispatcherNon2xxTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportRequestDispatcherRTIOExceptionTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportRequestDispatcherRTIOExceptionTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportRequestDispatcherRTIOExceptionTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportRequestDispatcherServletExceptionTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportRequestDispatcherServletExceptionTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportRequestDispatcherServletExceptionTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportUrlEmptyTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportUrlEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportUrlEmptyTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportUrlInvalidTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportUrlInvalidTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportUrlInvalidTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/negativeImportUrlNullTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/negativeImportUrlNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeImportUrlNullTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportAbsUrlEnvPropTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportAbsUrlEnvPropTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportAbsUrlEnvPropTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportAbsUrlTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportAbsUrlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportAbsUrlTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportBodyParamTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportBodyParamTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportBodyParamTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportCharEncodingNullEmptyTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportCharEncodingNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportCharEncodingNullEmptyTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportCharEncodingTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportCharEncodingTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.io.Reader,java.io.BufferedReader,java.io.IOException" %>

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportCtxRelUrlTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportCtxRelUrlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportCtxRelUrlTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportEncodingNotSpecifiedTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportEncodingNotSpecifiedTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <%-- If encoding is not specified, then use the encoding specfied
      in the response. In this case, the response will be UTF-16. --%>

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportFollowRedirectTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportFollowRedirectTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportFollowRedirectTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportPageRelUrlTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportPageRelUrlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportPageRelUrlTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportRelUrlEnvPropTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportRelUrlEnvPropTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportRelUrlEnvPropTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportScopeTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportScopeTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportUrlTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportUrlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportUrlTest">

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportVarReaderTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportVarReaderTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.io.Reader,java.io.BufferedReader,java.io.IOException" %>

--- a/src/web/jstl/spec/core/urlresource/importtag/positiveImportVarTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/importtag/positiveImportVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveImportVarTest">

--- a/src/web/jstl/spec/core/urlresource/param/import.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/import.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@page contentType="text/html"%>
 <c:if test="${param.testparm != null}">
     <c:out value="testparm found! Value is: ${param.testparm}" default="Test FAILED"/>

--- a/src/web/jstl/spec/core/urlresource/param/negativeParamExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/negativeParamExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeParamExcBodyContentTest">

--- a/src/web/jstl/spec/core/urlresource/param/positiveParamAggregationTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/positiveParamAggregationTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamAggregationTest">

--- a/src/web/jstl/spec/core/urlresource/param/positiveParamBodyValueTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/positiveParamBodyValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamBodyValueTest">

--- a/src/web/jstl/spec/core/urlresource/param/positiveParamEncodingTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/positiveParamEncodingTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamEncodingTest">

--- a/src/web/jstl/spec/core/urlresource/param/positiveParamNameNullEmptyTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/positiveParamNameNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamNameNullEmptyTest">

--- a/src/web/jstl/spec/core/urlresource/param/positiveParamNameValueTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/positiveParamNameValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamNameValueTest">

--- a/src/web/jstl/spec/core/urlresource/param/positiveParamValueNullTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/param/positiveParamValueNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamValueNullTest">

--- a/src/web/jstl/spec/core/urlresource/redirect/negativeRedirectContextUrlInvalidValueTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/redirect/negativeRedirectContextUrlInvalidValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeRedirectContextUrlInvalidValueTest">

--- a/src/web/jstl/spec/core/urlresource/redirect/negativeRedirectExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/redirect/negativeRedirectExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeRedirectExcBodyContentTest">

--- a/src/web/jstl/spec/core/urlresource/redirect/positiveRedirectParamsBodyTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/redirect/positiveRedirectParamsBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page session="false" %>

--- a/src/web/jstl/spec/core/urlresource/redirect/positiveRedirectTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/redirect/positiveRedirectTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page session="false" %>

--- a/src/web/jstl/spec/core/urlresource/url/negativeUrlContextUrlInvalidValueTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/negativeUrlContextUrlInvalidValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeUrlContextUrlInvalidValueTest">

--- a/src/web/jstl/spec/core/urlresource/url/negativeUrlExcBodyContentTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/negativeUrlExcBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeUrlExcBodyContentTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlAbsUrlNotRewrittenTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlAbsUrlNotRewrittenTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlAbsUrlNotRewrittenTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlContextTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlContextTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page session="false" %>

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlDisplayUrlTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlDisplayUrlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlDisplayUrlTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlNoCharEncodingTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlNoCharEncodingTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlNoCharEncodingTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlParamsBodyTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlParamsBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlParamsBodyTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlRelUrlRewrittenTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlRelUrlRewrittenTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlRelUrlRewrittenTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlScopeTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlScopeTest">

--- a/src/web/jstl/spec/core/urlresource/url/positiveUrlValueVarTest.jsp
+++ b/src/web/jstl/spec/core/urlresource/url/positiveUrlValueVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveUrlValueVarTest">

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:containsIgnoreCase(null, 'sub')}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullSubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:containsIgnoreCase('string', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseNullSubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseStringSubstringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseStringSubstringEqualTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:containsIgnoreCase('StRing', 'strInG')}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseStringSubstringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseStringSubstringEqualTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:if test="${fn:containsIgnoreCase('some string', 'me str')}">
     Test PASSED

--- a/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsIgnoreCaseTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:if test="${fn:containsIgnoreCase('some string', 'me str')}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:contains(null, 'sub')}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsContainsNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsNullSubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:contains('string', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsNullSubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsContainsStringSubstringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsStringSubstringEqualTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:contains('string', 'string')}">

--- a/src/web/jstl/spec/etu/functions/functionsContainsStringSubstringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsStringSubstringEqualTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsContainsTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:if test="${fn:contains('some string', 'me str')}">
     Test PASSED

--- a/src/web/jstl/spec/etu/functions/functionsContainsTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsContainsTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:if test="${fn:contains('some string', 'me str')}">

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithEmptySuffixStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithEmptySuffixStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:endsWith('string', '')}">

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithEmptySuffixStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithEmptySuffixStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;
     pageContext.setAttribute("str", str);

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithNullSuffixTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithNullSuffixTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithNullSuffixTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithNullSuffixTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:endsWith('string', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithSuffixStringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithSuffixStringEqualTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:startsWith('string', 'string')}">

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithSuffixStringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithSuffixStringEqualTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsEndsWithTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEndsWithTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:endsWith('string', 'ing')}">

--- a/src/web/jstl/spec/etu/functions/functionsEscapeXmlNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEscapeXmlNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;

--- a/src/web/jstl/spec/etu/functions/functionsEscapeXmlNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEscapeXmlNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;
     pageContext.setAttribute("nullString", str);

--- a/src/web/jstl/spec/etu/functions/functionsEscapeXmlTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEscapeXmlTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <% pageContext.setAttribute("escString", "><&'\""); %>
 <c:choose>
     <c:when test="${'&gt;&lt;&amp;&#039;&#034;' == fn:escapeXml(escString)}">

--- a/src/web/jstl/spec/etu/functions/functionsEscapeXmlTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsEscapeXmlTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <% pageContext.setAttribute("escString", "><&'\""); %>
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfEmptySubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfEmptySubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${0 == fn:indexOf('string', '')}">

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfEmptySubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfEmptySubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfNullEmptyStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfNullEmptyStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${-1 == fn:indexOf(null, 'ing')}">

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfNullEmptyStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfNullEmptyStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfNullSubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${0 == fn:indexOf('string', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfNullSubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${3 == fn:indexOf('string', 'ing')}">

--- a/src/web/jstl/spec/etu/functions/functionsIndexOfTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsIndexOfTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsJoinEmptySeparatorTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinEmptySeparatorTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%

--- a/src/web/jstl/spec/etu/functions/functionsJoinEmptySeparatorTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinEmptySeparatorTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%
     String[] strArray = { "one", "two", "three" };

--- a/src/web/jstl/spec/etu/functions/functionsJoinNullArrayTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinNullArrayTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:join(null, ',')}">

--- a/src/web/jstl/spec/etu/functions/functionsJoinNullArrayTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinNullArrayTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsJoinNullSeparatorTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinNullSeparatorTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%

--- a/src/web/jstl/spec/etu/functions/functionsJoinNullSeparatorTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinNullSeparatorTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%
     String[] strArray = { "one", "two", "three" };

--- a/src/web/jstl/spec/etu/functions/functionsJoinTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%

--- a/src/web/jstl/spec/etu/functions/functionsJoinTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsJoinTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%
     String[] strArray = { "one", "two", "three" };

--- a/src/web/jstl/spec/etu/functions/functionsLengthEmptyStringInputTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsLengthEmptyStringInputTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${0 == fn:length('')}">

--- a/src/web/jstl/spec/etu/functions/functionsLengthEmptyStringInputTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsLengthEmptyStringInputTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsLengthNullInputTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsLengthNullInputTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;

--- a/src/web/jstl/spec/etu/functions/functionsLengthNullInputTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsLengthNullInputTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;
     pageContext.setAttribute("nullString", str);

--- a/src/web/jstl/spec/etu/functions/functionsLengthTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsLengthTest.jsp
@@ -24,7 +24,7 @@
                  java.util.Enumeration,
                  java.util.Hashtable" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%
     int[] intArray = { 1, 2 };

--- a/src/web/jstl/spec/etu/functions/functionsLengthTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsLengthTest.jsp
@@ -23,7 +23,7 @@
                  java.util.Map,
                  java.util.Enumeration,
                  java.util.Hashtable" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%

--- a/src/web/jstl/spec/etu/functions/functionsReplaceEmptyAfterStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceEmptyAfterStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'stg' == fn:replace('stnirg', 'nir', '')}">

--- a/src/web/jstl/spec/etu/functions/functionsReplaceEmptyAfterStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceEmptyAfterStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceEmptyBeforeStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceEmptyBeforeStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'stnirg' == fn:replace('stnirg', '', 'rin')}">

--- a/src/web/jstl/spec/etu/functions/functionsReplaceEmptyBeforeStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceEmptyBeforeStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceEmptyInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceEmptyInputStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:replace('', 'a', 'b')}">

--- a/src/web/jstl/spec/etu/functions/functionsReplaceEmptyInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceEmptyInputStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceNullAfterStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceNullAfterStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceNullAfterStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceNullAfterStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'stg' == fn:replace('stnirg', 'nir', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsReplaceNullBeforeStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceNullBeforeStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'stnirg' == fn:replace('stnirg', null, 'rin')}">

--- a/src/web/jstl/spec/etu/functions/functionsReplaceNullBeforeStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceNullBeforeStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceNullInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceNullInputStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:replace(null, 'a', 'b')}">

--- a/src/web/jstl/spec/etu/functions/functionsReplaceNullInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceNullInputStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsReplaceTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsReplaceTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'string string' == fn:replace('stnirg stnirg', 'nir', 'rin')}">

--- a/src/web/jstl/spec/etu/functions/functionsSplitEmptyDelimiterTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitEmptyDelimiterTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'one|two|three' == fn:join(fn:split('one|two|three', ''), '-')}">

--- a/src/web/jstl/spec/etu/functions/functionsSplitEmptyDelimiterTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitEmptyDelimiterTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSplitEmptyInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitEmptyInputStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:join(fn:split('', '|'), '-')}">

--- a/src/web/jstl/spec/etu/functions/functionsSplitEmptyInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitEmptyInputStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSplitNullDelimiterTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitNullDelimiterTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'one|two|three' == fn:join(fn:split('one|two|three', null), '-')}">

--- a/src/web/jstl/spec/etu/functions/functionsSplitNullDelimiterTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitNullDelimiterTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSplitNullInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitNullInputStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:join(fn:split(null, '|'), '-')}">

--- a/src/web/jstl/spec/etu/functions/functionsSplitNullInputStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitNullInputStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSplitTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSplitTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSplitTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'one-two-three' == fn:join(fn:split('one|two|three', '|'), '-')}">

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithEmptyPrefixStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithEmptyPrefixStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:startsWith('string', '')}">

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithEmptyPrefixStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithEmptyPrefixStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithNullPrefixTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithNullPrefixTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:startsWith('string', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithNullPrefixTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithNullPrefixTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;
     pageContext.setAttribute("str", str);

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithPrefixStringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithPrefixStringEqualTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:startsWith('string', 'string')}">

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithPrefixStringEqualTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithPrefixStringEqualTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${fn:startsWith('string', 'str')}">

--- a/src/web/jstl/spec/etu/functions/functionsStartsWithTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsStartsWithTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterEmptySubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterEmptySubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterEmptySubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterEmptySubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'substring' == fn:substringAfter('substring', '')}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:substringAfter(nullObj, 'sub')}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullSubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'substring' == fn:substringAfter('substring', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterNullSubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringAfterTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringAfterTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'string' == fn:substringAfter('substring', 'sub')}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeEmptySubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeEmptySubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:set var="string1" value="This is first String." />

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeEmptySubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeEmptySubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:set var="string1" value="This is first String." />
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:substringBefore(null, 'sub')}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullSubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:substringBefore('substring', null)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeNullSubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeforeTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeforeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'sub' == fn:substringBefore('substring', 'string')}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeginIndexGTLastIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeginIndexGTLastIndexTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:substring('string', 7, 6)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringBeginIndexGTLastIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringBeginIndexGTLastIndexTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexGTStringLengthTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexGTStringLengthTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'substringG' == fn:substring('SsubstringG', 1, 12)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexGTStringLengthTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexGTStringLengthTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexLTBeginIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexLTBeginIndexTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexLTBeginIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringEndIndexLTBeginIndexTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:substring('SsubstringG', 12, 11)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringNegativeBeginIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringNegativeBeginIndexTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringNegativeBeginIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringNegativeBeginIndexTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'Ssubstring' == fn:substring('SsubstringG', -1, 10)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringNegativeEndIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringNegativeEndIndexTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'substringG' == fn:substring('SsubstringG', 1, -1)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringNegativeEndIndexTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringNegativeEndIndexTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsSubstringNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;
     pageContext.setAttribute("str", str);

--- a/src/web/jstl/spec/etu/functions/functionsSubstringNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = null;

--- a/src/web/jstl/spec/etu/functions/functionsSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'substring' == fn:substring('SsubstringG', 1, 10)}">

--- a/src/web/jstl/spec/etu/functions/functionsSubstringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsSubstringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsToLowerCaseNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToLowerCaseNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:toLowerCase(null)}">

--- a/src/web/jstl/spec/etu/functions/functionsToLowerCaseNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToLowerCaseNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsToLowerCaseTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToLowerCaseTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'lower' == fn:toLowerCase('lOwER')}">

--- a/src/web/jstl/spec/etu/functions/functionsToLowerCaseTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToLowerCaseTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsToUpperCaseNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToUpperCaseNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:toUpperCase(null)}">

--- a/src/web/jstl/spec/etu/functions/functionsToUpperCaseNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToUpperCaseNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsToUpperCaseTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToUpperCaseTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'UPPER' == fn:toUpperCase('uPpEr')}">

--- a/src/web/jstl/spec/etu/functions/functionsToUpperCaseTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsToUpperCaseTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsTrimNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsTrimNullStringTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>
     <c:when test="${'' == fn:trim(null)}">

--- a/src/web/jstl/spec/etu/functions/functionsTrimNullStringTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsTrimNullStringTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <c:choose>

--- a/src/web/jstl/spec/etu/functions/functionsTrimTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsTrimTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = "  \t  trimmed string  \n";

--- a/src/web/jstl/spec/etu/functions/functionsTrimTest.jsp
+++ b/src/web/jstl/spec/etu/functions/functionsTrimTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%
     String str = "  \t  trimmed string  \n";
     pageContext.setAttribute("str", str);

--- a/src/web/jstl/spec/etu/tlv/permitted/negativePermittedTlvTest.jsp
+++ b/src/web/jstl/spec/etu/tlv/permitted/negativePermittedTlvTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/permitted" %>
 <tck:test testName="negativePermittedTlvTest">
     <!-- core is not on the permitted list.  A fatail

--- a/src/web/jstl/spec/etu/uri/positiveJSTLURITest.jsp
+++ b/src/web/jstl/spec/etu/uri/positiveJSTLURITest.jsp
@@ -20,8 +20,8 @@
 <title>positiveJSTLURITest</title>
 <body>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 

--- a/src/web/jstl/spec/etu/uri/positiveJSTLURITest.jsp
+++ b/src/web/jstl/spec/etu/uri/positiveJSTLURITest.jsp
@@ -22,8 +22,8 @@
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 </body>
 </html>

--- a/src/web/jstl/spec/fmt/format/fmtdate/negativeFDScopeNoVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/negativeFDScopeNoVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFDScopeNoVarTest">
     <!-- If scope is specified and var is not, a fatal translation

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFDDateStyleTest">

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDPatternTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDPatternTest.jsp
@@ -16,10 +16,10 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFDPatternTest">
     <%  

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDScopeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFDScopeTest">

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFDTimeStyleTest">

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date,java.util.TimeZone" %>

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFDTypeTest">

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDValueNullTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDValueNullTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFDValueNullEmptyTest">
     <fmt:setLocale value="en_US"/>

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFDValueTest">

--- a/src/web/jstl/spec/fmt/format/fmtdate/positiveFDVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtdate/positiveFDVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/fmtnum/negativeFNScopeNoVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/negativeFNScopeNoVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFNScopeNoVarTest">
     <!-- If scope is specified and var is not, a fatal translation

--- a/src/web/jstl/spec/fmt/format/fmtnum/negativeFNUnableToParseValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/negativeFNUnableToParseValueTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeFNUnableToParseValueTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNBodyValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNBodyValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNBodyValueTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNCodeSymbolTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNCodeSymbolTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNCodeSymbolTest">
     <tck:checkRuntime var="is14"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNCurrencyCodeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNCurrencyCodeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNCurrencyCodeTest">
     <c:set var="code" value="USD"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNCurrencySymbolTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNCurrencySymbolTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNCurrencySymbolTest">
     <c:set var="us" value="@"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNFallbackLocaleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNFallbackLocaleTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNGroupingUsedTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNGroupingUsedTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNGroupingUsedTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNLocalizationContextTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNLocalizationContextTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNLocalizationContextTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMaxFracDigitsTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMaxFracDigitsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNMaxFracDigitsTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMaxIntDigitsTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMaxIntDigitsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNMaxIntDigitsTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMinFracDigitsTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMinFracDigitsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNMinFracDigitsTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMinIntDigitsTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNMinIntDigitsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNMinIntDigitsTest">

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNPatternTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNPatternTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNPatternTest">
     <c:set var="dec" value=".000"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNScopeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNScopeTest">
     <fmt:setLocale value="en_US"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNTypeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNTypeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNTypeTest">
     <c:set var="num" value="number"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNValueNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNValueNullEmptyTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNValueNullEmptyTest">
 

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNValueTest">
     <c:set var="num" value="123456"/>

--- a/src/web/jstl/spec/fmt/format/fmtnum/positiveFNVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/fmtnum/positiveFNVarTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFNVarTest">
     <fmt:setLocale value="en_US"/>

--- a/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFormatLocalizationContextBrowserLocaleTest">

--- a/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFormatLocalizationContextBundleTest">

--- a/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTest.jsp
+++ b/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFormatLocalizationContextI18NTest">

--- a/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positiveFormatLocalizationContextLocaleTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/negativePDScopeNoVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/negativePDScopeNoVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativePDScopeNoVarTest">
     <!-- If scope is specified and var is not, a fatal translation

--- a/src/web/jstl/spec/fmt/format/parsedate/negativePDUnableToParseValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/negativePDUnableToParseValueTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativePDUnableToParseValueTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDBodyValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDBodyValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDBodyValueTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDDateStyleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDDateStyleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDDateStyleTest">
     <c:set var="def" value="default"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positivePDFallbackLocaleTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDLocalizationContextTest">
     <fmt:setTimeZone value="EST"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDParseLocaleNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDParseLocaleNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDParseLocaleNullEmptyTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>
 <tck:test testName="positivePDParseLocaleTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDPatternTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDPatternTest.jsp
@@ -16,10 +16,10 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <tck:test testName="positivePDPatternTest">
     <c:set var="pat" value="yyyy.MM.dd G 'at' HH:mm:ss z"/>
     <c:set var="dte" value="2000.11.21 AD at 03:45:02 EST"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDScopeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDScopeTest">
     <c:set var="dte" value="Nov 21, 2000 3:45:02 AM"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDTimeStyleTest">
     <c:set var="def" value="default"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDTimeZoneNullEmpytTest">
     <c:set var="dt" value="Nov 21, 2000, 3:45 AM"/> 

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positivePDTimeZonePrecedenceTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.TimeZone" %>
 <tck:test testName="positivePDTimeZoneTest">

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDTypeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDTypeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDTypeTest">
     <c:set var="dte" value="Nov 21, 2000"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDValueNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDValueNullEmptyTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDValueNullEmptyTest">
 

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDValueTest">
     <c:set var="dte" value="Nov 21, 2000"/>

--- a/src/web/jstl/spec/fmt/format/parsedate/positivePDVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsedate/positivePDVarTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDVarTest">
     <c:set var="dte" value="Nov 21, 2000 3:45:02 AM"/>

--- a/src/web/jstl/spec/fmt/format/parsenum/negativePNScopeNoVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/negativePNScopeNoVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativePNScopeNoVarTest">
     <!-- If scope is specified and var is not, a fatal translation

--- a/src/web/jstl/spec/fmt/format/parsenum/negativePNUnableToParseValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/negativePNUnableToParseValueTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativePNUnableToParseValueTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNBodyValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNBodyValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNBodyValueTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNFallbackLocaleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNFallbackLocaleTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNIntegerOnlyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNIntegerOnlyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNIntegerOnlyTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNLocalizationContextTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNLocalizationContextTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNLocalizationContextTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNParseLocaleNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNParseLocaleNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNParseLocaleNullEmptyTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNParseLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNParseLocaleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>
 <tck:test testName="positivePNParseLocaleTest">

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNPatternTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNPatternTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNPatternTest">
     <c:set var="pat" value="##0.#####E0"/>

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNScopeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNScopeTest">
     <fmt:setLocale value="en_US"/>

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNTypeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNTypeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNTypeTest">
     <c:set var="num" value="number"/>

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNValueNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNValueNullEmptyTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNValueNullEmptyTest">
     <fmt:setLocale value="en_US"/>

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNValueTest">
     <c:set var="num" value="1,234"/>

--- a/src/web/jstl/spec/fmt/format/parsenum/positivePNVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/parsenum/positivePNVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePNVarTest">

--- a/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneAttrScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneAttrScopeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTimezoneAttrScopeTest">
 

--- a/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTimezoneScopeTest">

--- a/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneSetAttrTest.jsp
+++ b/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneSetAttrTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTimezoneSetAttrTest">
 

--- a/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.TimeZone,java.util.Date" %>
 <tck:test testName="positiveTimezoneValueTest">

--- a/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneVarTest.jsp
+++ b/src/web/jstl/spec/fmt/format/settimezone/positiveSetTimezoneVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTimezoneVarTest">

--- a/src/web/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>

--- a/src/web/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
+++ b/src/web/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.TimeZone,java.util.Date" %>
 <tck:test testName="positiveTimezoneValueTest">

--- a/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleBasenameNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleBasenameNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBundleBasenameNullEmptyTest">

--- a/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleBasenameTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleBasenameTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBundleBasenameTest">
     <c:set var="bun" value="com.sun.ts.tests.jstl.common.resources.Resources"/>

--- a/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleFallbackLocaleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>

--- a/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleLocaleConfigurationTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleLocaleConfigurationTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBundleLocaleConfigurationTest">

--- a/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleLocalizationScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/bundle/positiveBundleLocalizationScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBundleLocalizationScopeTest">

--- a/src/web/jstl/spec/fmt/i18n/bundle/positiveBundlePrefixTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/bundle/positiveBundlePrefixTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveBundlePrefixTest">
     <c:set var="pre" value="m"/>

--- a/src/web/jstl/spec/fmt/i18n/message/localeSupportTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/localeSupportTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocaleSupport" %>
 

--- a/src/web/jstl/spec/fmt/i18n/message/negativeLocaleSupportTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/negativeLocaleSupportTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocaleSupport" %>
 

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageBundleOverrideTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageBundleOverrideTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageBundleTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageBundleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageCompoundNoParamTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageCompoundNoParamTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageCompoundNoParamTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageFallbackLocaleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyBodyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageKeyBodyTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyNotFoundTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyNotFoundTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageKeyNotFoundTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageKeyNullEmptyTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyParamBodyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyParamBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageKeyParamBodyTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageKeyTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageKeyTest">
     <c:set var="eKey" value="mkey"/>

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageLocaleConfigurationTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageLocaleConfigurationTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageLocaleConfigurationVariableTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageNoLocalizationContextTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageNoLocalizationContextTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageParamBodyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageParamBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageParamBodyTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessagePrefixTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessagePrefixTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessagePrefixTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageScopeTest">

--- a/src/web/jstl/spec/fmt/i18n/message/positiveMessageVarTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/message/positiveMessageVarTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveMessageVarTest">
     <fmt:bundle basename="com.sun.ts.tests.jstl.common.resources.Resources">

--- a/src/web/jstl/spec/fmt/i18n/param/positiveParamValueBodyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/param/positiveParamValueBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamValueBodyTest">

--- a/src/web/jstl/spec/fmt/i18n/param/positiveParamValueTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/param/positiveParamValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParamValueTest">
     <c:set var="val1" value="value1"/>

--- a/src/web/jstl/spec/fmt/i18n/requestencoding/positiveContentTypeEncodingTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/requestencoding/positiveContentTypeEncodingTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveContentTypeEncodingTest">
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.request.charset"/>

--- a/src/web/jstl/spec/fmt/i18n/requestencoding/positiveDefaultEncodingTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/requestencoding/positiveDefaultEncodingTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveDefaultEncodingTest">
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.request.charset"/>

--- a/src/web/jstl/spec/fmt/i18n/requestencoding/positiveReqEncodingValueTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/requestencoding/positiveReqEncodingValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveReqEncodingValueTest">
     <c:set var="enc" value="US-ASCII"/>

--- a/src/web/jstl/spec/fmt/i18n/requestencoding/positiveScopedAttrEncodingTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/requestencoding/positiveScopedAttrEncodingTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveScopedAttrEncodingTest">
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.request.charset" scope="session"/>

--- a/src/web/jstl/spec/fmt/i18n/resourcelookup/formatBundleResourceLookup.jsp
+++ b/src/web/jstl/spec/fmt/i18n/resourcelookup/formatBundleResourceLookup.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.core.Config" %>
 <tck:test testName="formatSetBundleResourceLookup">

--- a/src/web/jstl/spec/fmt/i18n/resourcelookup/formatSetBundleResourceLookup.jsp
+++ b/src/web/jstl/spec/fmt/i18n/resourcelookup/formatSetBundleResourceLookup.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.core.Config" %>
 <tck:test testName="formatBundleResourceLookup">

--- a/src/web/jstl/spec/fmt/i18n/responseencoding/positiveResponseEncodingTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/responseencoding/positiveResponseEncodingTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>
 <tck:test testName="positiveBundleResponseSettersTest">

--- a/src/web/jstl/spec/fmt/i18n/responseencoding/positiveResponseSetCharEncodingAttrTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/responseencoding/positiveResponseSetCharEncodingAttrTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>
 <%!

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleBasenameNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleBasenameNullEmptyTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>
 <tck:test testName="positiveSetBundleBasenameNullEmptyTest">

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleBasenameTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleBasenameTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetBundleBasenameTest">
     <c:set var="base" value="com.sun.ts.tests.jstl.common.resources.Resources"/>

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleFallbackLocaleTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleFallbackLocaleTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>
 <tck:test testName="positiveSetBundleFallbackLocaleTest">

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleLocaleConfigurationTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleLocaleConfigurationTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetBundleLocaleConfigurationTest">

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleScopeLocCtxTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleScopeLocCtxTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetBundleScopeLocCtxTest">

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleScopeVarTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleScopeVarTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetBundleScopeVarTest">
 

--- a/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleVarTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setbundle/positiveSetBundleVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="jakarta.servlet.jsp.jstl.fmt.LocalizationContext" %>

--- a/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleOverrideTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleOverrideTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetLocaleOverrideTest">
 

--- a/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleScopeTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleScopeTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetLocaleScopeTest">
 

--- a/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleValueNullEmptyTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleValueNullEmptyTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>
 <tck:test testName="positveSetLocaleValueNullEmptyTest">

--- a/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleValueTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleValueTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>
 <tck:test testName="positiveSetLocaleValueTest">

--- a/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleVariantIgnoreTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleVariantIgnoreTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Locale" %>
 <tck:test testName="positiveSetLocaleVariantIgnoreTest">

--- a/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleVariantTest.jsp
+++ b/src/web/jstl/spec/fmt/i18n/setlocale/positiveSetLocaleVariantTest.jsp
@@ -16,9 +16,9 @@
 
 --%>
 
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetLocaleVariantTest">
     <c:set var="loc" value="EURO"/>

--- a/src/web/jstl/spec/sql/param/negativeDateParamTypeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeDateParamTypeAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/negativeDateParamTypeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeDateParamTypeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/negativeParamQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamQueryBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/negativeParamQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamQueryBodyContentTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/param/negativeParamQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamQuerySQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/negativeParamQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamQuerySQLAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/param/negativeParamUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamUpdateBodyContentTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/negativeParamUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamUpdateBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/negativeParamUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamUpdateSQLAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/negativeParamUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/negativeParamUpdateSQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryDateTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryDateTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.sql.Date, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryDateTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryDateTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryNoTypeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryNoTypeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryNoTypeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryNoTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryTimeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryTimeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.sql.Date, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryTimeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryTimeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryTimestampTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryTimestampTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamQueryTimestampTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamQueryTimestampTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateDateTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateDateTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateDateTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateDateTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateNoTypeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateNoTypeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateNoTypeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateNoTypeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimestampTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimestampTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimestampTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveDateParamUpdateTimestampTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamBodyContentQueryTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamBodyContentQueryTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamBodyContentQueryTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamBodyContentQueryTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamBodyContentUpdateTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamBodyContentUpdateTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamBodyContentUpdateTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamBodyContentUpdateTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQueryBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQueryBodyContentTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/param/positiveParamQueryMultiBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQueryMultiBodyContentTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQueryMultiBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQueryMultiBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQueryMultiSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQueryMultiSQLAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQueryMultiSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQueryMultiSQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQuerySQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamQuerySQLAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateBodyContentTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateMultiBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateMultiBodyContentTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateMultiBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateMultiBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateMultiSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateMultiSQLAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateMultiSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateMultiSQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateSQLAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/param/positiveParamUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/param/positiveParamUpdateSQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryBodyContentTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeEmptyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*,com.sun.ts.tests.jstl.common.wrappers.TckDataSourceWrapper" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryDataSourceAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/negativeQueryDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryDataSourceNullAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.* "%>

--- a/src/web/jstl/spec/sql/query/negativeQueryDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryDataSourceNullAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryMaxRowsAttributeTest2.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryMaxRowsAttributeTest2.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryMaxRowsAttributeTest2.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryMaxRowsAttributeTest2.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest2.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest2.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest2.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryMaxRowsConfigTest2.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryNoVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryNoVarAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryNoVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryNoVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQuerySQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQuerySQLAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import= "javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/negativeQueryScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryScopeAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 <%@ page import="javax.sql.*" %>
 
 <tck:test testName="negativeQueryScopeAttributeRTTest">

--- a/src/web/jstl/spec/sql/query/negativeQueryScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryScopeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 <%@ page import="javax.sql.*" %>
 

--- a/src/web/jstl/spec/sql/query/negativeQueryVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/negativeQueryVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/negativeQueryVarAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryBodyContentTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDataSourceTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigPrecedenceTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigPrecedenceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigPrecedenceTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryDataSourceConfigPrecedenceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*,java.util.*" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryEmptyResultTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryEmptyResultTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryEmptyResultTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryEmptyResultTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryMaxRowsAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryMaxRowsAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryMaxRowsAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryMaxRowsAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryMaxRowsConfigTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryMaxRowsConfigTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryMaxRowsConfigTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryMaxRowsConfigTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryMaxRowsIntegerConfigTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryMaxRowsIntegerConfigTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryMaxRowsIntegerConfigTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryMaxRowsIntegerConfigTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQuerySQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQuerySQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQuerySQLAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryScopeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryScopeAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryStartRowAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryStartRowAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryStartRowAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryStartRowAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveQueryVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/query/positiveQueryVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveQueryVarAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*" %>
 

--- a/src/web/jstl/spec/sql/query/positiveResultSupportTest.jsp
+++ b/src/web/jstl/spec/sql/query/positiveResultSupportTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ taglib prefix="resultSetQuery" uri="http://java.sun.com/jstltck/resultSetQuery" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesCountTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesCountTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesCountTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesCountTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetColumnNamesTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexCountTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexCountTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexCountTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexCountTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsByIndexTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsCountTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsCountTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsCountTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsCountTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsLowerCaseTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsLowerCaseTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsLowerCaseTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsLowerCaseTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsUpperCaseTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsUpperCaseTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/result/positiveResultGetRowsUpperCaseTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultGetRowsUpperCaseTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultIsLimitedByMaxRowsTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultIsLimitedByMaxRowsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/result/positiveResultIsLimitedByMaxRowsTest.jsp
+++ b/src/web/jstl/spec/sql/result/positiveResultIsLimitedByMaxRowsTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceAttributeEmptyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*,com.sun.ts.tests.jstl.common.wrappers.TckDataSourceWrapper" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceNullAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceDataSourceNullAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceScopeAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/negativeSetDataSourceScopeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryNoVarAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryURLTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryURLTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryURLTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceQueryURLTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeNoVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeNoVarAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*,

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeNoVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeNoVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeVarAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceScopeVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxNoVarAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxURLTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxURLTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxURLTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceTxURLTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateNoVarAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateURLTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateURLTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateURLTest.jsp
+++ b/src/web/jstl/spec/sql/setdatasource/positiveSetDataSourceUpdateURLTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeEmptyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*,com.sun.ts.tests.jstl.common.wrappers.TckDataSourceWrapper" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxDataSourceAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxDataSourceNullAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxDataSourceNullAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxIsolationLevelAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxIsolationLevelAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxIsolationLevelAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxIsolationLevelAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxQueryDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxQueryDataSourceAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxQueryDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxQueryDataSourceAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxUpdateDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxUpdateDataSourceAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/negativeTxUpdateDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/negativeTxUpdateDataSourceAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxCommitLifeCycleTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxCommitLifeCycleTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxCommitLifeCycleTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxCommitLifeCycleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*,java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigPrecedenceTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigPrecedenceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigPrecedenceTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxDataSourceConfigPrecedenceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_CommittedTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_CommittedTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_CommittedTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_CommittedTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_UnCommittedTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_UnCommittedTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_UnCommittedTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRead_UnCommittedTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRepeatable_Read.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRepeatable_Read.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRepeatable_Read.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeRepeatable_Read.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeSerializable.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeSerializable.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeSerializable.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxIsolationAttributeSerializable.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxQueryCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxQueryCommitTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxQueryCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxQueryCommitTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxQueryParamCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxQueryParamCommitTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxQueryParamCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxQueryParamCommitTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxRollbackLifeCycleTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxRollbackLifeCycleTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxRollbackLifeCycleTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxRollbackLifeCycleTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxUpdateCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxUpdateCommitTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxUpdateCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxUpdateCommitTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxUpdateParamCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxUpdateParamCommitTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxUpdateParamCommitTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxUpdateParamCommitTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxUpdateRollbackTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxUpdateRollbackTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/transaction/positiveTxUpdateRollbackTest.jsp
+++ b/src/web/jstl/spec/sql/transaction/positiveTxUpdateRollbackTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateBodyContentTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeEmptyTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeEmptyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*,com.sun.ts.tests.jstl.common.wrappers.TckDataSourceWrapper" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateDataSourceAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateDataSourceNullAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateDataSourceNullAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateDataSourceNullAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import= "javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest2.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest2.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest2.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateSQLAttributeTest2.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateScopeAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/negativeUpdateScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativeUpdateScopeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/negativesetDataSourceScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativesetDataSourceScopeAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/negativesetDataSourceScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/negativesetDataSourceScopeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateBodyContentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateBodyContentTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateBodyContentTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*" %>
 

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDataSourceTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceAttributeDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDataSourceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDataSourceTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDataSourceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*,java.util.*" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDriverManagerTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDriverManagerTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigDriverManagerTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*,java.util.*" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigPrecedenceTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigPrecedenceTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigPrecedenceTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateDataSourceConfigPrecedenceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateNoRowsResultTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateNoRowsResultTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateNoRowsResultTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateNoRowsResultTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*" %>
 

--- a/src/web/jstl/spec/sql/update/positiveUpdateNoVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateNoVarAttributeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateNoVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateNoVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateRowsResultTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateRowsResultTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateRowsResultTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateRowsResultTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.lang.Integer" %>
 

--- a/src/web/jstl/spec/sql/update/positiveUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateSQLAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateSQLAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateSQLAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/update/positiveUpdateScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateScopeAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateScopeAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateScopeAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.util.*" %>
 

--- a/src/web/jstl/spec/sql/update/positiveUpdateVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateVarAttributeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ taglib prefix="sql" uri="jakarta.tags.sql" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/sql/update/positiveUpdateVarAttributeTest.jsp
+++ b/src/web/jstl/spec/sql/update/positiveUpdateVarAttributeTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.sql.*, java.lang.Integer" %>
 

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWONoWhenActionsTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWONoWhenActionsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWONoWhenActionsRTTest">
     <!-- If there are no when actions nested within a choose action

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOOtherwiseNoParentTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOOtherwiseNoParentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOOtherwiseNoParentRTTest">
     <!-- If otherwise doesn't have choose an an immediate parent,

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenBeforeOtherwiseTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenBeforeOtherwiseTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenBeforeOtherwiseRTTest">
     <!-- When must appear before an otherwise action,

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenNoParentTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenNoParentTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenNoParentRTTest">
     <!-- A fatal translation error will occur if a when

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenSelectFailureTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenSelectFailureTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenSelectFailureTest">

--- a/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenSelectReqAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/negativeCWOWhenSelectReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeCWOWhenSelectReqAttrRTTest">
     <!-- Validate that if the select attribute is not present, a

--- a/src/web/jstl/spec/xml/xconditional/xcwo/positiveCWOTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/positiveCWOTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveCWOTest">

--- a/src/web/jstl/spec/xml/xconditional/xcwo/positiveCWOWhiteSpaceTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xcwo/positiveCWOWhiteSpaceTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveCWOWhiteSpaceTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/negativeForEachSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/negativeForEachSelectFailureTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xconditional/xforeach/negativeForEachSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/negativeForEachSelectFailureTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeForEachSelectFailureTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/negativeForEachSelectReqAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/negativeForEachSelectReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeForEachSelectReqAttrRTTest">
     <!-- RT: If select is not present, a fatal translation error will 

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachBeginTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachBeginTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsBeginTest">
     <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachBeginTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachBeginTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsBeginTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachEndLTBeginTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachEndLTBeginTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="jakarta.tags.xml" prefix="x" %>
  <x:parse var="doc">
         <a>
             <b>btext1</b>

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachEndTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachEndTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsEndTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachEndTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachEndTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsEndTest">
    <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachSelectEmptyTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachSelectEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveForEachSelectEmptyTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachSelectTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachSelectTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveForEachSelectTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachStepTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachStepTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsStepTest">
      <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachStepTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachStepTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveItemsStepTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarStatusTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarStatusTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveVarStatusTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarStatusTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarStatusTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveVarStatusTest">
     <%

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveVarForEachTest">

--- a/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xforeach/positiveForEachVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xconditional/xif/negativeIfInvalidScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/negativeIfInvalidScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeIfInvalidScopeRTTest">
     <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xconditional/xif/negativeIfScopeVarTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/negativeIfScopeVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeIfScopeVarRTTest">
     <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xconditional/xif/negativeIfSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/negativeIfSelectFailureTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xconditional/xif/negativeIfSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/negativeIfSelectFailureTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSelectFailureTest">

--- a/src/web/jstl/spec/xml/xconditional/xif/negativeIfSelectReqAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/negativeIfSelectReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeIfSelectReqAttrRTTest">
     <!-- A fatal translation error will occur of the select attribute

--- a/src/web/jstl/spec/xml/xconditional/xif/positiveIfScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/positiveIfScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xconditional/xif/positiveIfScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/positiveIfScopeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveIfScopeTest">

--- a/src/web/jstl/spec/xml/xconditional/xif/positiveIfSelectTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/positiveIfSelectTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveIfSelectTest">

--- a/src/web/jstl/spec/xml/xconditional/xif/positiveIfVarTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/positiveIfVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xconditional/xif/positiveIfVarTest.jsp
+++ b/src/web/jstl/spec/xml/xconditional/xif/positiveIfVarTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveIfVarTest">

--- a/src/web/jstl/spec/xml/xmlcore/bindings/positiveXPathVariableBindingsTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/bindings/positiveXPathVariableBindingsTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveXPathVariableBindingsTest">

--- a/src/web/jstl/spec/xml/xmlcore/bindings/positiveXPathVariableBindingsTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/bindings/positiveXPathVariableBindingsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/negativeParseDocNullEmptyTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/negativeParseDocNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/negativeParseDocNullEmptyTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/negativeParseDocNullEmptyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeParseDocNullEmptyTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/negativeParseInvalidScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/negativeParseInvalidScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeParseInvalidScopeRTTest">
     <!-- An invalid value provided to the scope attribute should

--- a/src/web/jstl/spec/xml/xmlcore/parse/negativeParseScopeVarDomSyntaxTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/negativeParseScopeVarDomSyntaxTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeParseScopeVarDomSyntaxELTest">
     <!-- If scopeDom is specified, and varDom is not, the TLV

--- a/src/web/jstl/spec/xml/xmlcore/parse/negativeParseScopeVarSyntaxTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/negativeParseScopeVarSyntaxTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeParseScopeVarSyntaxELTest">
     <!-- If scope is specified, and var is not, the TLV

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterNullTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterNullTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterNullTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterNullTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseFilterNullTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseFilterTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="com.sun.ts.tests.jstl.common.filters.SimpleXmlFilter,org.xml.sax.XMLFilter,java.io.Reader,java.io.StringReader" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseNoDTDValidationTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseNoDTDValidationTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseNoDTDValidationTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseNoDTDValidationTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseNoDTDValidationTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeDomTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeDomTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeDomTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeDomTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseScopeDomTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseScopeTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseSystemIdTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseSystemIdTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseSystemIdTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarDomTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarDomTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseVarDomTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarDomTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarDomTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseVarTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseVarTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlAttrTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ page contentType="text/plain" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="jakarta.tags.xml" prefix="x" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <%-- Validate that the xml attribute is still present and can be

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlAttrTest.jsp
@@ -18,7 +18,7 @@
 
 <%@ page contentType="text/plain" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <%-- Validate that the xml attribute is still present and can be
      used in JSTL 1.1 based tag libraries. --%>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlBodyTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlBodyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveParseXmlBodyTest">

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlBodyTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlInputTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlInputTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlInputTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/parse/positiveParseXmlInputTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.io.Reader,java.io.StringReader" %>

--- a/src/web/jstl/spec/xml/xmlcore/types/positiveJavaToXPathTypesTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/types/positiveJavaToXPathTypesTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/types/positiveJavaToXPathTypesTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/types/positiveJavaToXPathTypesTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveJavaToXPathTypesTest">

--- a/src/web/jstl/spec/xml/xmlcore/types/positiveXPathToJavaTypesTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/types/positiveXPathToJavaTypesTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/types/positiveXPathToJavaTypesTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/types/positiveXPathToJavaTypesTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveXPathToJavaTypesTest">

--- a/src/web/jstl/spec/xml/xmlcore/xout/negativeOutSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/negativeOutSelectFailureTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/xout/negativeOutSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/negativeOutSelectFailureTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeOutSelectFailureTest">

--- a/src/web/jstl/spec/xml/xmlcore/xout/negativeOutSelectReqAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/negativeOutSelectReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeOutSelectReqAttrRTTest">
     <!-- A fatal translation error will occur if the select attribute

--- a/src/web/jstl/spec/xml/xmlcore/xout/positiveOutEscXmlTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/positiveOutEscXmlTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/xout/positiveOutEscXmlTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/positiveOutEscXmlTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutEscXmlTest">

--- a/src/web/jstl/spec/xml/xmlcore/xout/positiveOutSelectTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/positiveOutSelectTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/xout/positiveOutSelectTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xout/positiveOutSelectTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveOutSelectTest">

--- a/src/web/jstl/spec/xml/xmlcore/xset/negativeSetInvalidScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/negativeSetInvalidScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSetInvalidScopeRTTest">
     <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xmlcore/xset/negativeSetSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/negativeSetSelectFailureTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/xset/negativeSetSelectFailureTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/negativeSetSelectFailureTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSetSelectFailureTest">

--- a/src/web/jstl/spec/xml/xmlcore/xset/negativeSetSelectReqAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/negativeSetSelectReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSetSelectReqAttrRTTest">
     <!-- A fatal translation error will occur if the select attribute

--- a/src/web/jstl/spec/xml/xmlcore/xset/negativeSetVarReqAttrTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/negativeSetVarReqAttrTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeSetVarReqAttrRTTest">
     <x:parse var="doc">

--- a/src/web/jstl/spec/xml/xmlcore/xset/positiveSetScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/positiveSetScopeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetScopeTest">

--- a/src/web/jstl/spec/xml/xmlcore/xset/positiveSetScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/positiveSetScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/xset/positiveSetSelectVarTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/positiveSetSelectVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xmlcore/xset/positiveSetSelectVarTest.jsp
+++ b/src/web/jstl/spec/xml/xmlcore/xset/positiveSetSelectVarTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveSetSelectVarTest">

--- a/src/web/jstl/spec/xml/xtransform/param/positiveXParamBodyValueTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/param/positiveXParamBodyValueTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveXParamBodyValueTest">

--- a/src/web/jstl/spec/xml/xtransform/param/positiveXParamBodyValueTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/param/positiveXParamBodyValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/param/positiveXParamNameTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/param/positiveXParamNameTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/param/positiveXParamNameTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/param/positiveXParamNameTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveXParamNameTest">

--- a/src/web/jstl/spec/xml/xtransform/param/positiveXParamValueTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/param/positiveXParamValueTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveXParamValueTest">

--- a/src/web/jstl/spec/xml/xtransform/param/positiveXParamValueTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/param/positiveXParamValueTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/negativeTransformXmlXsltNullEmptyTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/negativeTransformXmlXsltNullEmptyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/negativeTransformXmlXsltNullEmptyTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/negativeTransformXmlXsltNullEmptyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="negativeTransformXmlXsltNullEmptyTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyParamsTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyParamsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyParamsTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyParamsTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformBodyParamsTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyXmlParamsTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyXmlParamsTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformBodyXmlParamsTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyXmlParamsTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformBodyXmlParamsTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformDocSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformDocSystemIdTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformDocSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformDocSystemIdTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformDocSystemIdTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformResultTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformResultTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformResultTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformResultTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="javax.xml.transform.*,javax.xml.transform.stream.*,java.io.*" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformScopeTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformScopeTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformScopeTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformScopeTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformVarTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformVarTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformVarTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformVarTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformVarTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlAndXmlSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlAndXmlSystemIdTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformXmlAndXmlSystemIdTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlAndXmlSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlAndXmlSystemIdTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlBodyTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlBodyTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlBodyTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlBodyTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformXmlBodyTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlInputTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlInputTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlInputTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXmlInputTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.io.*,javax.xml.transform.*,javax.xml.transform.stream.*" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltInputTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltInputTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltInputTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltInputTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.io.*,javax.xml.transform.*,javax.xml.transform.stream.*" %>

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltSystemIdTest.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
+<%@ taglib prefix="x" uri="jakarta.tags.xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveTransformXsltSystemIdTest">

--- a/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltSystemIdTest.jsp
+++ b/src/web/jstl/spec/xml/xtransform/transform/positiveTransformXsltSystemIdTest.jsp
@@ -16,7 +16,7 @@
 
 --%>
 
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>


### PR DESCRIPTION
**Fixes Issue**
None specified

**Related Issue(s)**
https://github.com/eclipse-ee4j/jstl-api/issues/144

**Describe the change**
Updated the below taglibs. This will fix around 400 failing JSTL standalone TCK tests with glassfish 7
```
http://java.sun.com/jsp/jstl/sql -> jakarta.tags.sql
http://java.sun.com/jsp/jstl/functions -> jakarta.tags.functions
http://java.sun.com/jsp/jstl/xml -> jakarta.tags.xml

http://java.sun.com/jsp/jstl/core -> jakarta.tags.core
http://java.sun.com/jsp/jstl/fmt -> jakarta.tags.fmt
```

