### PR TITLE
use new UIViewRoot instead of createViewRoot

### DIFF
--- a/src/com/sun/ts/tests/jsf/common/servlets/HttpTCKServlet.java
+++ b/src/com/sun/ts/tests/jsf/common/servlets/HttpTCKServlet.java
@@ -192,7 +192,7 @@ public abstract class HttpTCKServlet extends HttpServlet {
 
   protected UIViewRoot createViewRoot() {
 
-    return createViewRoot(null);
+    return new UIViewRoot();
 
   }
 


### PR DESCRIPTION
**Fixes Issue**
Fixes test failures in faces tck

**Related Issue(s)**
(https://github.com/jakartaee/faces/issues/1600)

**Describe the change**
Use new UIViewRoot() instead of createViewRoot(null) as suggested at https://github.com/jakartaee/faces/issues/1600#issuecomment-1073113382 to resolve ViewHandlingStrategyNotFoundException in several of the tests. 


**Additional context**
Test job run with this change https://ci.eclipse.org/jakartaee-tck/blue/organizations/jenkins/jakartaee-tck-alw/detail/faces_ViewHandlingStrategyNotFoundException/2/pipeline/47/.
Number of tests completed:  5430 (4429 passed, 1001 failed, 0 with errors)

