### PR TITLE
Update (jacc) TCK install + userguide to Jakarta Authorization 2.1

### DIFF
--- a/install/jacc/docs/ReleaseNotes-authorization-2.1.html
+++ b/install/jacc/docs/ReleaseNotes-authorization-2.1.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=windows-1252">
     <title>Jakarta Authorization TCK Release Notes</title>
     <!--
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.    This program and the accompanying materials are made available under the    terms of the Eclipse Public License v. 2.0, which is available at    http://www.eclipse.org/legal/epl-2.0.    This Source Code may also be made available under the following Secondary    Licenses when the conditions for such availability set forth in the    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,    version 2 with the GNU Classpath Exception, which is available at    https://www.gnu.org/software/classpath/license.html.    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0-->
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.    This program and the accompanying materials are made available under the    terms of the Eclipse Public License v. 2.0, which is available at    http://www.eclipse.org/legal/epl-2.0.    This Source Code may also be made available under the following Secondary    Licenses when the conditions for such availability set forth in the    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,    version 2 with the GNU Classpath Exception, which is available at    https://www.gnu.org/software/classpath/license.html.    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0-->
     <style type="text/css">
 <!--
 body {  background-color: #ffffdd; color: #000000}
@@ -24,30 +24,30 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
 </style></head>
   <body>
     <div align="center">
-      <h1>Jakarta EE Authorization Technology Compatibility Kit, Version 2.0</h1>
-      <h2> <em class="emphasize">Release Notes, May 2021</em></h2>
+      <h1>Jakarta EE Authorization Technology Compatibility Kit, Version 2.1</h1>
+      <h2> <em class="emphasize">Release Notes, May 2022</em></h2>
     </div>
     <h2><a name="kit_contents">Kit Contents</a></h2>
-    <p>The Jakarta EE Authorization, Version 2.0 Technology Compatibility Kit
+    <p>The Jakarta EE Authorization, Version 2.1 Technology Compatibility Kit
       (TCK) includes the following items:</p>
     <ul>
       <li> <strong>Jakarta EE Authorization TCK tests for signature, API, and
           End-to-End test</strong> </li>
       <ul>
         <li>A <strong>signature test</strong> checks that all of the public
-          APIs are supported in the Jakarta EE Authorization Version 2.0
+          APIs are supported in the Jakarta EE Authorization Version 2.1
           implementation that is being tested </li>
         <li><strong>API tests</strong> for all of the public APIs under the <code>jakarta.security.jacc</code>
           package</li>
         <li><strong>End-To-End tests</strong> that demonstrate compliance with
-          the <em>Jakarta EE Authorization 2.0 Specification</em></li>
+          the <em>Jakarta EE Authorization 2.1 Specification</em></li>
       </ul>
       <li>Jakarta EE Authorization TCK Users Guide</li>
     </ul>
     <hr>
     <h2><a name="platform">Platform Notes</a></h2>
-    <p>The Jakarta EE Authorization TCK tests have been built with JDK 8 (1.8)
-      and tested with JDK 8 (1.8) and JDK 11.</p>
+    <p>The Jakarta EE Authorization TCK tests have been built with JDK 11 
+      and tested with JDK 11 and JDK 17.</p>
     <p>The Jakarta EE Authorization TCK tests have been run on the following
       platforms:</p>
     <ul>
@@ -55,8 +55,8 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
       <li>Alpine Linux v3.12</li>
     </ul>
     <p>The Jakarta EE Authorization TCK tests have been run against the Jakarta
-      EE Authorization 2.0 Compatible Implementation (CI), Eclipse GlassFish 6.0
-      and 6.1</p>
+      EE Authorization 2.1 Compatible Implementation (CI), Eclipse GlassFish 7.0
+      </p>
     <p>Jakarta Enterprise Beans was formerly known as Enterprise Java Beans and
       abbreviated EJB. References to EJB below refer to Jakarta Enterprise
       Beans. Use of this term, as commands, switches, or keywords have not been
@@ -64,9 +64,9 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
     <hr>
     <h2><a name="install_setup_run">Installing, Setting Up, and Running the
         Jakarta EE Authorization TCK</a></h2>
-    <p>Refer to the <cite>Jakarta EE Authorization TCK 2.0 User's Guide</cite>
-      (<a href="./html-usersguide/title.html" title="Jakarta EE Authorization 2.0 TCK User's Guide (HTML)">HTML</a>,
-      <a href="./pdf-usersguide/Jakarta-Authorization-TCK-Users-Guide.pdf" title="Jakarta EE Authorization 2.0 TCK User's Guide (PDF)">PDF</a>)
+    <p>Refer to the <cite>Jakarta EE Authorization TCK 2.1 User's Guide</cite>
+      (<a href="./html-usersguide/title.html" title="Jakarta EE Authorization 2.1 TCK User's Guide (HTML)">HTML</a>,
+      <a href="./pdf-usersguide/Jakarta-Authorization-TCK-Users-Guide.pdf" title="Jakarta EE Authorization 2.1 TCK User's Guide (PDF)">PDF</a>)
       for complete instructions on installing, setting up, and running the
       Jakarta EE Authorization TCK. </p>
     <p>The online version of the JT Harness version 5.0 documentation is
@@ -75,23 +75,8 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
     <h2>Jakarta EE Authorization TCK Requirements, Facts, and Figures</h2>
     <p>The Jakarta EE Authorization TCK requires a minimum of 103 MB of free
       disk space:</p>
-    <ul>
-      <li>Jakarta EE Authorization TCK (zipped): 23 MB</li>
-      <li>Jakarta EE Authorization TCK (unzipped): 79 MB</li>
-      <li>Space for Jakarta EE Authorization log/report files: 1 MB minimum </li>
-    </ul>
-    <p>The test suite bundle contains the following:</p>
-    <ul>
-      <li>EARs: 0</li>
-      <li>JARs: 41</li>
       <li>WARs: 6</li>
-      <li>Total tests: 32
-        <ul>
-          <li>Web Container: 23</li>
-          <li>EJB-lite: 9</li>
-          <li>EJB Container: n/a (Jakarta Enterprise Beans Container tests are
-            only available in full CTS 8)</li>
-        </ul>
+      <li>Total tests: 34
       </li>
     </ul>
     <p> There are multiple levels of compliance available for Jakarta EE
@@ -103,8 +88,8 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
       Web Profile environment). There are keywords available which can be
       supplied on the command line which allow isolating the tests for a given
       level of certification. (For more on keywords, see the Jakarta EE
-      Authorization 2.0 TCK User Guide). The list of keywords available for
-      Jakarta EE Authorization 2.0 TCK is as follows:</p>
+      Authorization 2.1 TCK User Guide). The list of keywords available for
+      Jakarta EE Authorization 2.1 TCK is as follows:</p>
     <ul>
       <li>keyword <strong>jacc_web</strong> : used to run Web Container tests </li>
       <li>keyword <strong>jacc_ejb</strong> : used to run Jakarta Enterprise
