### PR TITLE
update taglibs for jsf and other suites

### DIFF
--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.jsp
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.jsp
@@ -17,8 +17,8 @@
 --%>
 
 <%@page contentType="text/html"%>
-<%@taglib prefix="f" uri="http://java.sun.com/jsf/core"%>
-<%@taglib prefix="h" uri="http://java.sun.com/jsf/html"%>
+<%@taglib prefix="f" uri="jakarta.faces.core"%>
+<%@taglib prefix="h" uri="jakarta.faces.html"%>
 
 <html>
     <head><title>${param['testName']}_from_ejblitejsf</title></head>

--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp
@@ -18,7 +18,7 @@
 
 <%@page contentType="text/html"%>
 <%@taglib prefix="ejblitejsp" uri="/WEB-INF/tlds/ejblitejsp.tld"%>
-<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="c" uri="jakarta.tags.core"%>
 
 <html>
     <head><title>${param['testName']}_from_ejblitejsp</title></head>

--- a/src/com/sun/ts/tests/common/vehicle/ejblitesecuredjsp/ejblitesecuredjsp_vehicle.jsp
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitesecuredjsp/ejblitesecuredjsp_vehicle.jsp
@@ -18,7 +18,7 @@
 
 <%@page contentType="text/html"%>
 <%@taglib prefix="ejblitesecuredjsp" uri="/WEB-INF/tlds/ejblitesecuredjsp.tld"%>
-<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="c" uri="jakarta.tags.core"%>
 
 <html>
     <head><title>${param['testName']}_from_ejblitesecuredjsp</title></head>

--- a/src/com/sun/ts/tests/common/vehicle/ejbliteservletcal/ejbliteservletcal_vehicle.jsp
+++ b/src/com/sun/ts/tests/common/vehicle/ejbliteservletcal/ejbliteservletcal_vehicle.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%@page contentType="text/html"%>
-<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="c" uri="jakarta.tags.core"%>
 
 <html>
     <head><title>${param['testName']}_from_ejbliteservletcal</title></head>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/blue.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/blue.xhtml
@@ -24,9 +24,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/compOne.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/compOne.xhtml
@@ -19,10 +19,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>A simple composite tag</title>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/neg_jsp_test.jsp
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/neg_jsp_test.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/red.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/red.xhtml
@@ -24,9 +24,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/start.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/start.xhtml
@@ -24,9 +24,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/stop.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/common/resources/stop.xhtml
@@ -24,9 +24,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/common/components/myComp.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/common/components/myComp.xhtml
@@ -18,10 +18,10 @@
 
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>composite:attribute tag</title>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/common/myRoot.xhtml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/common/myRoot.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <xhtml xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:tck="jakarta.faces.composite.tckcomp">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>root_facelet</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/actionsource/components/noTargetAtt.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/actionsource/components/noTargetAtt.xhtml
@@ -17,10 +17,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <head>
 
         <title>No Name Attribute</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/actionsource/components/targetAndNameAtt.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/actionsource/components/targetAndNameAtt.xhtml
@@ -18,10 +18,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <head>
 
         <title>Target and Name Specified</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/attribute/components/attributeCompOne.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/attribute/components/attributeCompOne.xhtml
@@ -20,10 +20,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>composite:attribute tag</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/attribute/components/attributeCompThree.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/attribute/components/attributeCompThree.xhtml
@@ -20,10 +20,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>composite:attribute tag</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/attribute/components/attributeCompTwo.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/attribute/components/attributeCompTwo.xhtml
@@ -20,10 +20,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>composite:attribute tag</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/common/tckcomponents/1_0/compVer.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/common/tckcomponents/1_0/compVer.xhtml
@@ -20,10 +20,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>Version 1.0 Component</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/common/tckcomponents/2_0/compVer.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/common/tckcomponents/2_0/compVer.xhtml
@@ -20,10 +20,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>A simple composite tag</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/common/tckcomponents/compOne.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/common/tckcomponents/compOne.xhtml
@@ -20,10 +20,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <h:head>
 
         <title>A simple composite tag</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/components/noTargetAtt.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/components/noTargetAtt.xhtml
@@ -18,10 +18,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <head>
 
         <title>No Name Attribute</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/components/targetAndNameAtt.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/components/targetAndNameAtt.xhtml
@@ -18,10 +18,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <head>
 
         <title>Name and Targets Attribute</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/facet/components/facetOne.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/facet/components/facetOne.xhtml
@@ -17,10 +17,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <head>
 
         <title>FacetOne</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/insertchildren/components/rupc.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/insertchildren/components/rupc.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
 
 <!--
 

--- a/src/com/sun/ts/tests/jsf/spec/composite/valueholder/components/noTargetAtt.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/valueholder/components/noTargetAtt.xhtml
@@ -17,10 +17,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
     <head>
 
         <title>No Name Attribute</title>

--- a/src/com/sun/ts/tests/jsf/spec/composite/valueholder/components/targetAndNameAtt.xhtml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/valueholder/components/targetAndNameAtt.xhtml
@@ -19,10 +19,10 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:composite="http://java.sun.com/jsf/composite">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:composite="jakarta.faces.composite">
 
     <head>
 

--- a/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/JSFSigTEI.java
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/JSFSigTEI.java
@@ -20,8 +20,8 @@ public class JSFSigTEI extends SignatureExtraInfo {
 
   protected String[][] getTaglibDescriptorInfo() {
     return new String[][] {
-        { "/WEB-INF/jsf_core.tld", "http://java.sun.com/jsf/core" },
-        { "/WEB-INF/html_basic.tld", "http://java.sun.com/jsf/html" }, };
+        { "/WEB-INF/jsf_core.tld", "jakarta.faces.core" },
+        { "/WEB-INF/html_basic.tld", "jakarta.faces.html" }, };
   }
 
 }

--- a/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/SignatureExtraInfo.java
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/SignatureExtraInfo.java
@@ -108,7 +108,7 @@ public abstract class SignatureExtraInfo extends TagExtraInfo {
    * is the resource that contains the 'master' tld, the second element contains
    * the well known URI for which we can obtain a matching TagLibraryInfo from
    * the container. Example: return new String[][] { { "/jsf-core.tld",
-   * "http://java.sun.com/jsf/core" } };
+   * "jakarta.faces.core" } };
    */
   protected abstract String[][] getTaglibDescriptorInfo();
 

--- a/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/html_basic.tld
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/html_basic.tld
@@ -33,7 +33,7 @@
         h
     </short-name>
     <uri>
