### PR TITLE
Remove maxpermsize, as it's not supported anymore and crashes new JDKs

### DIFF
--- a/install/connector/bin/ts.jte
+++ b/install/connector/bin/ts.jte
@@ -154,7 +154,7 @@ ri.asenv.loc=${connector.home}/config
 ri.imqbin.loc=${connector.home}/imq/bin
 ri.lib=${connector.home}/modules
 ri.imq.share.lib=${connector.home}/imq/lib
-ri.jvm.options=-XX\\\:MaxPermSize=512m:-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}
+ri.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}
 ri.java.endorsed.dirs=${endorsed.dirs}
 ri.applicationRoot=c:
 
@@ -171,7 +171,7 @@ s1as.domain=${s1as.domain.dir}/${s1as.domain.name}
 s1as.asenv.loc=${connector.home}/config
 s1as.imqbin.loc=${connector.home}/imq/bin
 s1as.imq.share.lib=${connector.home}/imq/lib
-s1as.jvm.options=-XX\\\:MaxPermSize=512m:-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}
+s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}
 s1as.java.endorsed.dirs=${endorsed.dirs}
 s1as.applicationRoot=c:
 

--- a/install/jacc/bin/ts.jte
+++ b/install/jacc/bin/ts.jte
@@ -128,7 +128,7 @@ s1as.asenv.loc=${jacc.home}/config
 s1as.imqbin.loc=${jacc.home}/imq/bin
 s1as.lib=${jacc.home}/lib
 s1as.imq.share.lib=${jacc.home}/imq/lib
-s1as.jvm.options=-XX\\\:MaxPermSize=512m:-Doracle.jdbc.J2EE13Compliant=true
+s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true
 s1as.java.endorsed.dirs=${endorsed.dirs}
 s1as.applicationRoot=c:
 

--- a/install/jakartaee/bin/ts.jte
+++ b/install/jakartaee/bin/ts.jte
@@ -305,8 +305,8 @@ ri.lib=${javaee.home.ri}/lib
 ri.log.file.location=${ri.domain}/logs
 ri.modules=${javaee.home.ri}/modules
 ri.imq.share.lib=${javaee.home.ri}/../mq/lib
-ri.jvm.options=-XX\\\:MaxPermSize=512m:-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http
-ri.jvm.options.remove=-XX\\\:MaxPermSize=192m:-Xmx512m:${ri.jvm.options}
+ri.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http
+ri.jvm.options.remove=-Xmx512m:${ri.jvm.options}
 ri.java.endorsed.dirs=${endorsed.dirs.ri}
 ri.applicationRoot=c:
 ri.and.vi.run.on.same.host=true
@@ -355,8 +355,8 @@ vi.lib=${javaee.home}/server/lib
 vi.log.file.location=${vi.domain}/logs
 vi.modules=${javaee.home}/modules
 vi.imq.share.lib=${javaee.home}/../mq/lib
-vi.jvm.options=-XX\\\:MaxPermSize=512m:-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http
-vi.jvm.options.remove=-XX\\\:MaxPermSize=192m:-Xmx512m:${vi.jvm.options}
+vi.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-Dcsiv2.save.log.file=${harness.log.traceflag}:-Djavax.xml.accessExternalStylesheet=all:-Djavax.xml.accessExternalDTD=file,http
+vi.jvm.options.remove=-Xmx512m:${vi.jvm.options}
 vi.java.endorsed.dirs=${endorsed.dirs}
 vi.applicationRoot=c:
 
@@ -401,8 +401,8 @@ s1as.imqbin.loc=${javaee.home}/../mq/bin
 s1as.lib=${javaee.home}/lib
 s1as.modules=${javaee.home}/modules
 s1as.imq.share.lib=${javaee.home}/../mq/lib
-s1as.jvm.options=-XX\\\:MaxPermSize=512m:-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}
-s1as.jvm.options.remove=-XX\\\:MaxPermSize=192m:-Xmx512m:${s1as.jvm.options}
+s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}
+s1as.jvm.options.remove=-Xmx512m:${s1as.jvm.options}
 s1as.java.endorsed.dirs=${endorsed.dirs}
 s1as.applicationRoot=c:
 

--- a/install/jaspic/bin/ts.jte
+++ b/install/jaspic/bin/ts.jte
@@ -180,7 +180,7 @@ s1as.asenv.loc=${jaspic.home}/config
 s1as.imqbin.loc=${jaspic.home}/imq/bin
 s1as.lib=${jaspic.home}/lib
 s1as.imq.share.lib=${jaspic.home}/imq/lib
-s1as.jvm.options=-XX\\\:MaxPermSize=128m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}
+s1as.jvm.options=-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}
 s1as.java.endorsed.dirs=${endorsed.dirs}
 s1as.applicationRoot=c:
 

--- a/user_guides/jaspic/src/main/jbake/content/config.inc
+++ b/user_guides/jaspic/src/main/jbake/content/config.inc
@@ -140,8 +140,6 @@ principal-to-role mappings may vary for each application.
   e.  Appends the file `<TS_HOME>/bin/client_policy.append` to the
   application client's Java policy file, which is referenced in the
   `TestExecuteAppClient` section of the `ts.jte` file.
-  f.  Creates a JVM option that increases the MaxPermSize for your
-  implementation.
 +
 4.  Run `ant enable.jaspic`. +
 This task performs the configuration necessary for adding the test


### PR DESCRIPTION
Fixes #951

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>
