### PR TITLE
Tests that use Jakarta Faces need to also include a beans.xml (bean-discovery-mode=all) to enable CDI

### DIFF
--- a/bin/xml/ts.vehicles.xml
+++ b/bin/xml/ts.vehicles.xml
@@ -450,7 +450,7 @@
                     <var name="vehicle.prefix" value="${vehicle.name}_web"/>
 
                     <copy todir="${dist.dir}/${pkg.dir}">
-                        <fileset dir="${src.dir}/${vehicle.pkg.dir}/@{vehicle}" includes="faces-config.xml"/>
+                        <fileset dir="${src.dir}/${vehicle.pkg.dir}/@{vehicle}" includes="faces-config.xml,beans.xml"/>
                         <filterset>
                             <filter token="package" value="${package}"/>
                         </filterset>
@@ -475,7 +475,7 @@
                                     excludes="${runner.classes}, @{excludedfiles}"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
-                        <zipfileset dir="${dist.dir}/${pkg.dir}" includes="faces-config.xml" prefix="WEB-INF"/>
+                        <zipfileset dir="${dist.dir}/${pkg.dir}" includes="faces-config.xml,beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="*.jar" prefix="WEB-INF/lib" excludes="ejbembed_vehicle*.jar"/>
                         <zipfileset dir="${basedir}" includes="*.tld" prefix="WEB-INF/tlds"/>
                         <fileset dir="${src.dir}/${vehicle.pkg.dir}/@{vehicle}" includes="*.jsp"/>
@@ -483,7 +483,7 @@
                         <jar-elements/>
                     </ts.war>
                     <delete failonerror="false">
-                        <fileset dir="${dist.dir}/${pkg.dir}" includes="faces-config.xml"/>
+                        <fileset dir="${dist.dir}/${pkg.dir}" includes="faces-config.xml,beans.xml"/>
                     </delete>
                 </then>
                 </elseif>

--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsf/beans.xml
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsf/beans.xml
@@ -1,0 +1,22 @@
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd" bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Fix for https://github.com/eclipse-ee4j/jakartaee-tck/issues/950 that we are testing via https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-scottmarlow/job/faces_beansxml/2/