-        http://java.sun.com/jsf/html
+        jakarta.faces.html
     </uri>
 
 <!-- ============== Tag Library Validator ============= -->

--- a/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/jsf_core.tld
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/jsf_core.tld
@@ -31,7 +31,7 @@
     </description>
     <tlib-version>2.1</tlib-version>
     <short-name>f</short-name>
-    <uri>http://java.sun.com/jsf/core</uri>
+    <uri>jakarta.faces.core</uri>
 
 
 

--- a/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/test.jsp
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/test.jsp
@@ -18,8 +18,8 @@
 
 <%-- Testing JSF core and html taglibraries --%>
 <%@ page contentType="plain/txt" %>
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <%@ taglib uri="/WEB-INF/signaturetest.tld" prefix="tck" %>
 

--- a/src/com/sun/ts/tests/securityapi/ham/customform/base/login.xhtml
+++ b/src/com/sun/ts/tests/securityapi/ham/customform/base/login.xhtml
@@ -18,8 +18,8 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:jsf="http://xmlns.jcp.org/jsf">
+	xmlns:h="jakarta.faces.html"
+	xmlns:jsf="jakarta.faces">
 <h:head>
 	<title>login</title>
 </h:head>

--- a/src/com/sun/ts/tests/securityapi/ham/customform/expression/login.xhtml
+++ b/src/com/sun/ts/tests/securityapi/ham/customform/expression/login.xhtml
@@ -18,8 +18,8 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:jsf="http://xmlns.jcp.org/jsf">
+	xmlns:h="jakarta.faces.html"
+	xmlns:jsf="jakarta.faces">
 <h:head>
 	<title>login</title>
 </h:head>

--- a/src/web/jsf/api/jakarta_faces/application/applicationISE/applicationtest.jsp
+++ b/src/web/jsf/api/jakarta_faces/application/applicationISE/applicationtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/api/jakarta_faces/application/resourcehandlerEx/resourceHandlerExcludeTest.jsp
+++ b/src/web/jsf/api/jakarta_faces/application/resourcehandlerEx/resourceHandlerExcludeTest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/api/jakarta_faces/model/annotationsTest.xhtml
+++ b/src/web/jsf/api/jakarta_faces/model/annotationsTest.xhtml
@@ -21,8 +21,8 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>annotationsTest</title>
   </head>

--- a/src/web/jsf/spec/ajax/jsresource/pdlApproach.xhtml
+++ b/src/web/jsf/spec/ajax/jsresource/pdlApproach.xhtml
@@ -21,9 +21,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxAllKeyword1.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxAllKeyword1.xhtml
@@ -20,9 +20,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxAllKeyword2.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxAllKeyword2.xhtml
@@ -20,9 +20,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxAllKeyword3.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxAllKeyword3.xhtml
@@ -20,9 +20,9 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxFormKeyword1.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxFormKeyword1.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxFormKeyword2.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxFormKeyword2.xhtml
@@ -19,9 +19,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxFormKeyword3.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxFormKeyword3.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxNoneKeyword1.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxNoneKeyword1.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxNoneKeyword2.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxNoneKeyword2.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxNoneKeyword3.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxNoneKeyword3.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxThisKeyword1.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxThisKeyword1.xhtml
@@ -19,9 +19,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxThisKeyword2.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxThisKeyword2.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/keyword/ajaxThisKeyword3.xhtml
+++ b/src/web/jsf/spec/ajax/keyword/ajaxThisKeyword3.xhtml
@@ -20,9 +20,9 @@
         PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/src/web/jsf/spec/ajax/tagwrapper/ajaxTagWrap.xhtml
+++ b/src/web/jsf/spec/ajax/tagwrapper/ajaxTagWrap.xhtml
@@ -20,9 +20,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 <h:head>
     <title>Ajax Tag Wrapping Test</title>
 </h:head>

--- a/src/web/jsf/spec/appconfigresources/absolute_ordering/test.xhtml
+++ b/src/web/jsf/spec/appconfigresources/absolute_ordering/test.xhtml
@@ -22,7 +22,7 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Document Ordering</title>
     </head>

--- a/src/web/jsf/spec/appconfigresources/relative_ordering/testOne.xhtml
+++ b/src/web/jsf/spec/appconfigresources/relative_ordering/testOne.xhtml
@@ -21,7 +21,7 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Document Ordering</title>
     </head>

--- a/src/web/jsf/spec/appconfigresources/startupbehavior/appconfig_01.xhtml
+++ b/src/web/jsf/spec/appconfigresources/startupbehavior/appconfig_01.xhtml
@@ -21,8 +21,8 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <h:head>
         <title>appconfig_01</title>
     </h:head>

--- a/src/web/jsf/spec/appconfigresources/startupbehavior/appconfig_02.xhtml
+++ b/src/web/jsf/spec/appconfigresources/startupbehavior/appconfig_02.xhtml
@@ -21,8 +21,8 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <h:head>
         <title>appconfig_01</title>
     </h:head>

--- a/src/web/jsf/spec/composite/actionsource/notargets.xhtml
+++ b/src/web/jsf/spec/composite/actionsource/notargets.xhtml
@@ -17,10 +17,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
     <h:head>
         <title>No Targets Attribute</title>
         <style type="text/css">

--- a/src/web/jsf/spec/composite/actionsource/targetandname.xhtml
+++ b/src/web/jsf/spec/composite/actionsource/targetandname.xhtml
@@ -17,10 +17,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
     <h:head>
         <title>Name Before Target</title>
         <style type="text/css">

--- a/src/web/jsf/spec/composite/attribute/attributeTest.xhtml
+++ b/src/web/jsf/spec/composite/attribute/attributeTest.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/composite/attribute/attributeTestTwo.xhtml
+++ b/src/web/jsf/spec/composite/attribute/attributeTestTwo.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/composite/editablevalueholder/caseOne.xhtml
+++ b/src/web/jsf/spec/composite/editablevalueholder/caseOne.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
 
 <!--
 

--- a/src/web/jsf/spec/composite/editablevalueholder/caseTwo.xhtml
+++ b/src/web/jsf/spec/composite/editablevalueholder/caseTwo.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp"> 
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp"> 
 
 <!--
 

--- a/src/web/jsf/spec/composite/facet/facetsOne.xhtml
+++ b/src/web/jsf/spec/composite/facet/facetsOne.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
 <!--
 
     Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.

--- a/src/web/jsf/spec/composite/insertchildren/testOne.xhtml
+++ b/src/web/jsf/spec/composite/insertchildren/testOne.xhtml
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
 
 <!--
 

