### PR TITLE
Set javatest.security.noSecurityManager=true if Java 18+

### DIFF
--- a/bin/xml/ts.top.import.xml
+++ b/bin/xml/ts.top.import.xml
@@ -34,6 +34,11 @@
     <import file="./ts.vehicles.xml"/>
     
     <!-- PROPERTIES -->
+    <condition property="noSecurityManager" value="true">
+        <javaversion atleast="18"/>
+    </condition>
+    <property name="noSecurityManager" value="false"/>
+
     <!-- Set the archives to deploy - default to wars-->
     <target name="setup.archive.set">
         <fileset dir="${dist.dir}/${pkg.dir}" id="deploy.vi.archive.set">
@@ -769,6 +774,7 @@
             <sysproperty key="TZ" value="${tz}"/>
             <sysproperty key="deliverable.class" value="${deliverable.class}"/>
             <sysproperty key="common.apps.only" value="${common.apps.only}"/>
+            <sysproperty key="javatest.security.noSecurityManager" value="${noSecurityManager}"/>
             <sysproperty key="harness.executeMode" value="${exec.mode}"/>
             <sysproperty key="DEPLOY_DELAY_IN_MINUTES" 
                          value="${deploy.delay.in.minutes}"/>


### PR DESCRIPTION
**Fixes Issue**
Allows JavaTest to be run with Java 18+

**Related Issue(s)**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/743

**Describe the change**
This updates all invocations of JavaTest in the Platform TCK to use noSecurityManager=true when running with Java 18+.  This has no impact on actual test outcomes because the VI's processes and the execution commands defined in ts.jte will still have the default security behavior for the level of JDK being tested.

Note: This implementation requires use of the <javaversion> condition introduced in Ant 1.10.2.  To support older levels of Ant, a more elaborate statement using Ant's builtin ant.java.version would be required instead.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
