### PR TITLE
Messaging 3.1 - TCK guide update

### DIFF
--- a/user_guides/jms/src/main/jbake/content/attributes.conf
+++ b/user_guides/jms/src/main/jbake/content/attributes.conf
@@ -1,12 +1,12 @@
 :TechnologyFullName: Jakarta Messaging
 :TechnologyShortName: Messaging
 :LegacyAcronym: JMS
-:ReleaseDate: May 2021
-:CopyrightDates: 2017, 2021		   
-:TechnologyVersion: 3.0
-:TechnologyRI: Eclipse OpenMQ 6.1
+:ReleaseDate: March 2022
+:CopyrightDates: 2017, 2022		   
+:TechnologyVersion: 3.1
+:TechnologyRI: Eclipse OpenMQ 6.3
 :TechnologyRIURL: https://projects.eclipse.org/projects/ee4j.openmq
-:SpecificationURL: https://jakarta.ee/specifications/messaging/3.0/
+:SpecificationURL: https://jakarta.ee/specifications/messaging/3.1/
 :TCKInquiryList: mailto:jakartaee-tck-dev@eclipse.org[jakartaee-tck-dev@eclipse.org]
 :SpecificationInquiryList: mailto:jms-dev@eclipse.org[jms-dev@eclipse.org]
 :techID: Messaging
@@ -22,13 +22,13 @@
 // for the technology.  Used in config.inc.
 :TechnologyHomeEnv: JMS_HOME
 // Java SE version required.
-:SEversion: 8 (1.8) or 11
+:SEversion: 11
 :AntVersion: 1.10.0+
-:JakartaEEVersion: 9.1
+:JakartaEEVersion: 10
 :JavaTestVersion: 5.0
 :jteFileName: <TS_HOME>/bin/ts.jte
 :jtxFileName: <TS_HOME>/bin/ts.jtx
-:TCKPackageName: jakarta-messaging-tck-3.0.1.zip
+:TCKPackageName: jakarta-messaging-tck-3.1.0.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/signaturetest/jms
 :singleTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/jms


### PR DESCRIPTION
**Describe the change**
Adapts the attributes of the standalone Messaging TCK guide for the new Messaging 3.1 release.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
