### PR TITLE
Jsp plugin updates

### DIFF
--- a/src/com/sun/ts/tests/jsp/api/jakarta_servlet/jsp/jspwriter/JspWriterValidator.java
+++ b/src/com/sun/ts/tests/jsp/api/jakarta_servlet/jsp/jspwriter/JspWriterValidator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,10 +28,6 @@ import com.sun.ts.tests.common.webclient.WebTestCase;
 import com.sun.ts.tests.common.webclient.http.HttpResponse;
 import com.sun.ts.tests.common.webclient.validation.TokenizedValidator;
 
-/**
- * This validator will, loosely, validate the generated output of a jsp:plugin
- * action.
- */
 public class JspWriterValidator extends TokenizedValidator {
 
   private static final String UNIX_LINE_SEPARATOR = "\n";

--- a/src/com/sun/ts/tests/jsp/spec/core_syntax/actions/plugin/JspPluginValidator.java
+++ b/src/com/sun/ts/tests/jsp/spec/core_syntax/actions/plugin/JspPluginValidator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,8 +32,8 @@ import com.sun.ts.tests.common.webclient.WebTestCase;
 import com.sun.ts.tests.common.webclient.validation.ValidationStrategy;
 
 /**
- * This validator will, loosely, validate the generated output of a jsp:plugin
- * action.
+ * This validator will, loosely, validate that a jsp:plugin action does not
+ * generate any output.
  */
 public class JspPluginValidator implements ValidationStrategy {
   private static final String NL = System.getProperty("line.separartor", "\n");
@@ -67,8 +68,7 @@ public class JspPluginValidator implements ValidationStrategy {
   public boolean validate(WebTestCase testCase) {
 
     List<String> searchStrings = testCase.getSearchStrings();
-    List<String> unexpectedSearchStrings = testCase
-        .getUnexpectedSearchStrings();
+    List<String> unexpectedSearchStrings = testCase.getUnexpectedSearchStrings();
     boolean passed = true;
     String response = null;
 
@@ -83,8 +83,7 @@ public class JspPluginValidator implements ValidationStrategy {
 
     // get response body
     try {
-      response = testCase.getResponse().getResponseBodyAsRawString()
-          .toLowerCase();
+      response = testCase.getResponse().getResponseBodyAsRawString().toLowerCase();
 
       String[] htmlTokens = prepareTokens(
           new StringTokenizer(response, "<>='\";\n\t "));
@@ -104,16 +103,19 @@ public class JspPluginValidator implements ValidationStrategy {
             + sb.toString());
       }
 
-      // check the response for either an object or embed tag in the
-      // response
-      if (response.indexOf("<embed") < 0 && response.indexOf("<object") < 0) {
-        TestUtil.logErr("[JspPluginValidator] Unable to locate either an"
-            + "OBJECT or EMBED tag in the server's response.");
+      // Check the response for object tag in the response
+      if (response.indexOf("<embed") > -1) {
+        TestUtil.logErr("[JspPluginValidator] Found EMBED tag in the server's response.");
         return false;
       }
 
-      List<String> itemsNotFound = scanForExpectedValues(response, htmlTokens,
-          searchStrings);
+      // Check the response for embed tag in the response
+      if (response.indexOf("<object") > -1) {
+        TestUtil.logErr("[JspPluginValidator] Found OBJECT tag in the server's response.");
+        return false;
+      }
+
+      List<String> itemsNotFound = scanForExpectedValues(response, htmlTokens, searchStrings);
 
       // check to see if we had any misses
       if (itemsNotFound.size() > 0) {

--- a/src/com/sun/ts/tests/jsp/spec/core_syntax/actions/plugin/URLClient.java
+++ b/src/com/sun/ts/tests/jsp/spec/core_syntax/actions/plugin/URLClient.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,12 +77,13 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginAppletTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING,
-        "http://www.nowaythiswebsitecouldpossiblyexist.com|"
-            + "fallback_text|vspace=1|hspace=1|"
-            + "width=10|height=10|test=testvalue|applet|"
-            + "code=foo.class|archive=test.jar|name=test|"
-            + "align=middle|codebase=/");
+    TEST_PROPS.setProperty(SEARCH_STRING, "expected_text");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH,
+        "http://www.nowaythiswebsitecouldpossiblyexist.com|" +
+        "fallback_text|vspace=1|hspace=1|" +
+        "width=10|height=10|test=testvalue|applet|" +
+        "code=foo.class|archive=test.jar|name=test|" +
+        "align=middle|codebase=/");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -89,12 +91,13 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginBeanTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING,
-        "http://www.nowaythiswebsitecouldpossiblyexist.com|"
-            + "fallback_text|vspace=1|hspace=1|"
-            + "width=10|height=10|test=testvalue|bean|"
-            + "code=foo.class|archive=test.jar|name=test|"
-            + "align=middle|codebase=/");
+    TEST_PROPS.setProperty(SEARCH_STRING, "expected_text");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH,
+        "http://www.nowaythiswebsitecouldpossiblyexist.com|" +
+        "fallback_text|vspace=1|hspace=1|" +
+        "width=10|height=10|test=testvalue|bean|" +
+        "code=foo.class|archive=test.jar|name=test|" +
+        "align=middle|codebase=/");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -113,7 +116,7 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginHeightElAttributeValueTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING, "height=10");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "height=10");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -121,7 +124,7 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginHeightRtAttributeValueTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING, "height=10");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "height=10");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -129,7 +132,7 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginWidthElAttributeValueTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING, "width=10");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "width=10");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -137,7 +140,7 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginWidthRtAttributeValueTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING, "width=10");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "width=10");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -323,8 +326,8 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspFallbackBodyTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING, "fallback_text");
-    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "<jsp:body>|</jsp:body>");
+    TEST_PROPS.setProperty(SEARCH_STRING, "expected_text");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "<jsp:body>|fallback_text|</jsp:body>");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -343,8 +346,8 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspParamsBodyTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING, "param1=value1");
-    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "<jsp:body>|</jsp:body>");
+    TEST_PROPS.setProperty(SEARCH_STRING, "expected_text");
+    TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH, "<jsp:body>|param1=value1|</jsp:body>");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();
@@ -380,14 +383,14 @@ public class URLClient extends AbstractUrlClient {
         "com.sun.ts.tests.jsp.spec.core_syntax.actions.plugin.JspPluginValidator");
     TEST_PROPS.setProperty(REQUEST,
         "GET /jsp_core_act_plugin_web/JspPluginJspAttributeTest.jsp HTTP/1.1");
