### PR TITLE
Update JSTL TCK User Guide for Tags 3.0

### DIFF
--- a/user_guides/jstl/pom.xml
+++ b/user_guides/jstl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,8 +27,8 @@
     <groupId>org.glassfish</groupId>
     <artifactId>tck_jstl</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1</version>
-    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Standard Tag Library for Jakarta EE, Release 2.0</name>
+    <version>3.0.0</version>
+    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Standard Tag Library for Jakarta EE, Release 3.0</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/user_guides/jstl/src/main/jbake/content/attributes.conf
+++ b/user_guides/jstl/src/main/jbake/content/attributes.conf
@@ -2,7 +2,7 @@
 :TechnologyShortName: Tag Library
 :LegacyAcronym: JSTL		   
 :TechnologyVersion: 3.0
-:ReleaseDate: March 2022
+:ReleaseDate: May 2022
 :CopyrightDates: 2017, 2022
 :TechnologyRI: Eclipse GlassFish 7.0
 :TechnologyRIURL: https://projects.eclipse.org/projects/ee4j.glassfish

--- a/user_guides/jstl/src/main/jbake/content/attributes.conf
+++ b/user_guides/jstl/src/main/jbake/content/attributes.conf
@@ -22,7 +22,7 @@
 // for the technology.  Used in config.inc.
 :TechnologyHomeEnv: JAVAEE_HOME
 // Java SE version required.
-:SEversion: 11
+:SEversion: 11 or 17
 :AntVersion: 1.10.0+
 :JakartaEEVersion: 10
 :JavaTestVersion: 5.0

--- a/user_guides/jstl/src/main/jbake/content/attributes.conf
+++ b/user_guides/jstl/src/main/jbake/content/attributes.conf
@@ -1,12 +1,12 @@
 :TechnologyFullName: Jakarta Standard Tag Library
 :TechnologyShortName: Tag Library
 :LegacyAcronym: JSTL		   
-:TechnologyVersion: 2.0
-:ReleaseDate: May 2021
-:CopyrightDates: 2017, 2021
-:TechnologyRI: Eclipse GlassFish 6.1
+:TechnologyVersion: 3.0
+:ReleaseDate: March 2022
+:CopyrightDates: 2017, 2022
+:TechnologyRI: Eclipse GlassFish 7.0
 :TechnologyRIURL: https://projects.eclipse.org/projects/ee4j.glassfish
-:SpecificationURL: https://jakarta.ee/specifications/tags/2.0/
+:SpecificationURL: https://jakarta.ee/specifications/tags/3.0
 :TCKInquiryList: mailto:jakartaee-tck-dev@eclipse.org[jakartaee-tck-dev@eclipse.org]
 :SpecificationInquiryList: mailto:jstl-dev@eclipse.org[jstl-dev@eclipse.org]
 :techID: Tags
@@ -22,13 +22,13 @@
 // for the technology.  Used in config.inc.
 :TechnologyHomeEnv: JAVAEE_HOME
 // Java SE version required.
-:SEversion: 8 (1.8) or 11
+:SEversion: 11
 :AntVersion: 1.10.0+
-:JakartaEEVersion: 9.1
+:JakartaEEVersion: 10
 :JavaTestVersion: 5.0
 :jteFileName: <TS_HOME>/bin/ts.jte
 :jtxFileName: <TS_HOME>/bin/ts.jtx
-:TCKPackageName: jakarta-tags-tck-2.0.1.zip
+:TCKPackageName: jakarta-tags-tck-3.0.0.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/signaturetest/jstl
 :singleTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/jstl