@@ -122,7 +107,7 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
       <p>You can find the exclude list in the Jakarta EE Authorization bundle in
         <code>&lt;TS_HOME&gt;/bin/ts.jtx</code>. Since the list can change over
         time, please be sure to get the latest exclude list from the Jakarta EE
-        Authorization Specification Web site: <a href="https://jakarta.ee/specifications/authorization/2.0/">https://jakarta.ee/specifications/authorization/2.0/</a>.</p>
+        Authorization Specification Web site: <a href="https://jakarta.ee/specifications/authorization/2.1/">https://jakarta.ee/specifications/authorization/2.1/</a>.</p>
     </blockquote>
     <hr>
     <h2>Known Problems and Workarounds</h2>
@@ -131,7 +116,7 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
     <blockquote>
       <p>When configuring and running the Jakarta EE Authorization TCK against
         the CI on Windows, please make sure to install all related software
-        (Java SE 8, the CI, the Jakarta EE Authorization TCK, etc.) on the same
+        (Java SE 11/17, the CI, the Jakarta EE Authorization TCK, etc.) on the same
         drive (for example, <code>C:</code>). If you want to install on a drive
         other than <code>C:</code>, please be sure to change the following
         properties in <code>&lt;TS_HOME&gt;/bin/ts.jte:</code></p>