-    TEST_PROPS.setProperty(SEARCH_STRING,
-        "http://www.nowaythiswebsitecouldpossiblyexist.com|"
-            + "fallback_text|vspace=1|hspace=1|"
-            + "width=10|height=10|test=testvalue|bean|"
-            + "code=foo.class|archive=test.jar|name=test|"
-            + "align=middle|codebase=/");
+    TEST_PROPS.setProperty(SEARCH_STRING, "expected_text");
     TEST_PROPS.setProperty(UNEXPECTED_RESPONSE_MATCH,
-        "<jsp:attribute>|</jsp:attribute>");
+        "<jsp:attribute>|</jsp:attribute>|" +
+        "http://www.nowaythiswebsitecouldpossiblyexist.com|" +
+        "fallback_text|vspace=1|hspace=1|" +
+        "width=10|height=10|test=testvalue|bean|" +
+        "code=foo.class|archive=test.jar|name=test|" +
+        "align=middle|codebase=/");
     TEST_PROPS.setProperty(REQUEST_HEADERS,
         "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)");
     invoke();

--- a/src/web/jsp/spec/core_syntax/actions/plugin/JspFallbackBodyTest.jsp
+++ b/src/web/jsp/spec/core_syntax/actions/plugin/JspFallbackBodyTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,3 +24,4 @@
         <jsp:body>fallback_text</jsp:body>
     </jsp:fallback>
 </jsp:plugin>
+expected_text

--- a/src/web/jsp/spec/core_syntax/actions/plugin/JspParamsBodyTest.jsp
+++ b/src/web/jsp/spec/core_syntax/actions/plugin/JspParamsBodyTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,3 +30,4 @@
         </jsp:body>
     </jsp:params>
 </jsp:plugin>
+expected_text

--- a/src/web/jsp/spec/core_syntax/actions/plugin/JspPluginAppletTest.jsp
+++ b/src/web/jsp/spec/core_syntax/actions/plugin/JspPluginAppletTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,3 +29,4 @@
             </jsp:params>
             <jsp:fallback>fallback_text</jsp:fallback>
 </jsp:plugin>
+expected_text

--- a/src/web/jsp/spec/core_syntax/actions/plugin/JspPluginBeanTest.jsp
+++ b/src/web/jsp/spec/core_syntax/actions/plugin/JspPluginBeanTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,3 +29,4 @@
             </jsp:params>
             <jsp:fallback>fallback_text</jsp:fallback>
 </jsp:plugin>
+expected_text

--- a/src/web/jsp/spec/core_syntax/actions/plugin/JspPluginJspAttributeTest.jsp
+++ b/src/web/jsp/spec/core_syntax/actions/plugin/JspPluginJspAttributeTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,3 +43,4 @@
         <jsp:fallback>fallback_text</jsp:fallback>
     </jsp:body>
 </jsp:plugin>
+expected_text


### PR DESCRIPTION
**Fixes Issue**
#937 

**Related Issue(s)**
Previous PR #938

**Describe the change**
Modify the TCK so jsp:plugin syntax in JSP pages is still validated but the action is a NO-OP in terms out HTML output.

**Additional context**
https://github.com/eclipse-ee4j/jsp-api/issues/226

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
