### PR TITLE
Update JSTL TCK for EE10

### DIFF
--- a/docker/jstltck.sh
+++ b/docker/jstltck.sh
@@ -96,10 +96,6 @@ cd $TCK_HOME/$GF_TOPLEVEL_DIR/glassfish/bin
 ./asadmin create-jvm-options -Djavax.xml.accessExternalStylesheet=all
 ./asadmin create-jvm-options -Djavax.xml.accessExternalSchema=all
 ./asadmin create-jvm-options -Djavax.xml.accessExternalDTD=file,http
-#https://github.com/eclipse-ee4j/jakartaee-tck/issues/631
-if [[ "$JDK" == "JDK11" || "$JDK" == "jdk11" ]]; then
-  ./asadmin create-jvm-options -Djava.locale.providers=COMPAT
-fi
 
 ./asadmin stop-domain
 ./asadmin start-domain

--- a/src/web/jstl/spec/core/general/set/positiveSetDeferredValueTest.jsp
+++ b/src/web/jstl/spec/core/general/set/positiveSetDeferredValueTest.jsp
@@ -36,7 +36,7 @@
           ValueExpression ve = (ValueExpression) al.get(i);
    %>
           <%= i %>
-          <%= ve.getValue(pageContext.getELContext()) %>
+          <%= (Object) ve.getValue(pageContext.getELContext()) %>
           <br/>
    <%
        }

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest1.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest1.jsp
@@ -38,7 +38,7 @@
           ValueExpression ve = (ValueExpression) al.get(i);
    %>
           <%= i %>
-          <%= ve.getValue(pageContext.getELContext()) %>
+          <%= (Object) ve.getValue(pageContext.getELContext()) %>
           <br/>
    <%
        }

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest2.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest2.jsp
@@ -36,7 +36,7 @@
           ValueExpression ve = (ValueExpression) al.get(i);
    %>
           <%= i %>
-          <%= ve.getValue(pageContext.getELContext()) %>
+          <%= (Object) ve.getValue(pageContext.getELContext()) %>
           <br/>
    <%
        }

--- a/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest3.jsp
+++ b/src/web/jstl/spec/core/iteration/foreach/positiveForEachDeferredValueTest3.jsp
@@ -40,7 +40,7 @@
           ValueExpression ve = (ValueExpression) al.get(i);
    %>
           <%= i %>
-          <%= ve.getValue(pageContext.getELContext()) %>
+          <%= (Object) ve.getValue(pageContext.getELContext()) %>
           <br/>
    <%
        }

--- a/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensDeferredValueTest.jsp
+++ b/src/web/jstl/spec/core/iteration/fortokens/positiveForTokensDeferredValueTest.jsp
@@ -36,7 +36,7 @@
           ValueExpression ve = (ValueExpression) al.get(i);
    %>
           <%= i %>
-          <%= ve.getValue(pageContext.getELContext()) %>
+          <%= (Object) ve.getValue(pageContext.getELContext()) %>
           <br/>
    <%
        }


### PR DESCRIPTION
**Fixes Issue**
Addresses some of the failures reported in #223

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
My local testing shows that "-Djava.locale.providers=COMPAT" is responsible for the Date Parsing exceptions in the EE10 JSTL TCK runs. (Thanks @brideck  for pointing it out)

The other 5 changes cast Object to ve.getValue(pageContext.getELContext()) per Mark's comment here:  https://github.com/eclipse-ee4j/jakartaee-tck/issues/882#issuecomment-1064272480  I tested locally and they are fixed once I place the cast. 

**Additional context**
I can't seem to get the the JSTL TCK to run locally. Can one be run with my PR instead? 

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