--- a/user_guides/jstl/src/main/jbake/content/config.inc
+++ b/user_guides/jstl/src/main/jbake/content/config.inc
@@ -46,8 +46,7 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`,
   +{TechnologyHomeEnv}/bin+, and `ANT_HOME/bin`
-2.  Copy <TS_HOME>/bin/ts.jte.jdk11 as <TS_HOME>/bin/ts.jte if JAVA_HOME is Java SE 11.
-Edit your `<TS_HOME>/bin/ts.jte` file and set the following
+2.  Edit your `<TS_HOME>/bin/ts.jte` file and set the following
 environment variables:
   a.  Set the `webServerHost` property to the name of the host on which
   CI (for example, {TechnologyRI}), is running. +

--- a/user_guides/jstl/src/main/jbake/content/config.inc
+++ b/user_guides/jstl/src/main/jbake/content/config.inc
@@ -84,12 +84,6 @@ The porting package interface, `TSURLInterface.java`, obtains URL
 strings for web resources in an implementation-specific manner. API
 documentation for the `TSURLInterface.java` porting package interface is
 available in the {TechnologyShortName} TCK documentation bundle.
-+
-4. JVM option `-Djava.locale.providers=COMPAT` should be passed for JDK 11 test runs. 
-The JVM compatibility option should be passed while starting implementation under test. 
-`-Djava.locale.providers=COMPAT` option will enable JDK 8 compatibility mode,
-JDK 8 compatibility mode is required for tags TCK tests with Dates, TimeZones to PASS with JDK 11.
-`-Djava.locale.providers=COMPAT` should not be passed to JVM, when tests are run with JDK 8.
 
 4.1.1 Initializing Database and Packaging the War Files for Deployment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/user_guides/jstl/src/main/jbake/content/config.inc
+++ b/user_guides/jstl/src/main/jbake/content/config.inc
@@ -173,7 +173,7 @@ Adapt the instructions above for the vendor implementation.
 4.3 Deploying the {TechnologyShortName} TCK Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To deploy the {TechnologyShortName} TCK tests to the Jakarta EE 8 platform, perform the
+To deploy the {TechnologyShortName} TCK tests to the Jakarta EE 10 platform, perform the
 following steps.
 
 1.  Make sure that the Web server to which you will deploy the {TechnologyShortName} TCK

--- a/user_guides/jstl/src/main/jbake/content/install-server.inc
+++ b/user_guides/jstl/src/main/jbake/content/install-server.inc
@@ -1,10 +1,10 @@
-.  Install the Jakarta EE 8 CI software, for example, {TechnologyRI} (the servlet Web container used
+.  Install the Jakarta EE 10 CI software, for example, {TechnologyRI} (the servlet Web container used
 for running the {TechnologyShortName} TCK with the
 {TechnologyShortName} {TechnologyVersion} CI), if it is not already
 installed. +
 Download and install the Servlet Web container with the
 {TechnologyShortName} {TechnologyVersion} CI used for running the
 {TechnologyShortName} TCK {TechnologyVersion}, represented by the Jakarta
-EE 8 CI.
+EE 10 CI.
 If you intend to use {TechnologyRI}, you may obtain this software via the
 downloads tab from the project website: {TechnologyRIURL}.

--- a/user_guides/jstl/src/main/jbake/content/rebuild.inc
+++ b/user_guides/jstl/src/main/jbake/content/rebuild.inc
@@ -23,7 +23,7 @@ published in a Java SE environment are located under
 `$TS_HOME/classes`.
 
 The {TechnologyShortName} TCK comes with prebuilt test WAR files for
-deployment on Java EE 10 RI , which provides a Servlet–compliant Web
+deployment on Jakarta EE 10 RI , which provides a Servlet–compliant Web
 container. The WAR files are {TechnologyRI}-specific, with {TechnologyRI}'s servlet
 class and {TechnologyRI}'s servlet defined in the `web.xml` deployment
 descriptor. To run the TCK tests against the VI in a Servlet–compliant
@@ -50,7 +50,7 @@ B.1 Overview
 
 The set of prebuilt archives and classes that ship with the
 {TechnologyShortName} TCK were built using the Reference
-Implementation, and must be deployed on Java EE 10 RI and run against
+Implementation, and must be deployed on Jakarta EE 10 RI and run against
 the {TechnologyRI} RI.
 
 The prebuilt {TechnologyRI}-specific Servlet–compliant WAR files are located
@@ -147,7 +147,7 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 ----
 
 The {TechnologyShortName} TCK provides a tool,
-`${ts.home}/bin/xml/impl/glassfish/jersey.xml`, for the Java EE 10 RI
+`${ts.home}/bin/xml/impl/glassfish/jersey.xml`, for the Jakarta EE 10 RI
 that you can use as a model to help you create your own VI-specific Web
 test application.
 

--- a/user_guides/jstl/src/main/jbake/content/rebuild.inc
+++ b/user_guides/jstl/src/main/jbake/content/rebuild.inc
@@ -23,7 +23,7 @@ published in a Java SE environment are located under
 `$TS_HOME/classes`.
 
 The {TechnologyShortName} TCK comes with prebuilt test WAR files for
-deployment on Java EE 8 RI , which provides a Servlet–compliant Web
+deployment on Java EE 10 RI , which provides a Servlet–compliant Web
 container. The WAR files are {TechnologyRI}-specific, with {TechnologyRI}'s servlet
 class and {TechnologyRI}'s servlet defined in the `web.xml` deployment
 descriptor. To run the TCK tests against the VI in a Servlet–compliant
@@ -50,7 +50,7 @@ B.1 Overview
 
 The set of prebuilt archives and classes that ship with the
 {TechnologyShortName} TCK were built using the Reference
-Implementation, and must be deployed on Java EE 8 RI and run against
+Implementation, and must be deployed on Java EE 10 RI and run against
 the {TechnologyRI} RI.
 
 The prebuilt {TechnologyRI}-specific Servlet–compliant WAR files are located
@@ -147,7 +147,7 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 ----
 
 The {TechnologyShortName} TCK provides a tool,
-`${ts.home}/bin/xml/impl/glassfish/jersey.xml`, for the Java EE 8 RI
+`${ts.home}/bin/xml/impl/glassfish/jersey.xml`, for the Java EE 10 RI
 that you can use as a model to help you create your own VI-specific Web
 test application.
 

--- a/user_guides/jstl/src/main/jbake/content/req-software.inc
+++ b/user_guides/jstl/src/main/jbake/content/req-software.inc
@@ -8,6 +8,6 @@ below line can be removed.
 This is used in intro.adoc in section 1.3 and install.adoc in section 3.2.
 ///////////////////////////////////////////////////////////////////////
 
-* A Jakarta EE 8 CI (for example {TechnologyRI}) or, at a minimum, a Web server with a Servlet container
+* A Jakarta EE 10 CI (for example {TechnologyRI}) or, at a minimum, a Web server with a Servlet container
 
 * A suitable database for your CI. {TechnologyRI} is preconfigured to use Apache Derby. 


### PR DESCRIPTION
~ Ready for Review  ~
- Updated attributes to reference Tags version 3.0 and Glassfish 7.0
- Updated dates & references to EE 10. 
- Removed COMPAT documentation as that's no longer needed (since the tests were updated to use the default Java 11 locales. See https://github.com/eclipse-ee4j/jakartaee-tck/issues/631#issuecomment-799764345) 

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