@@ -139,7 +124,7 @@ th {  background-color: #eeeeee; padding-left: 2pt; padding-right: 2pt;}
 </pre> </blockquote>
     <hr>
     <p><cite><small></small></cite></p>
-    <address><small> Copyright © 2013, 2021 Oracle and/or its affiliates. All
+    <address><small> Copyright © 2013, 2022 Oracle and/or its affiliates. All
         rights reserved. </small></address>
     <p></p>
   </body>

--- a/install/jacc/docs/index.html
+++ b/install/jacc/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=windows-1252">
     <!--
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.    This program and the accompanying materials are made available under the
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.    This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at    http://www.eclipse.org/legal/epl-2.0.    This Source Code may also be made available under the following Secondary
     Licenses when the conditions for such availability set forth in the    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,    version 2 with the GNU Classpath Exception, which is available at    https://www.gnu.org/software/classpath/license.html.
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0-->
@@ -25,24 +25,24 @@ h4 {  font-style: italic; color: #000099}
   <body>
     <div align="center">
       <h1>Welcome to the Jakarta EE Authorization Technology Compatibility Kit,
-        Version 2.0</h1>
+        Version 2.1</h1>
       <h2> <span class="emphasize">Your Starting Point</span></h2>
     </div>
     <hr>
-    <h2>Jakarta EE Authorization TCK 2.0 Documentation</h2>
+    <h2>Jakarta EE Authorization TCK 2.1 Documentation</h2>
     <p>The Jakarta<small><sup></sup></small> EE Authorization Technology
-      Compatibility Kit (TCK) 2.0 documentation includes the
+      Compatibility Kit (TCK) 2.1 documentation includes the
       following:</p>
     <ul>
       <li>
-        <p>The <a href="ReleaseNotes-authorization-2.0.html">Jakarta EE
-            Authorization TCK 2.0 Release Notes</a> provides late-breaking
-          information about the Jakarta EE Authorization TCK, Version 2.0.</p>
+        <p>The <a href="ReleaseNotes-authorization-2.1.html">Jakarta EE
+            Authorization TCK 2.1 Release Notes</a> provides late-breaking
+          information about the Jakarta EE Authorization TCK, Version 2.1.</p>
       </li>
       <li>
-        <p>The <em>Jakarta EE Authorization 2.0 Technology Compatibility Kit
-            User's Guide</em> (<a href="./html-usersguide/title.html" title="Jakarta EE Authorization 2.0 TCK User's Guide (HTML)">HTML</a>,
-          <a href="./pdf-usersguide/Jakarta-Authorization-TCK-Users-Guide.pdf" title="Jakarta EE Authorization 2.0 TCK User's Guide (PDF)">PDF</a>)
+        <p>The <em>Jakarta EE Authorization 2.1 Technology Compatibility Kit
+            User's Guide</em> (<a href="./html-usersguide/title.html" title="Jakarta EE Authorization 2.1 TCK User's Guide (HTML)">HTML</a>,
+          <a href="./pdf-usersguide/Jakarta-Authorization-TCK-Users-Guide.pdf" title="Jakarta EE Authorization 2.1 TCK User's Guide (PDF)">PDF</a>)
           provides the information you need to install, configure, and run the
           Jakarta EE Authorization TCK. The User's Guide also contains the rules
           you need to pass for certification. </p>
