### PR TITLE
Make sure the test ELContext has a resolver that can invoke methods.

### DIFF
--- a/src/com/sun/ts/tests/el/common/elcontext/VarMapperELContext.java
+++ b/src/com/sun/ts/tests/el/common/elcontext/VarMapperELContext.java
@@ -54,6 +54,7 @@ public class VarMapperELContext extends ELContext {
   public ELResolver getELResolver() {
     ELResolver elResolver;
     this.compResolver.add(new VariableELResolver());
+    this.compResolver.add(new jakarta.el.BeanELResolver());
     elResolver = (ELResolver) compResolver;
 
     return elResolver;


### PR DESCRIPTION
**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/932

**Describe the change**
The expression language tests make use of a custom test `ELContext`, which only contains some minimal functionality for passing tests. Before expressions of the form `#{bean.targetD('1','1')}` have seemingly not been tested, and therefor this minimal `ELContext` did not take them into account.

This change adds the standard `jakarta.el.BeanELResolver` to the list of resolvers, so that if a test needs to invoke something, it will succeed for those implementations that make use of resolvers to invoke methods.

**Additional context**
I've not been able to build the TCK bundle itself and test it, but did test this exact change on a copied example.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>

cc @markt-asf  @pnicolucci 