--- a/src/web/jsf/spec/composite/packaging/classpath/pkgTest.xhtml
+++ b/src/web/jsf/spec/composite/packaging/classpath/pkgTest.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp"
-      xmlns:ver="http://java.sun.com/jsf/composite/versioned">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:tck="jakarta.faces.composite.tckcomp"
+      xmlns:ver="jakarta.faces.composite.versioned">
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/composite/packaging/webapproot/pkgTest.xhtml
+++ b/src/web/jsf/spec/composite/packaging/webapproot/pkgTest.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp"
-      xmlns:ver="http://java.sun.com/jsf/composite/versioned">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:tck="jakarta.faces.composite.tckcomp"
+      xmlns:ver="jakarta.faces.composite.versioned">
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/composite/valueholder/caseOne.xhtml
+++ b/src/web/jsf/spec/composite/valueholder/caseOne.xhtml
@@ -17,10 +17,10 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
     <h:head>
         <title>Composite:editableValueHolder Tag Test</title>
     </h:head>

--- a/src/web/jsf/spec/composite/valueholder/caseTwo.xhtml
+++ b/src/web/jsf/spec/composite/valueholder/caseTwo.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:tck="http://java.sun.com/jsf/composite/tckcomp">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:tck="jakarta.faces.composite.tckcomp">
 <!--
 
     Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.

--- a/src/web/jsf/spec/coretags/selectitems/test_facelet.xhtml
+++ b/src/web/jsf/spec/coretags/selectitems/test_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/coretags/viewaction/passed_facelet.xhtml
+++ b/src/web/jsf/spec/coretags/viewaction/passed_facelet.xhtml
@@ -21,8 +21,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core">
 <h:head>
 	<title>UIViewAction Result Page</title>
 </h:head>

--- a/src/web/jsf/spec/coretags/viewaction/test_facelet.xhtml
+++ b/src/web/jsf/spec/coretags/viewaction/test_facelet.xhtml
@@ -21,8 +21,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core">
 <f:metadata>
 	<f:viewParam id="id" name="author" value="#{book.authorName}" />
 	<f:viewAction action="#{book.checkAuthor}" onPostback="true" />

--- a/src/web/jsf/spec/flows/basicflowcall/flow-a/flow-a.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/flow-a/flow-a.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core">
 
 <head>
 <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicflowcall/flow-a/next_a.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/flow-a/next_a.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Second page in the flow</title>

--- a/src/web/jsf/spec/flows/basicflowcall/flow-a/next_b.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/flow-a/next_b.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Last page in the flow</title>

--- a/src/web/jsf/spec/flows/basicflowcall/flow-b/flow-b.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/flow-b/flow-b.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicflowcall/flow-b/next_a.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/flow-b/next_a.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Second page in the flow</title>

--- a/src/web/jsf/spec/flows/basicflowcall/flow-b/next_b.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/flow-b/next_b.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Last page in the flow</title>

--- a/src/web/jsf/spec/flows/basicflowcall/index.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/index.xhtml
@@ -19,7 +19,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Outside of flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicflowcall/nonFlow.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/nonFlow.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Try to access a flow bean from outside of a flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicflowcall/return1.xhtml
+++ b/src/web/jsf/spec/flows/basicflowcall/return1.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page navigated to upon return from any flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicimplicit/index.xhtml
+++ b/src/web/jsf/spec/flows/basicimplicit/index.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page with link to flow entry</title>
     </head>

--- a/src/web/jsf/spec/flows/basicimplicit/nonFlow.xhtml
+++ b/src/web/jsf/spec/flows/basicimplicit/nonFlow.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Try to access a flow bean from outside of a flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicimplicit/start.xhtml
+++ b/src/web/jsf/spec/flows/basicimplicit/start.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmethodcall/flow-a/flow-a.xhtml
+++ b/src/web/jsf/spec/flows/basicmethodcall/flow-a/flow-a.xhtml
@@ -23,8 +23,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmethodcall/flow-a/next_b.xhtml
+++ b/src/web/jsf/spec/flows/basicmethodcall/flow-a/next_b.xhtml
@@ -23,8 +23,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Last page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmethodcall/flow-b/flow-b.xhtml
+++ b/src/web/jsf/spec/flows/basicmethodcall/flow-b/flow-b.xhtml
@@ -23,8 +23,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmethodcall/flow-b/next_b.xhtml
+++ b/src/web/jsf/spec/flows/basicmethodcall/flow-b/next_b.xhtml
@@ -23,8 +23,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Last page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmethodcall/index.xhtml
+++ b/src/web/jsf/spec/flows/basicmethodcall/index.xhtml
@@ -23,7 +23,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Outside of flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicmethodcall/return1.xhtml
+++ b/src/web/jsf/spec/flows/basicmethodcall/return1.xhtml
@@ -23,7 +23,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page navigated to upon return from any flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicmultipage/boundtaskflow/bounded-task-flow.xhtml
+++ b/src/web/jsf/spec/flows/basicmultipage/boundtaskflow/bounded-task-flow.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmultipage/boundtaskflow/next_a.xhtml
+++ b/src/web/jsf/spec/flows/basicmultipage/boundtaskflow/next_a.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Second page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmultipage/boundtaskflow/next_b.xhtml
+++ b/src/web/jsf/spec/flows/basicmultipage/boundtaskflow/next_b.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Last page in the flow</title>

--- a/src/web/jsf/spec/flows/basicmultipage/index.xhtml
+++ b/src/web/jsf/spec/flows/basicmultipage/index.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page with link to flow entry</title>
     </head>

--- a/src/web/jsf/spec/flows/basicmultipage/nonFlow.xhtml
+++ b/src/web/jsf/spec/flows/basicmultipage/nonFlow.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Try to access a flow bean from outside of a flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicmultipage/return1.xhtml
+++ b/src/web/jsf/spec/flows/basicmultipage/return1.xhtml
@@ -23,7 +23,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page navigated to upon return from bounded-task-flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicswitch/flow-a/flow-a.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-a/flow-a.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-a/switchA_result.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-a/switchA_result.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>switchA_result</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-a/switchB_result.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-a/switchB_result.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>switchB_result</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-a/switchC_result.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-a/switchC_result.xhtml
@@ -21,8 +21,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>switchC_result</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-b/flow-b.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-b/flow-b.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-b/switchA_result.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-b/switchA_result.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>switchA_result</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-b/switchB_result.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-b/switchB_result.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>switchB_result</title>

