### PR TITLE
address FormatterUIBean integer number too large failure

### DIFF
--- a/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterUIBean.java
@@ -25,7 +25,7 @@ import jakarta.faces.component.html.HtmlOutputFormat;
 @jakarta.inject.Named("score") @jakarta.enterprise.context.SessionScoped
 public class FormatterUIBean implements Serializable {
 
-  private static final long serialVersionUID = -9564143088038088087L;
+  private static final long serialVersionUID = -956414308038088087L;
 
   private HtmlOutputFormat fscore;
 


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Address compile failure:
```
compile:
 [ts.javac] Compiling 3 source files to /home/jenkins/agent/workspace/jakartaee-tck_master/classes
 [ts.javac] Picked up JAVA_TOOL_OPTIONS: -Xmx6G
 [ts.javac] /home/jenkins/agent/workspace/jakartaee-tck_master/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterUIBean.java:28: error: integer number too large
 [ts.javac]   private static final long serialVersionUID = -9564143088038088087L;
 [ts.javac]                                                 ^
 [ts.javac] 1 error
[dosubdirs] The following error occurred while executing this line:
[dosubdirs] /home/jenkins/agent/workspace/jakartaee-tck_master/src/com/sun/ts/tests/jsf/spec/render/common/render.common.xml:44: Compile failed; see the compiler error output for details.
[dosubdirs]     at org.apache.tools.ant.ProjectHelper.addLocationToBuildException(ProjectHelper.java:582)
[dosubdirs]     at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:440)
[dosubdirs]     at com.sun.ant.taskdefs.common.DoSubdirs.execute(DoSubdirs.java:123)
[dosubdirs]     at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:299)
[dosubdirs]     at jdk.internal.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
[dosubdirs]     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[dosubdirs]     at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[dosubdirs]     at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
[dosubdirs]     at org.apache.tools.ant.Task.perform(Task.java:350)
[dosubdirs]     at org.apache.tools.ant.Target.execute(Target.java:449)
[dosubdirs]     at org.apache.tools.ant.Target.performTasks(Target.java:470)
[dosubdirs]     at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1401)
[dosubdirs]     at org.apache.tools.ant.Project.executeTarget(Project.java:1374)
[dosubdirs]     at org.apache.tools.ant.helper.DefaultExecutor.executeTargets(DefaultExecutor.java:41)
[dosubdirs]     at org.apache.tools.ant.Project.executeTargets(Project.java:1264)
[dosubdirs]     at org.apache.tools.ant.Main.runBuild(Main.java:818)
[dosubdirs]     at org.apache.tools.ant.Main.startAnt(Main.java:223)
```