### PR TITLE
specify explicit CDI bean discovery mode 

### DIFF
--- a/src/com/sun/ts/tests/servlet/ee/platform/cdi/TCKTestBean.java
+++ b/src/com/sun/ts/tests/servlet/ee/platform/cdi/TCKTestBean.java
@@ -16,5 +16,8 @@
 
 package com.sun.ts.tests.servlet.ee.platform.cdi;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
 public class TCKTestBean {
 }


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Related Issue(s)**
https://github.com/eclipse-ee4j/cdi/issues/500 change  ([see blog](https://eclipse-ee4j.github.io/cdi/2021/10/25/way-to-cdi4.html))
Quoting from the blog:

> One notable change coming to CDI is the [discovery mode of bean archives containing empty beans.xml](https://github.com/eclipse-ee4j/cdi/issues/500). These were formerly treated as explicit bean archives (i.e. having discovery mode all) but beginning with CDI 4.0, they will be considered as implicit bean archives (discovery mode annotated).
> 
> In other words, if a class in such an archive is to be recognized as a bean, it needs to have at least one bean defining annotation. It can be a breaking change which is why this change also comes with a backward compatible switch - all CDI Full products have to contain an option that switches the behavior to how it worked in the past. The option is of course a temporary measure to ease transition and applications are encouraged to adapt their bean archives accordingly in the long term.

We can now ask what is `bean defining annotations`?  To answer that, we can look at the [CDI 3.0 Spec](https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#bean_defining_annotations) which states:
```
The set of bean defining annotations contains:
-     @ApplicationScoped, @SessionScoped, @ConversationScoped and @RequestScoped annotations,
-     all other normal scope types,
-     @Interceptor and @Decorator annotations,
-     all stereotype annotations (i.e. annotations annotated with @Stereotype),
-     and the @Dependent scope annotation.
``` 


**Describe the change**
The default Discovery Mode for empty beans.xml  is implicit bean archives, so we need to switch to explicit bean archives mode.


https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#bean_defining_annotations