--- a/src/web/jsf/spec/flows/basicswitch/flow-b/switchC_result.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/flow-b/switchC_result.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>switchC_result</title>

--- a/src/web/jsf/spec/flows/basicswitch/index.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/index.xhtml
@@ -21,7 +21,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Outside of flow</title>
     </head>

--- a/src/web/jsf/spec/flows/basicswitch/return1.xhtml
+++ b/src/web/jsf/spec/flows/basicswitch/return1.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page navigated to upon return from any flow</title>
     </head>

--- a/src/web/jsf/spec/flows/factory/index.xhtml
+++ b/src/web/jsf/spec/flows/factory/index.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page with link to flow entry</title>
     </head>

--- a/src/web/jsf/spec/flows/factory/start.xhtml
+++ b/src/web/jsf/spec/flows/factory/start.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/intermediate/complete.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/complete.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page navigated to upon return from bounded-task-flow</title>
     </head>

--- a/src/web/jsf/spec/flows/intermediate/index.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/index.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <title>Outside of flow</title>
     </head>

--- a/src/web/jsf/spec/flows/intermediate/maintain-customer-record-java/create-customer.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/maintain-customer-record-java/create-customer.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Create customer page</title>

--- a/src/web/jsf/spec/flows/intermediate/maintain-customer-record-java/maintain-customer-record-java.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/maintain-customer-record-java/maintain-customer-record-java.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <title>First page in the flow</title>
     </head>

--- a/src/web/jsf/spec/flows/intermediate/maintain-customer-record-java/view-customer.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/maintain-customer-record-java/view-customer.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>View customer page</title>

--- a/src/web/jsf/spec/flows/intermediate/maintain-customer-record/create-customer.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/maintain-customer-record/create-customer.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Create customer page</title>

--- a/src/web/jsf/spec/flows/intermediate/maintain-customer-record/maintain-customer-record.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/maintain-customer-record/maintain-customer-record.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <title>First page in the flow</title>
     </head>

--- a/src/web/jsf/spec/flows/intermediate/maintain-customer-record/view-customer.xhtml
+++ b/src/web/jsf/spec/flows/intermediate/maintain-customer-record/view-customer.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>View customer page</title>

--- a/src/web/jsf/spec/flows/multipagewebinf/bounded-task-flow/bounded-task-flow.xhtml
+++ b/src/web/jsf/spec/flows/multipagewebinf/bounded-task-flow/bounded-task-flow.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>First page in the flow</title>

--- a/src/web/jsf/spec/flows/multipagewebinf/bounded-task-flow/next_a.xhtml
+++ b/src/web/jsf/spec/flows/multipagewebinf/bounded-task-flow/next_a.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Second page in the flow</title>

--- a/src/web/jsf/spec/flows/multipagewebinf/bounded-task-flow/next_b.xhtml
+++ b/src/web/jsf/spec/flows/multipagewebinf/bounded-task-flow/next_b.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     
     <head>
         <title>Last page in the flow</title>

--- a/src/web/jsf/spec/flows/multipagewebinf/index.xhtml
+++ b/src/web/jsf/spec/flows/multipagewebinf/index.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page with link to flow entry</title>
     </head>

--- a/src/web/jsf/spec/flows/multipagewebinf/nonFlow.xhtml
+++ b/src/web/jsf/spec/flows/multipagewebinf/nonFlow.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Try to access a flow bean from outside of a flow</title>
     </head>

--- a/src/web/jsf/spec/flows/multipagewebinf/return1.xhtml
+++ b/src/web/jsf/spec/flows/multipagewebinf/return1.xhtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <head>
         <title>Page navigated to upon return from bounded-task-flow</title>
     </head>

--- a/src/web/jsf/spec/jstl/cwo/cwo_facelet.xhtml
+++ b/src/web/jsf/spec/jstl/cwo/cwo_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>choose, when, and otherwise tags test.</title>

--- a/src/web/jsf/spec/jstl/fncontains/fncontains.xhtml
+++ b/src/web/jsf/spec/jstl/fncontains/fncontains.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function contains tag test</title>

--- a/src/web/jsf/spec/jstl/fncontainsignore/fncontainsignore.xhtml
+++ b/src/web/jsf/spec/jstl/fncontainsignore/fncontainsignore.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function contains tag test</title>

--- a/src/web/jsf/spec/jstl/fnendswith/fnendswith.xhtml
+++ b/src/web/jsf/spec/jstl/fnendswith/fnendswith.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function contains tag test</title>

--- a/src/web/jsf/spec/jstl/fnescapexml/fnescapexml.xhtml
+++ b/src/web/jsf/spec/jstl/fnescapexml/fnescapexml.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function escapeXml tag test</title>

--- a/src/web/jsf/spec/jstl/fnindexof/fnindexof.xhtml
+++ b/src/web/jsf/spec/jstl/fnindexof/fnindexof.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function indexOf tag test</title>

--- a/src/web/jsf/spec/jstl/fnjoin/fnjoin.xhtml
+++ b/src/web/jsf/spec/jstl/fnjoin/fnjoin.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function join tag test</title>

--- a/src/web/jsf/spec/jstl/fnlength/fnlength.xhtml
+++ b/src/web/jsf/spec/jstl/fnlength/fnlength.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function length tag test</title>

--- a/src/web/jsf/spec/jstl/fnreplace/fnreplace.xhtml
+++ b/src/web/jsf/spec/jstl/fnreplace/fnreplace.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function replace tag test</title>

--- a/src/web/jsf/spec/jstl/fnsplit/fnsplit.xhtml
+++ b/src/web/jsf/spec/jstl/fnsplit/fnsplit.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function split tag test</title>

--- a/src/web/jsf/spec/jstl/fnstartswith/fnendswith.xhtml
+++ b/src/web/jsf/spec/jstl/fnstartswith/fnendswith.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function contains tag test</title>

--- a/src/web/jsf/spec/jstl/fnsubstring/fnsubstring.xhtml
+++ b/src/web/jsf/spec/jstl/fnsubstring/fnsubstring.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function subString tag test</title>

--- a/src/web/jsf/spec/jstl/fnsubstringafter/fnsubstringafter.xhtml
+++ b/src/web/jsf/spec/jstl/fnsubstringafter/fnsubstringafter.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function subStringAfter tag test</title>

--- a/src/web/jsf/spec/jstl/fnsubstringbefore/fnsubstringbefore.xhtml
+++ b/src/web/jsf/spec/jstl/fnsubstringbefore/fnsubstringbefore.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function subStringBefore tag test</title>