@@ -50,12 +50,12 @@ h4 {  font-style: italic; color: #000099}
       <li>
         <p>The <a href="assertions/api/JACCJavaDocAssertions.html">Javadoc
             Assertion List</a> lists all the javadoc assertions from Jakarta EE
-          Authorization 2.0 Specification.</p>
+          Authorization 2.1 Specification.</p>
       </li>
       <li>
         <p>The <a href="assertions/spec/JACCSpecAssertions.html">Specification
             Assertion List</a> lists all the specification assertions from
-          Jakarta EE Authorization 2.0 Specification.</p>
+          Jakarta EE Authorization 2.1 Specification.</p>
       </li>
     </ul>
     <h2>JT Harness Documentation</h2>
@@ -63,7 +63,7 @@ h4 {  font-style: italic; color: #000099}
       available <a href="https://wiki.openjdk.java.net/display/CodeTools/Documentation">here</a>.</p>
     <hr>
     <p><cite><small></small></cite></p>
-    <address><small> Copyright © 2013, 2021 Oracle and/or its affiliates. All
+    <address><small> Copyright © 2013, 2022 Oracle and/or its affiliates. All
         rights reserved. </small></address>
     <p></p>
   </body>

--- a/user_guides/jacc/pom.xml
+++ b/user_guides/jacc/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,10 +28,10 @@
 
     <groupId>org.glassfish</groupId>
     <artifactId>tck_jacc</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
     <packaging>pom</packaging>
 
-    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Authorization for Jakarta EE, Release 2.0</name>
+    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Authorization for Jakarta EE, Release 2.1</name>
 
     <distributionManagement>
         <site>

--- a/user_guides/jacc/src/main/jbake/content/attributes.conf
+++ b/user_guides/jacc/src/main/jbake/content/attributes.conf
@@ -1,12 +1,12 @@
 :TechnologyFullName: Jakarta Authorization
 :TechnologyShortName: Authorization
 :LegacyAcronym: JACC		   
-:TechnologyVersion: 2.0
-:ReleaseDate: May 2021
-:CopyrightDates: 2017, 2021
-:TechnologyRI: Eclipse GlassFish 6.1
+:TechnologyVersion: 2.1
+:ReleaseDate: May 2022
+:CopyrightDates: 2017, 2022
+:TechnologyRI: Eclipse GlassFish 7.0
 :TechnologyRIURL: https://projects.eclipse.org/projects/ee4j.glassfish
-:SpecificationURL: https://jakarta.ee/specifications/authorization/2.0/
+:SpecificationURL: https://jakarta.ee/specifications/authorization/2.1/
 :TCKInquiryList: mailto:jakartaee-tck-dev@eclipse.org[jakartaee-tck-dev@eclipse.org]
 :SpecificationInquiryList: mailto:jacc-dev@eclipse.org[jacc-dev@eclipse.org]
 :techID: Authorization
@@ -22,13 +22,13 @@
 // for the technology.  Used in config.inc.
 :TechnologyHomeEnv: JACC_HOME
 // Java SE version required.
-:SEversion: 8 (1.8) or 11
+:SEversion: 11 or 17
 :AntVersion: 1.10.0+
-:JakartaEEVersion: 9.1
+:JakartaEEVersion: 10
 :JavaTestVersion: 5.0
 :jteFileName: <TS_HOME>/bin/ts.jte
 :jtxFileName: <TS_HOME>/bin/ts.jtx
-:TCKPackageName: jakarta-authorization-tck-2.0.1.zip
+:TCKPackageName: jakarta-authorization-tck-2.1.0.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/signaturetest/jacc
 :singleTestDirectoryExample: <TS_HOME>/src/com/sun/ts/tests/jacc/ejb


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Change from `Authorization 2.0` to `Authorization 2.1` for https://github.com/jakartaee/specifications/pull/461