### PR TITLE
JPA jpa/jpa22/datetime test LocalDateTime truncated to miliseconds to fit into database types.

### DIFF
--- a/src/com/sun/ts/tests/jpa/jpa22/datetime/Client.java
+++ b/src/com/sun/ts/tests/jpa/jpa22/datetime/Client.java
@@ -101,7 +101,7 @@ public class Client extends PMClientBase {
       .of(1970, 1, 1, 0, 0, 0);
 
   /** LocalDateTime constant. */
-  private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
+  private static final LocalDateTime LOCAL_DATE_TIME = initLocalDateTime();
 
   /** Default OffsetTime constant. */
   private static final OffsetTime OFFSET_TIME_DEF = OffsetTime
@@ -130,6 +130,12 @@ public class Client extends PMClientBase {
           LOCAL_DATE_TIME_DEF, OFFSET_TIME, OFFSET_DATE_TIME_DEF),
       new DateTimeEntity(5L, LOCAL_DATE_DEF, LOCAL_TIME_DEF,
           LOCAL_DATE_TIME_DEF, OFFSET_TIME_DEF, OFFSET_DATE_TIME) };
+
+  // Databases precision is usually not nanoseconds. Truncate to miliseconds.
+  private static LocalDateTime initLocalDateTime() {
+    final LocalDateTime value = LocalDateTime.now();
+    return value.withNano((value.getNano() / 1000000) * 1000000);
+  }
 
   /*
    * @testName: dateTimeTest


### PR DESCRIPTION
**Fixes Issue**
[LocalDateTime check in dateTimeTest is failing on MySQL](https://github.com/eclipse-ee4j/jakartaee-tck/issues/901)

**Describe the change**
LocalDateTime second fraction precision is rounded to miliseconds in the test.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