--- a/src/web/jsf/spec/jstl/fntolowercase/fntolowercase.xhtml
+++ b/src/web/jsf/spec/jstl/fntolowercase/fntolowercase.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function toLowerCase tag test</title>

--- a/src/web/jsf/spec/jstl/fntouppercase/fntouppercase.xhtml
+++ b/src/web/jsf/spec/jstl/fntouppercase/fntouppercase.xhtml
@@ -19,10 +19,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
-      xmlns:fn="http://java.sun.com/jsp/jstl/functions">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
+      xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>JSTL function toUpperCase tag test</title>

--- a/src/web/jsf/spec/jstl/fntrim/fntrim.xhtml
+++ b/src/web/jsf/spec/jstl/fntrim/fntrim.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
       xmlns:fn="jakarta.tags.functions">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/jstl/foreachtag/foreachtag_facelet.xhtml
+++ b/src/web/jsf/spec/jstl/foreachtag/foreachtag_facelet.xhtml
@@ -20,9 +20,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core"
       xmlns:fn="jakarta.tags.functions">
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/jstl/iftag/iftag_facelet.xhtml
+++ b/src/web/jsf/spec/jstl/iftag/iftag_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:c="http://java.sun.com/jsp/jstl/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:c="jakarta.tags.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>JSTL if tag test</title>

--- a/src/web/jsf/spec/jstl/iftag/uri_test_facelet.xhtml
+++ b/src/web/jsf/spec/jstl/iftag/uri_test_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:c="http://java.sun.com/jsp/jstl/core"
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:c="jakarta.tags.core"
 	xmlns:cc="http://java.sun.com/jstl/core">
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/body/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/body/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/body/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/body/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/booleancheckbox/decodetest.jsp
+++ b/src/web/jsf/spec/render/booleancheckbox/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/booleancheckbox/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/booleancheckbox/decodetest_facelet.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>decodetest_facelets</title>
   </head>

--- a/src/web/jsf/spec/render/booleancheckbox/encodetest.jsp
+++ b/src/web/jsf/spec/render/booleancheckbox/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/booleancheckbox/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/booleancheckbox/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/booleancheckbox/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/booleancheckbox/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/booleancheckbox/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/booleancheckbox/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/commandbutton/decodetest.jsp
+++ b/src/web/jsf/spec/render/commandbutton/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/commandbutton/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/commandbutton/decodetest_facelet.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest_facelet</title>

--- a/src/web/jsf/spec/render/commandbutton/encodetest.jsp
+++ b/src/web/jsf/spec/render/commandbutton/encodetest.jsp
@@ -20,8 +20,8 @@
 <%@ page import="jakarta.faces.context.ExternalContext"%>
 <%@ page import="jakarta.faces.application.ViewHandler"%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/commandbutton/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/commandbutton/encodetest_facelet.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest_facelet</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/commandbutton/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/commandbutton/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/commandbutton/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/commandbutton/passthroughtest_facelet.xhtml
@@ -23,9 +23,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <title>passthroughtest_facelet</title>
 </head>

--- a/src/web/jsf/spec/render/commandlink/decodetest.jsp
+++ b/src/web/jsf/spec/render/commandlink/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/commandlink/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/commandlink/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>decodetest_facelet</title>

--- a/src/web/jsf/spec/render/commandlink/encodetest.jsp
+++ b/src/web/jsf/spec/render/commandlink/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
       
 <html>
     <head>

--- a/src/web/jsf/spec/render/commandlink/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/commandlink/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/commandlink/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/commandlink/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/commandlink/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/commandlink/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/datatable/encodetestBasic.jsp
+++ b/src/web/jsf/spec/render/datatable/encodetestBasic.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <%@ include file="include.jsp"%>
 

--- a/src/web/jsf/spec/render/datatable/encodetestBasic_facelet.xhtml
+++ b/src/web/jsf/spec/render/datatable/encodetestBasic_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetestBasic_facelet</title>

--- a/src/web/jsf/spec/render/datatable/encodetestCaption.jsp
+++ b/src/web/jsf/spec/render/datatable/encodetestCaption.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <%@ include file="include.jsp"%>
 

--- a/src/web/jsf/spec/render/datatable/encodetestCaption_facelet.xhtml
+++ b/src/web/jsf/spec/render/datatable/encodetestCaption_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/datatable/encodetestColumnHeaderFooter.jsp
+++ b/src/web/jsf/spec/render/datatable/encodetestColumnHeaderFooter.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <%@ include file="include.jsp" %>
 

--- a/src/web/jsf/spec/render/datatable/encodetestColumnHeaderFooter_facelet.xhtml
+++ b/src/web/jsf/spec/render/datatable/encodetestColumnHeaderFooter_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/datatable/encodetestTableHeaderFooter.jsp
+++ b/src/web/jsf/spec/render/datatable/encodetestTableHeaderFooter.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <%@ include file="include.jsp"%>
 

