### PR TITLE
avoid OOM error while deployment in jsf tck

### DIFF
--- a/docker/jsftck.sh
+++ b/docker/jsftck.sh
@@ -61,6 +61,9 @@ export PATH=$JAVA_HOME/bin:$PATH
 which java
 java -version
 
+# to avoid OOM error while deployment
+sed -i.bak 's/-Xmx512m/-Xmx1024m/g' $TCK_HOME/$GF_TOPLEVEL_DIR/glassfish/domains/domain1/config/domain.xml
+
 cd $TCK_HOME/$GF_TOPLEVEL_DIR/bin
 ./asadmin start-domain
 


### PR DESCRIPTION
**Fixes Issue**
The jsf tck tests are stuck during deployment due to OOM error as seen in glassfish server.logs


**Describe the change**
Doubles the maximum memory allocation for glassfish for jsf tck tests.