### PR TITLE
Refactor to avoid use of deprecated and removed HttpUtils.

### DIFF
--- a/src/com/sun/ts/tests/integration/sec/secbasicssl/basicSSL.jsp
+++ b/src/com/sun/ts/tests/integration/sec/secbasicssl/basicSSL.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2006, 2022 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,7 +38,7 @@
     // supported.
     //
     // Check that isSecure() returns true, indicating that this is indeed
-    // an SSL session.  Also, check that the request URL begins with https.
+    // an SSL session.  Also, check that the scheme is https.
     // We cannot do much more than this from here 
     // to guarantee that it is truly SSL, but this is a good failsafe.  
     String testName = "test_login_basic_over_ssl";
@@ -50,11 +51,9 @@
 	    fail = true;
 	}
 
-	String requestURL = HttpUtils.getRequestURL( request ).toString();
-	boolean isHttps = requestURL.toLowerCase().startsWith( "https" );
-	if( !isHttps ) {
+	if( !"https".equals(request.getScheme()) ) {
             out.println( testName + ": " + FAILSTRING +
-                " - must start with https." );
+                " - must use https." );
 
 	    fail = true;
 	}


### PR DESCRIPTION
**Fixes Issue**
#960

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
Remove use of HttpUtils. Replace with simpler call.

**Additional context**
I opted to refactor in a way that - broadly - resulted in code that did the same thing just with the newer API. However, there is another option.  The test is trying to confirm that TLS is being used. Rather than check `isSecure()` and `getScheme()` checking one or more of the TLS request attributes (`jakarta.servlet.request.cipher_suite`, `jakarta.servlet.request.ssl_session_id`) may give a better indication that TLS is being used. Probably not something to change this late in the release cycle but maybe worth creating an issue to change this for Jakarta EE 11.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