--- a/src/web/jsf/spec/render/datatable/encodetestTableHeaderFooter_facelet.xhtml
+++ b/src/web/jsf/spec/render/datatable/encodetestTableHeaderFooter_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <style type="text/css">
       th.sansserif {

--- a/src/web/jsf/spec/render/datatable/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/datatable/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <%@ include file="include.jsp" %>
 

--- a/src/web/jsf/spec/render/datatable/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/datatable/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <title>passthroughtest_facelet</title>
 </head>

--- a/src/web/jsf/spec/render/form/decodetest.jsp
+++ b/src/web/jsf/spec/render/form/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/form/encodetest.jsp
+++ b/src/web/jsf/spec/render/form/encodetest.jsp
@@ -20,8 +20,8 @@
 <%@ page import="jakarta.faces.context.ExternalContext" %>
 <%@ page import="jakarta.faces.context.FacesContext" %>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/form/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/form/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/form/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/form/passthroughtest_facelet.xhtml
@@ -21,9 +21,9 @@
 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/graphic/encodetest.jsp
+++ b/src/web/jsf/spec/render/graphic/encodetest.jsp
@@ -20,8 +20,8 @@
 <%@ page import="jakarta.faces.context.ExternalContext" %>
 <%@ page import="jakarta.faces.context.FacesContext" %>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/graphic/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/graphic/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/graphic/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/graphic/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/graphic/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/graphic/passthroughtest_facelet.xhtml
@@ -21,9 +21,9 @@
 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/grid/encodetestBasic.jsp
+++ b/src/web/jsf/spec/render/grid/encodetestBasic.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/grid/encodetestBasic_facelet.xhtml
+++ b/src/web/jsf/spec/render/grid/encodetestBasic_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetestBasic</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/grid/encodetestCaption.jsp
+++ b/src/web/jsf/spec/render/grid/encodetestCaption.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/grid/encodetestCaption_facelet.xhtml
+++ b/src/web/jsf/spec/render/grid/encodetestCaption_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/grid/encodetestTableHeaderFooter.jsp
+++ b/src/web/jsf/spec/render/grid/encodetestTableHeaderFooter.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/grid/encodetestTableHeaderFooter_facelet.xhtml
+++ b/src/web/jsf/spec/render/grid/encodetestTableHeaderFooter_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/head/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/head/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head id="myHead"

--- a/src/web/jsf/spec/render/head/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/head/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 
 <h:head id="myHead" dir="LTR" lang="en" p:foo="bar">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/hidden/decodetest.jsp
+++ b/src/web/jsf/spec/render/hidden/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/hidden/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/hidden/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest</title> 

--- a/src/web/jsf/spec/render/hidden/encodetest.jsp
+++ b/src/web/jsf/spec/render/hidden/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/hidden/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/hidden/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
   </head>

--- a/src/web/jsf/spec/render/inputtext/decodetest.jsp
+++ b/src/web/jsf/spec/render/inputtext/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/inputtext/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/inputtext/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest</title>    

--- a/src/web/jsf/spec/render/inputtext/encodetest.jsp
+++ b/src/web/jsf/spec/render/inputtext/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/inputtext/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/inputtext/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest</title>

--- a/src/web/jsf/spec/render/inputtext/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/inputtext/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/inputtext/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/inputtext/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/manycheckbox/decodetest.jsp
+++ b/src/web/jsf/spec/render/manycheckbox/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
   <head>

--- a/src/web/jsf/spec/render/manycheckbox/encodetest.jsp
+++ b/src/web/jsf/spec/render/manycheckbox/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
   <head>

--- a/src/web/jsf/spec/render/manycheckbox/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/manycheckbox/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/manycheckbox/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/manycheckbox/passthroughtest_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<title>passthroughtest_facelet</title>
 </h:head>

--- a/src/web/jsf/spec/render/manycheckbox/selectmany01.xhtml
+++ b/src/web/jsf/spec/render/manycheckbox/selectmany01.xhtml
@@ -21,8 +21,8 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <title>selectmany01</title>
     </head>

--- a/src/web/jsf/spec/render/manylistbox/decodetest.jsp
+++ b/src/web/jsf/spec/render/manylistbox/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
   <head>

--- a/src/web/jsf/spec/render/manylistbox/encodetest.jsp
+++ b/src/web/jsf/spec/render/manylistbox/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/manylistbox/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/manylistbox/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/manylistbox/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/manylistbox/passthroughtest_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<title>passthroughtest_facelet</title>
 </h:head>

--- a/src/web/jsf/spec/render/manylistbox/selectmany01.xhtml
+++ b/src/web/jsf/spec/render/manylistbox/selectmany01.xhtml
@@ -21,8 +21,8 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <title>selectmany01</title>
     </head>

--- a/src/web/jsf/spec/render/manymenu/decodetest.jsp
+++ b/src/web/jsf/spec/render/manymenu/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
   <head>

--- a/src/web/jsf/spec/render/manymenu/encodetest.jsp
+++ b/src/web/jsf/spec/render/manymenu/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/manymenu/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/manymenu/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/manymenu/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/manymenu/passthroughtest_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<title>passthroughtest_facelet</title>
 </h:head>

--- a/src/web/jsf/spec/render/manymenu/selectmany01.xhtml
+++ b/src/web/jsf/spec/render/manymenu/selectmany01.xhtml
@@ -21,8 +21,8 @@
 PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <head>
         <title>selectmany01</title>
     </head>

--- a/src/web/jsf/spec/render/message/encodetest.jsp
+++ b/src/web/jsf/spec/render/message/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/message/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/message/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <title>encodetest</title>
     <style type="text/css">

--- a/src/web/jsf/spec/render/message/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/message/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/message/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/message/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<title>passthroughtest_facelet</title>
 </h:head>

--- a/src/web/jsf/spec/render/messages/encodetest.jsp
+++ b/src/web/jsf/spec/render/messages/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/messages/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/messages/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest</title>

--- a/src/web/jsf/spec/render/messages/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/messages/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/messages/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/messages/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/onelistbox/decodetest.jsp
+++ b/src/web/jsf/spec/render/onelistbox/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/onelistbox/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/onelistbox/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest</title>

--- a/src/web/jsf/spec/render/onelistbox/encodetest.jsp
+++ b/src/web/jsf/spec/render/onelistbox/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/onelistbox/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/onelistbox/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest</title>

--- a/src/web/jsf/spec/render/onelistbox/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/onelistbox/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/onelistbox/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/onelistbox/passthroughtest_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:p="http://xmlns.jcp.org/jsf/passthrough" >
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="jakarta.faces.passthrough" >
   <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/onemenu/decodetest.jsp
+++ b/src/web/jsf/spec/render/onemenu/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/onemenu/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/onemenu/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest</title>

--- a/src/web/jsf/spec/render/onemenu/encodetest.jsp
+++ b/src/web/jsf/spec/render/onemenu/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/onemenu/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/onemenu/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest</title>

--- a/src/web/jsf/spec/render/onemenu/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/onemenu/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/onemenu/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/onemenu/passthroughtest_facelet.xhtml
@@ -19,9 +19,9 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:p="http://xmlns.jcp.org/jsf/passthrough" >
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="jakarta.faces.passthrough" >
   <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/oneradio/decodetest.jsp
+++ b/src/web/jsf/spec/render/oneradio/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/oneradio/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/oneradio/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest_facelet</title>

--- a/src/web/jsf/spec/render/oneradio/encodetest.jsp
+++ b/src/web/jsf/spec/render/oneradio/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
   <head>

--- a/src/web/jsf/spec/render/oneradio/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/oneradio/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/oneradio/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/oneradio/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/oneradio/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/oneradio/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/web/jsf/spec/render/outputformat/encodetest.jsp
+++ b/src/web/jsf/spec/render/outputformat/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputformat/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputformat/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/outputformat/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/outputformat/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputformat/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputformat/passthroughtest_facelet.xhtml
@@ -23,9 +23,9 @@
  
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/outputlabel/encodetest.jsp
+++ b/src/web/jsf/spec/render/outputlabel/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputlabel/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputlabel/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/outputlabel/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/outputlabel/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputlabel/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputlabel/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/outputlink/encodetest.jsp
+++ b/src/web/jsf/spec/render/outputlink/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputlink/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputlink/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/outputlink/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/outputlink/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputlink/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputlink/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/outputscript/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputscript/encodetest_facelet.xhtml
@@ -18,8 +18,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>encodetest</title>

--- a/src/web/jsf/spec/render/outputstyle/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputstyle/encodetest_facelet.xhtml
@@ -18,8 +18,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core">
 <h:head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>encodetest</title>

--- a/src/web/jsf/spec/render/outputstyle/encodetest_facelet_1.xhtml
+++ b/src/web/jsf/spec/render/outputstyle/encodetest_facelet_1.xhtml
@@ -18,8 +18,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>encodetest_01</title>

--- a/src/web/jsf/spec/render/outputstyle/encodetest_facelet_2.xhtml
+++ b/src/web/jsf/spec/render/outputstyle/encodetest_facelet_2.xhtml
@@ -18,8 +18,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <title>encodetest</title>

--- a/src/web/jsf/spec/render/outputtext/encodetest.jsp
+++ b/src/web/jsf/spec/render/outputtext/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/outputtext/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputtext/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/outputtext/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/outputtext/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/outputtext/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/outputtext/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/secret/decodetest.jsp
+++ b/src/web/jsf/spec/render/secret/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/secret/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/secret/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest_facelet</title>

--- a/src/web/jsf/spec/render/secret/encodetest.jsp
+++ b/src/web/jsf/spec/render/secret/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/secret/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/secret/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/secret/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/secret/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/secret/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/secret/passthroughtest_facelet.xhtml
@@ -22,9 +22,9 @@
  -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/render/textarea/decodetest.jsp
+++ b/src/web/jsf/spec/render/textarea/decodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
     <head>

--- a/src/web/jsf/spec/render/textarea/decodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/textarea/decodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>decodetest_facelet</title>

--- a/src/web/jsf/spec/render/textarea/encodetest.jsp
+++ b/src/web/jsf/spec/render/textarea/encodetest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/textarea/encodetest_facelet.xhtml
+++ b/src/web/jsf/spec/render/textarea/encodetest_facelet.xhtml
@@ -19,8 +19,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>encodetest_facelet</title>

--- a/src/web/jsf/spec/render/textarea/passthroughtest.jsp
+++ b/src/web/jsf/spec/render/textarea/passthroughtest.jsp
@@ -16,8 +16,8 @@
 
 --%>
 
-<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
-<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="jakarta.faces.core" prefix="f" %>
+<%@ taglib uri="jakarta.faces.html" prefix="h" %>
 
 <html>
 <head>

--- a/src/web/jsf/spec/render/textarea/passthroughtest_facelet.xhtml
+++ b/src/web/jsf/spec/render/textarea/passthroughtest_facelet.xhtml
@@ -23,9 +23,9 @@
  
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:p="http://xmlns.jcp.org/jsf/passthrough">
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="jakarta.faces.passthrough">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>passthroughtest_facelet</title>

--- a/src/web/jsf/spec/resource/relocatable/reloc-body.xhtml
+++ b/src/web/jsf/spec/resource/relocatable/reloc-body.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:head>
         <title>Relocatable Resource Body Test</title>

--- a/src/web/jsf/spec/resource/relocatable/reloc-form.xhtml
+++ b/src/web/jsf/spec/resource/relocatable/reloc-form.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:head>
         <title>Relocatable Resource Form Test</title>

--- a/src/web/jsf/spec/resource/relocatable/reloc-head.xhtml
+++ b/src/web/jsf/spec/resource/relocatable/reloc-head.xhtml
@@ -20,8 +20,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:head>
         <title>Relocatable Resource Head Test</title>

--- a/src/web/jsf/spec/templating/component/bindTest.xhtml
+++ b/src/web/jsf/spec/templating/component/bindTest.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:composition template="templateOne.xhtml">
 	<ui:define name="body">

--- a/src/web/jsf/spec/templating/component/component_binding.xhtml
+++ b/src/web/jsf/spec/templating/component/component_binding.xhtml
@@ -18,10 +18,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:c="http://java.sun.com/jsp/jstl/core">
+	xmlns:ui="jakarta.faces.facelets"
+	xmlns:f="jakarta.faces.core"
+	xmlns:h="jakarta.faces.html"
+	xmlns:c="jakarta.tags.core">
 
 <ui:component id="bind" rendered="true" binding="#{Character.name}">
 </ui:component>

--- a/src/web/jsf/spec/templating/component/component_false.xhtml
+++ b/src/web/jsf/spec/templating/component/component_false.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:component id="seeNo" rendered="false">
 	<span>notrendered</span>

--- a/src/web/jsf/spec/templating/component/component_true.xhtml
+++ b/src/web/jsf/spec/templating/component/component_true.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:component id="seeYes" rendered="true">
 	<span>rendered</span>

--- a/src/web/jsf/spec/templating/component/notVisableTest.xhtml
+++ b/src/web/jsf/spec/templating/component/notVisableTest.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:composition template="templateOne.xhtml">
 	<ui:define name="body">

--- a/src/web/jsf/spec/templating/component/templateOne.xhtml
+++ b/src/web/jsf/spec/templating/component/templateOne.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <head>
 <title><H2>ui_component_facelet</H2>

--- a/src/web/jsf/spec/templating/component/visableTest.xhtml
+++ b/src/web/jsf/spec/templating/component/visableTest.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:composition template="templateOne.xhtml">
 	<ui:define name="body">

--- a/src/web/jsf/spec/templating/fragment/bindTest.xhtml
+++ b/src/web/jsf/spec/templating/fragment/bindTest.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:composition template="templateOne.xhtml">
 	<ui:define name="body">

--- a/src/web/jsf/spec/templating/fragment/fragment_binding.xhtml
+++ b/src/web/jsf/spec/templating/fragment/fragment_binding.xhtml
@@ -18,10 +18,10 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets"
-	xmlns:f="http://java.sun.com/jsf/core"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:c="http://java.sun.com/jsp/jstl/core">
+	xmlns:ui="jakarta.faces.facelets"
+	xmlns:f="jakarta.faces.core"
+	xmlns:h="jakarta.faces.html"
+	xmlns:c="jakarta.tags.core">
 
 <ui:fragment id="bind" rendered="true" binding="#{Character.name}">
 </ui:fragment>

--- a/src/web/jsf/spec/templating/fragment/fragment_false.xhtml
+++ b/src/web/jsf/spec/templating/fragment/fragment_false.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:fragment id="seeNo" rendered="false">
 	<span>notrendered</span>

--- a/src/web/jsf/spec/templating/fragment/fragment_true.xhtml
+++ b/src/web/jsf/spec/templating/fragment/fragment_true.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:fragment id="seeYes" rendered="true">
 	<span>rendered</span>

--- a/src/web/jsf/spec/templating/fragment/notVisableTest.xhtml
+++ b/src/web/jsf/spec/templating/fragment/notVisableTest.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:composition template="templateOne.xhtml">
 	<ui:define name="body">

--- a/src/web/jsf/spec/templating/fragment/templateOne.xhtml
+++ b/src/web/jsf/spec/templating/fragment/templateOne.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <head>
 <title><H2>temaplating_fragment_facelet</H2>

--- a/src/web/jsf/spec/templating/fragment/visableTest.xhtml
+++ b/src/web/jsf/spec/templating/fragment/visableTest.xhtml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-	xmlns:ui="http://java.sun.com/jsf/facelets">
+	xmlns:ui="jakarta.faces.facelets">
 
 <ui:composition template="templateOne.xhtml">
 	<ui:define name="body">

--- a/src/web/jsf/spec/templating/insert/compositionPgOne.xhtml
+++ b/src/web/jsf/spec/templating/insert/compositionPgOne.xhtml
@@ -18,7 +18,7 @@
 
 -->
 
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="jakarta.faces.facelets">
 
     <body>
         <ui:composition template="/layout.xhtml">

--- a/src/web/jsf/spec/templating/insert/compositionPgThree.xhtml
+++ b/src/web/jsf/spec/templating/insert/compositionPgThree.xhtml
@@ -17,9 +17,9 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:body>
         <div id="IGNORED_TOP">

--- a/src/web/jsf/spec/templating/insert/compositionPgTwo.xhtml
+++ b/src/web/jsf/spec/templating/insert/compositionPgTwo.xhtml
@@ -17,9 +17,9 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:body>
         

--- a/src/web/jsf/spec/templating/insert/decoratePgOne.xhtml
+++ b/src/web/jsf/spec/templating/insert/decoratePgOne.xhtml
@@ -18,9 +18,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:body>
 

--- a/src/web/jsf/spec/templating/insert/decoratePgTwo.xhtml
+++ b/src/web/jsf/spec/templating/insert/decoratePgTwo.xhtml
@@ -17,9 +17,9 @@
 
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
     <h:body>
 

--- a/src/web/jsf/spec/templating/insert/decorate_base.xhtml
+++ b/src/web/jsf/spec/templating/insert/decorate_base.xhtml
@@ -16,7 +16,7 @@
 
 -->
 
-<div id="title_header_content" xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets">
+<div id="title_header_content" xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="jakarta.faces.facelets">
     <ui:debug/>
 
     <ui:insert name="title">Default Title</ui:insert>

--- a/src/web/jsf/spec/templating/insert/layout.xhtml
+++ b/src/web/jsf/spec/templating/insert/layout.xhtml
@@ -18,7 +18,7 @@
 
 -->
 
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="jakarta.faces.facelets">
     <head>
         <title><ui:insert name="title">Default Title</ui:insert></title>
     </head>

--- a/src/web/jsf/spec/templating/remove/removeOne.xhtml
+++ b/src/web/jsf/spec/templating/remove/removeOne.xhtml
@@ -20,9 +20,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/templating/repeat/repeatOffset.xhtml
+++ b/src/web/jsf/spec/templating/repeat/repeatOffset.xhtml
@@ -19,9 +19,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/templating/repeat/repeatVar.xhtml
+++ b/src/web/jsf/spec/templating/repeat/repeatVar.xhtml
@@ -19,9 +19,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/templating/repeat/repeatVarStat.xhtml
+++ b/src/web/jsf/spec/templating/repeat/repeatVarStat.xhtml
@@ -20,9 +20,9 @@
 -->
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets">
 
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/src/web/jsf/spec/view/protectedview/protected.xhtml
+++ b/src/web/jsf/spec/view/protectedview/protected.xhtml
@@ -18,8 +18,8 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"> 
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"> 
 	
 	<h:head>
 		<title>Protected View</title>

--- a/src/web/jsf/spec/view/protectedview/public.xhtml
+++ b/src/web/jsf/spec/view/protectedview/public.xhtml
@@ -18,8 +18,8 @@
 -->
 
 <xhtml xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core"> <h:head>
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"> <h:head>
 	<title>Public View</title>
 </h:head> <h:body>
 	<h:outputText value="This is a Public View!" />

--- a/src/web/jsf/spec/view/viewhandler/greetings.jsp
+++ b/src/web/jsf/spec/view/viewhandler/greetings.jsp
@@ -18,8 +18,8 @@
 
 <HTML>
     <HEAD> <title>Hello</title> </HEAD>
-    <%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
-    <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
+    <%@ taglib uri="jakarta.faces.html" prefix="h" %>
+    <%@ taglib uri="jakarta.faces.core" prefix="f" %>
     <body bgcolor="white">
     <h2>Hi. My name is Duke.  I'm thinking of a number from 0 to 10.
     Can you guess it?</h2>


### PR DESCRIPTION
**Fixes Issue**
None specified.

**Related Issue(s)**
https://github.com/jakartaee/faces/issues/1553 

**Describe the change**
Below taglibs have been replaced mostly for jsf source.

```
http://xmlns.jcp.org/jsf/html 
http://xmlns.jcp.org/jsf/facelets 
http://xmlns.jcp.org/jsf/core
http://xmlns.jcp.org/jsf/passthrough
http://xmlns.jcp.org/jsf/composite 
http://xmlns.jcp.org/jsf/component 
http://xmlns.jcp.org/jsf 

http://java.sun.com/jsf/html
http://java.sun.com/jsf/facelets
http://java.sun.com/jsf/core
http://java.sun.com/jsf/passthrough
http://java.sun.com/jsf/composite/tckcomp
http://java.sun.com/jsf/composite/versioned
http://java.sun.com/jsf/composite
http://java.sun.com/jsf/component
http://java.sun.com/jsf
http://java.sun.com/jsp/jstl/core
http://java.sun.com/jsp/jstl/functions
```

