### PR TITLE
fix for "java.lang.NoClassDefFoundError: java/rmi/activation/Activator" jaxws tck test failure with JDK 17

### DIFF
--- a/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Service/Client.java
+++ b/src/com/sun/ts/tests/jaxws/api/jakarta_xml_ws/Service/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -862,7 +862,7 @@ public class Client extends ServiceEETest {
       TestUtil.logMsg("Call Service.getPort(Class)");
       TestUtil.logMsg("Should not find port (expect Exception)");
       Hello tests = (Hello) service
-          .getPort(java.rmi.activation.Activator.class);
+          .getPort((Class) java.util.regex.Pattern.class);
       TestUtil.logErr("Did not throw expected Exception");
       TestUtil.logErr("hello port=" + tests);
       pass = false;


### PR DESCRIPTION
fix for "java.lang.NoClassDefFoundError: java/rmi/activation/Activator" jaxws tck test failure with JDK 17

Signed-off-by: gurunrao <gurunandan.rao@oracle.com>

jaxws standalone TCK JDK 17 Failure stack-trace:
```
[javatest.batch] Mar 03, 2022 3:56:02 AM com.sun.ts.tests.jaxws.common.Modules <clinit>
[javatest.batch] INFO: Error during initialization of [com.sun.ts.tests.jaxws.common.Modules]. Probably not Jigsaw runtime.
[javatest.batch] 03-03-2022 03:56:02:  siClass=com.sun.ts.tests.jaxws.sharedclients.doclithelloclient.HelloService
[javatest.batch] 03-03-2022 03:56:02:  Test getPort (invalid SEI class/WSDL access) - negative test 1
[javatest.batch] 03-03-2022 03:56:02:  Call Service.getPort(Class)
[javatest.batch] 03-03-2022 03:56:02:  Should not find port (expect Exception)
[javatest.batch] 03-03-2022 03:56:02:  ERROR: Test case throws exception: java/rmi/activation/Activator
[javatest.batch] 03-03-2022 03:56:02:  ERROR: Exception at:  
[javatest.batch] 03-03-2022 03:56:02:  ERROR: java.lang.NoClassDefFoundError: java/rmi/activation/Activator
[javatest.batch] 	at com.sun.ts.tests.jaxws.api.jakarta_xml_ws.Service.Client.GetPort2NegTest1WithWsdl(Client.java:864)
[javatest.batch] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[javatest.batch] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[javatest.batch] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[javatest.batch] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[javatest.batch] 	at com.sun.ts.lib.harness.EETest.run(EETest.java:596)
[javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:115)
[javatest.batch] 	at com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.run(EmptyVehicleRunner.java:41)
[javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:105)
[javatest.batch] 	at com.sun.ts.lib.harness.EETest.getPropsReady(EETest.java:486)
[javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:209)
[javatest.batch] 	at com.sun.ts.lib.harness.EETest.run(EETest.java:285)
[javatest.batch] 	at com.sun.ts.tests.common.vehicle.VehicleClient.main(VehicleClient.java:37)
[javatest.batch] Caused by: java.lang.ClassNotFoundException: java.rmi.activation.Activator
[javatest.batch] 	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
[javatest.batch] 	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
[javatest.batch] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
[javatest.batch] 	... 13 more
```

CI run JDK 17: https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-build-run/job/jaxws-jdk17-fix/5/
CI run JDK 11: https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-build-run/job/jaxws-jdk17-fix/9/


