### PR TITLE
Convert jsp to xhtml for ejblitejsf vehicle test runs - ejb30/lite/appexception

### DIFF
--- a/bin/xml/ts.vehicles.xml
+++ b/bin/xml/ts.vehicles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -436,7 +436,7 @@
                                            com/sun/ts/tests/ejb30/common/lite/*.class,
                                            com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                            ${harness.pkg.dir}/ServiceEETest*.class"
-                                 excludes="@{excludedfiles}"/>
+                                 excludes="@{excludedfiles}, ${pkg.dir}/**/JsfClient.class"/>
                     </ts.ejbjar>
                 </then>
                 </elseif>
@@ -472,13 +472,13 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}"
+                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/Client.class"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="faces-config.xml,beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="*.jar" prefix="WEB-INF/lib" excludes="ejbembed_vehicle*.jar"/>
                         <zipfileset dir="${basedir}" includes="*.tld" prefix="WEB-INF/tlds"/>
-                        <fileset dir="${src.dir}/${vehicle.pkg.dir}/@{vehicle}" includes="*.jsp"/>
+                        <fileset dir="${src.dir}/${vehicle.pkg.dir}/@{vehicle}" includes="*.xhtml"/>
                         <jsp-elements/>
                         <jar-elements/>
                     </ts.war>
@@ -529,7 +529,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}"
+                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/JsfClient.class"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="ejblitejsp.tld" prefix="WEB-INF/tlds"/>
@@ -653,7 +653,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}"
+                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/JsfClient.class"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="*.jar" prefix="WEB-INF/lib" excludes="ejbembed_vehicle*.jar"/>
@@ -782,7 +782,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}"
+                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/JsfClient.class"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="*.jar" prefix="WEB-INF/lib" excludes="ejbembed_vehicle*.jar"/>

--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -136,6 +136,18 @@ com/sun/ts/tests/jpa/core/StoredProcedureQuery/Client.java#executeUpdateTransact
 com/sun/ts/tests/jpa/ee/entityManager/Client.java#joinTransactionTransactionRequiredExceptionTest = pmservlet stateless3
 
 com/sun/ts/tests/ejb30/lite  = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/appexception/stateless/override/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/appexception/stateless/override/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/stateful/timeout = ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/tx/cm/singleton/webrw = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/lite/tx/cm/stateless/webrw = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp

--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsf/EJBLiteJSFVehicleRunner.java
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsf/EJBLiteJSFVehicleRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,6 @@ public class EJBLiteJSFVehicleRunner extends EJBLiteWebVehicleRunner {
 
   @Override
   protected String getServletPath(String vehicle) {
-    return "/faces/" + vehicle + "_vehicle.jsp";
+    return "/faces/" + vehicle + "_vehicle.xhtml";
   }
 }

--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml
@@ -1,4 +1,4 @@
-<%--
+<!--
 
     Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
@@ -14,17 +14,12 @@
 
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
---%>
+-->
 
-<%@page contentType="text/html"%>
-<%@taglib prefix="f" uri="jakarta.faces.core"%>
-<%@taglib prefix="h" uri="jakarta.faces.html"%>
-
-<html>
-    <head><title>${param['testName']}_from_ejblitejsf</title></head>
+<!DOCTYPE html>
+<html xmlns:f="jakarta.faces.core" xmlns:h="jakarta.faces.html">
+    <head><title>#{param['testName']}_from_ejblitejsf</title></head>
     <body>
-        <f:view>
-            <h:outputText value="#{client.status} #{client.reason}" />
-        </f:view>
+        #{client.status} #{client.reason}
     </body>
 </html>

--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,10 +18,6 @@
 -->
 
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.0" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
-    <context-param>
-        <param-name>jakarta.faces.CONFIG_FILES</param-name>
-        <param-value>/WEB-INF/faces-config.xml</param-value>
-    </context-param>
     
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>

--- a/src/com/sun/ts/tests/common/vehicle/ejblitejsf/faces-config.xml
+++ b/src/com/sun/ts/tests/common/vehicle/ejblitejsf/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,39 +21,5 @@
               xmlns="https://jakarta.ee/xml/ns/jakartaee" 
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
               xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd">
-    <managed-bean>
-        <managed-bean-name>client</managed-bean-name>
-        <managed-bean-class>@package@.Client</managed-bean-class>
-        <managed-bean-scope>request</managed-bean-scope>
-        <managed-property>
-            <description>name of the current test</description>
-            <property-name>testName</property-name>
-            <property-class>java.lang.String</property-class>
-            <value>#{param.testName}</value>
-        </managed-property>
-        <managed-property>
-            <description>module name, typically the base name of the WAR file</description>
-            <property-name>moduleName</property-name>
-            <property-class>java.lang.String</property-class>
-            <value>#{facesContext.externalContext.requestContextPath}</value>
-        </managed-property>
-        <managed-property>
-            <description>test status, either 'TEST PASSED. ' or 'TEST FAILED. '</description>
-            <property-name>status</property-name>
-            <property-class>java.lang.String</property-class>
-            <null-value/>
-        </managed-property>
-        <managed-property>
-            <description>why the test passed or failed, and exceptions if any</description>
-            <property-name>reason</property-name>
-            <property-class>java.lang.String</property-class>
-            <null-value/>
-        </managed-property>
-        <managed-property>
-            <description>if annotaion injection is supported.  Always true for jsf managed beans</description>
-            <property-name>injectionSupported</property-name>
-            <property-class>java.lang.Boolean</property-class>
-            <value>true</value>
-        </managed-property>
-    </managed-bean>
+
 </faces-config>

--- a/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteJsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteJsfClientBase.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.common.lite;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.naming.NamingException;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF;
+import com.sun.ts.tests.ejb30.common.helper.Helper;
+
+import jakarta.ejb.EJBException;
+import jakarta.ejb.embeddable.EJBContainer;
+
+public class EJBLiteJsfClientBase extends ServiceEETest
+    implements EJBLiteClientIF {
+
+  /////////////////////////////////////////////////////////////////////
+  // properties that may communicate with runtime environment (vehicles) and
+  // may be configured as managed-property
+  /////////////////////////////////////////////////////////////////////
+  /**
+   * status and reason indicate test status and may be configured as
+   * managed-property. They must be updated by subclass test clients, typically
+   * indirectly via invoking pass or fail method.
+   */
+  private String status;
+
+  private String reason;
+
+  /**
+   * the current testName (without _from_<vehicle> suffix). When running in
+   * vehicles, this field is initialized either by container (ejblitejsf
+   * vehicle) or by runner class. When running as standalone client, need to
+   * initialize it in setup method
+   */
+  @jakarta.inject.Inject 
+  @jakarta.faces.annotation.ManagedProperty("#{param.testName}")
+  private String testName;
+
+  /**
+   * If annotation injections on this class are supported in the runtime
+   * environment. For example, in a servlet vehicle, this class will be
+   * reflectively instantiated by the test app, and so any annotations will be
+   * ignored.
+   */
+  private Boolean injectionSupported;
+
+  /**
+   * used in portable global jndi name.
+   */
+  @jakarta.inject.Inject 
+  @jakarta.faces.annotation.ManagedProperty("#{facesContext.externalContext.requestContextPath}")
+  private String moduleName;
+
+  private EJBContainer container;
+
+  private javax.naming.Context context;
+
+  /**
+   * Maps the lookup name of EJB injections to their portable global jndi names.
+   */
+  private Map<String, String> jndiMapping = new HashMap<String, String>();
+
+  /**
+   * Additional embeddable ejb modules that are outside current classpath. Its
+   * getter method (protected) is intended for subclass to retrieve it. Its
+   * setter method is declared in EJBLiteClientIF interface.
+   */
+  private File[] additionalModules;
+
+  /////////////////////////////////////////////////////////////////////
+  // internal fields
+  /////////////////////////////////////////////////////////////////////
+  /** a StringBuilder for reason property */
+  private StringBuilder reasonBuffer;
+
+  /**
+   * number of times this class has been used to run test. When used as vehicle,
+   * instances of this class (actually its concrete subclass) are either not
+   * shared across multiple tests (e.g. ejblitejsf, ejblitejsp vehicles), or
+   * internal state must be reset (e.g., ejbliteservlet vehicle). This field
+   * must equal either 0 or 1.
+   */
+  private byte accessCount;
+
+  /**
+   * indicates this class is now inside a vehicle, e.g., jsf managed bean,
+   * servlet, servlet filter, etc. This field is not initialized util
+   * this.runTestInVehicle() is called.
+   */
+  private boolean inVehicle;
+
+  /////////////////////////////////////////////////////////////////////
+  // property accessors
+  /////////////////////////////////////////////////////////////////////
+
+  public String getTestName() {
+    return testName;
+  }
+
+  public void setTestName(String testName) {
+    this.testName = testName;
+  }
+
+  /**
+   * Typically invoked by containers or vehicles to run the actual test method.
+   * This method must not be invoked more than once for each test. Subclass test
+   * client must not invoke this method.
+   */
+  public String getStatus() {
+    if (accessCount == 0) {
+      runTestInVehicle();
+    } else {
+      passOrFail(false,
+          "This class has been incorrectly shared across multiple tests: ",
+          this.toString(), ", timesCalled=", String.valueOf(accessCount));
+    }
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  /**
+   * Similar to getStatus() method, and subclass test client should not invoke
+   * it. However, this method is used by both standalone and vehicle clients.
+   */
+  public String getReason() {
+    if (reason == null) {
+      if (reasonBuffer == null) {
+        reason = "WARNING: both reason and reasonBuffer is null.";
+      } else {
+        reason = reasonBuffer.toString();
+      }
+    }
+    return this.reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public String getModuleName() {
+    return moduleName;
+  }
+
+  public void setModuleName(String mn) {
+    if (mn.startsWith("/")) {
+      this.moduleName = mn.substring(1);
+    } else {
+      this.moduleName = mn;
+    }
+  }
+
+  public EJBContainer getContainer() {
+    return container;
+  }
+
+  public void setContainer(EJBContainer container) {
+    this.container = container;
+  }
+
+  public javax.naming.Context getContext() {
+    if (context != null) {
+      return context;
+    }
+    javax.naming.Context ctx = null;
+    try {
+      ctx = new javax.naming.InitialContext();
+    } catch (NamingException e) {
+      throw new RuntimeException(e);
+    }
+    return ctx;
+  }
+
+  public void setContext(javax.naming.Context context) {
+    this.context = context;
+  }
+
+  /////////////////////////////////////////////////////////////////////
+  // harness-required methods
+  /////////////////////////////////////////////////////////////////////
+  /**
+   * setup method is invoked by harness prior to each test method. If
+   * getInjectionSupported() returns false, need to initialize those injected
+   * fields here. When running inside vehicles, setup(null, null) are called
+   * (see runTestInVehicle method)
+   */
+  public void setup(String[] args, Properties p) {
+    if (!inVehicle && (testName == null) && p != null) {
+      String s = p.getProperty("testName"); // strip off _from_<vehicle>
+      testName = s.substring(0, s.indexOf("_from_"));
+      String m = p.getProperty("vehicle_archive_name");
+      setModuleName(m);
+      Helper.getLogger()
+          .fine("testName from test properties: " + s
+              + ", setting testName field to the short name: " + testName
+              + ". set moduleName to vehicle_archive_name property: " + m);
+    }
+  }
+
+  /**
+   * cleanup method is invoked by harness after each test method. For vehicles,
+   * this methos is invoked only by servlet filter.
+   */
+  public void cleanup() {
+    if (!inVehicle) {
+      Helper.getLogger()
+          .info("The following events occurred before test passed or failed: "
+              + getReason());
+    }
+    nuke();
+  }
+
+  /////////////////////////////////////////////////////////////////////
+  // EJBLiteClientIF methods
+  /////////////////////////////////////////////////////////////////////
+  public void runTestInVehicle() {
+    inVehicle = true;
+    try {
+      setup(null, null);
+      Method testMethod = getClass().getMethod(testName);
+      testMethod.invoke(this, (Object[]) null);
+      passOrFail(true);
+    } catch (NoSuchMethodException e) {
+      passOrFail(false, "Failed to get test method " + testName, e.toString());
+    } catch (IllegalAccessException e) {
+      passOrFail(false,
+          "Failed to access test method (is it public?) " + testName,
+          e.toString());
+    } catch (InvocationTargetException e) {
+      // If it's EJBException with a cause, just include the cause in the
+      // message
+      String msg = "Failed with exception ";
+      Throwable root = e.getCause();
+      if (root == null) {
+        root = e;
+      } else if (root instanceof EJBException) {
+        Throwable cause2 = root.getCause();
+        if (cause2 != null) {
+          root = cause2;
+          msg = "Failed with EJBException caused by ";
+        }
+      }
+      passOrFail(false, msg, TestUtil.printStackTraceToString(root));
+    } catch (Exception e) {
+      passOrFail(false, "Unexpected exception for test " + testName,
+          TestUtil.printStackTraceToString(e));
+    } // finally { skip cleanup
+  }
+
+  /**
+   * When running inside a vehicle, the vehicle runner class should call
+   * setInjectionSupported(true|false) to explicitly initialize it. Its default
+   * value is null. For ejblitejsf vehicle, it is set in faces-config.xml as a
+   * managed-property. For standalone client, injectionSupported field is not
+   * initialized. But if ejb spec requires injection support, we need to
+   * initialize it from a property in ts.jte.
+   */
+  public Boolean getInjectionSupported() {
+    return injectionSupported;
+  }
+
+  public void setInjectionSupported(Boolean injectionSupported) {
+    this.injectionSupported = injectionSupported;
+  }
+
+  public Map<String, String> getJndiMapping() {
+    return jndiMapping;
+  }
+
+  public void setContextClassLoader() {
+  }
+
+  public Map<String, Object> getContainerInitProperties() {
+    return null;
+  }
+
+  public void setAdditionalModules(File[] additionalModules) {
+    this.additionalModules = additionalModules;
+  }
+
+  /////////////////////////////////////////////////////////////////////
+  // convenience methods
+  /////////////////////////////////////////////////////////////////////
+
+  /**
+   * In embeddable usage, only the portable global jndi name lookup is
+   * supported. In JavaEE or web environment, the following lookupName format
+   * can be used:
+   * 
+   * x will be expanded to java:comp/env/x java:comp/env/x
+   * java:global/app-name/module-name/bean-name!FQN
+   * java:app/module-name/bean-name!FQN java:module/bean-name!FQN
+   * 
+   * beanName and beanInterface is to be used in embed mode to create a
+   * java:global name
+   */
+  protected Object lookup(String lookupName, String beanName,
+      Class<?> beanInterface) {
+    String nameNormalized = lookupName;
+
+    if (container == null) {
+      // in JavaEE or Web environment
+      if (!lookupName.startsWith("java:")) {
+        nameNormalized = JAVA_COMP_ENV_PREFIX + lookupName;
+      }
+    } else {
+      // embaddable usage, only look up with portable global jndi name
+      if (!lookupName.startsWith(JAVA_GLOBAL_PREFIX)) {
+        if (beanName == null) {
+          // type-level @EJB injections are stored in jndiMapping
+          String s = getJndiMapping().get(lookupName);
+          if (s == null) {
+            s = getJndiMapping().get(JAVA_COMP_ENV_PREFIX + lookupName);
+          }
+
+          if (s == null) {
+            throw new RuntimeException(String.format(
+                "Lookup name (%s) does not start with %s, beanName is %s, and not in jndiMapping %s",
+                lookupName, JAVA_GLOBAL_PREFIX, beanName, getJndiMapping()));
+          }
+          nameNormalized = s;
+          Helper.getLogger()
+              .info("Retrieved the global jndi name from jndiMapping: "
+                  + lookupName + " : " + nameNormalized);
+        } else {
+          nameNormalized = JAVA_GLOBAL_PREFIX + EJBEMBED_JAR_NAME_BASE + "/"
+              + beanName;
+          if (beanInterface != null) {
+            nameNormalized = nameNormalized + "!" + beanInterface.getName();
+          }
+        }
+      }
+    }
+    try {
+      return getContext().lookup(nameNormalized);
+    } catch (javax.naming.NamingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected File[] getAdditionalModules() {
+    return additionalModules;
+  }
+
+  protected StringBuilder getReasonBuffer() {
+    if (reasonBuffer == null) {
+      reasonBuffer = new StringBuilder(); // single-threaded access
+    }
+    return reasonBuffer;
+  }
+
+  protected void appendReason(Object... oo) {
+    for (Object o : oo) {
+      getReasonBuffer().append(o).append(System.getProperty("line.separator"));
+    }
+  }
+
+  protected void assertEquals(final String messagePrefix, final Object expected,
+      final Object actual) throws RuntimeException {
+    Helper.assertEquals(messagePrefix, expected, actual, getReasonBuffer());
+  }
+
+  protected void assertNotEquals(final String messagePrefix,
+      final Object expected, final Object actual) throws RuntimeException {
+    Helper.assertNotEquals(messagePrefix, expected, actual, getReasonBuffer());
+  }
+
+  protected void assertGreaterThan(final String messagePrefix, long arg1,
+      long arg2) throws RuntimeException {
+    Helper.assertGreaterThan(messagePrefix, arg1, arg2, getReasonBuffer());
+  }
+
+  /**
+   * A central place to clear up state. Note that we cannot call it in cleanup()
+   * since vehicle tests (at least jsf) test status is written to jsp page after
+   * cleanup method. We cannot call it in setup either, since in vehicle tests
+   * containers inject to these fields upon instantiate and we don't want to
+   * remove these field values. In vehicle tests this test is instantiated once
+   * for each test, and so it should not matter if we leave the state behind.
+   * When running in standalone, this test client should also be instantiated
+   * once per test.
+   */
+  private void nuke() {
+    accessCount = 0;
+    injectionSupported = null;
+    status = null;
+    reason = null;
+    testName = null;
+    inVehicle = false;
+    reasonBuffer = null;
+
+    moduleName = null;
+    container = null;
+    context = null;
+    jndiMapping = null;
+    additionalModules = null;
+  }
+
+  private void passOrFail(boolean passOrFail, String... why) {
+    this.status = (passOrFail ? TEST_PASSED : TEST_FAILED) + "testName="
+        + testName;
+    appendReason((Object[]) why);
+    if (reasonBuffer != null) {
+      this.reason = reasonBuffer.toString();
+    }
+    this.accessCount++;
+  }
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/common/JsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/common/JsfClientBase.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.appexception.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.ts.tests.ejb30.common.appexception.AppExceptionIF;
+import com.sun.ts.tests.ejb30.common.appexception.AtCheckedAppException;
+import com.sun.ts.tests.ejb30.common.appexception.AtCheckedRollbackAppException;
+import com.sun.ts.tests.ejb30.common.appexception.AtUncheckedAppException;
+import com.sun.ts.tests.ejb30.common.appexception.AtUncheckedRollbackAppException;
+import com.sun.ts.tests.ejb30.common.appexception.CheckedAppException;
+import com.sun.ts.tests.ejb30.common.appexception.CheckedRollbackAppException;
+import com.sun.ts.tests.ejb30.common.appexception.CommonIF;
+import com.sun.ts.tests.ejb30.common.appexception.RollbackIF;
+import com.sun.ts.tests.ejb30.common.appexception.UncheckedAppException;
+import com.sun.ts.tests.ejb30.common.appexception.UncheckedRollbackAppException;
+import com.sun.ts.tests.ejb30.common.helper.TestFailedException;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.EJB;
+
+abstract public class JsfClientBase extends EJBLiteJsfClientBase {
+  @EJB(description = "It should map to <ejb-ref>/<description> xml element.", beanName = "AppExceptionBean")
+  protected AppExceptionIF bean;
+
+  @EJB(beanName = "RollbackBean")
+  protected RollbackIF rollbackBean;
+
+  // injected in subclass
+  protected AppExceptionIF noInterfaceBean;
+
+  protected List<CommonIF> appExceptionBeans = new ArrayList<CommonIF>();
+
+  abstract protected void setNoInterfaceBean(AppExceptionIF noInterfaceBean);
+
+  @SuppressWarnings("unused")
+  @PostConstruct
+  private void postConstruct() {
+    appExceptionBeans.add(bean);
+    appExceptionBeans.add(noInterfaceBean);
+  }
+
+  // tests used by both */appexception/annotated/ and */appexception/override/
+
+  /*
+   * testName: atCheckedRollbackAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atCheckedRollbackAppExceptionTest() throws TestFailedException {
+    try {
+      rollbackBean.atCheckedRollbackAppException();
+    } catch (AtCheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: atCheckedRollbackAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atCheckedRollbackAppExceptionTestLocal()
+      throws TestFailedException {
+    try {
+      rollbackBean.atCheckedRollbackAppExceptionLocal();
+    } catch (AtCheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: atUncheckedRollbackAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atUncheckedRollbackAppExceptionTest() throws TestFailedException {
+    try {
+      rollbackBean.atUncheckedRollbackAppException();
+    } catch (AtUncheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: atUncheckedRollbackAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atUncheckedRollbackAppExceptionTestLocal()
+      throws TestFailedException {
+    try {
+      rollbackBean.atUncheckedRollbackAppExceptionLocal();
+    } catch (AtUncheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: checkedAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void checkedAppExceptionTest() throws TestFailedException {
+    for (CommonIF b : appExceptionBeans) {
+      try {
+        b.checkedAppException();
+        throw new TestFailedException(
+            "Did not get expected exception: CheckedAppException");
+      } catch (CheckedAppException e) {
+        appendReason("Got expected exception: ", e);
+      }
+    }
+  }
+
+  /*
+   * testName: checkedAppExceptionTest2
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void checkedAppExceptionTest2() throws TestFailedException {
+    try {
+      rollbackBean.checkedAppException();
+    } catch (CheckedAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: checkedAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void checkedAppExceptionTestLocal() throws TestFailedException {
+    try {
+      rollbackBean.checkedAppExceptionLocal();
+    } catch (CheckedAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: checkedRollbackAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void checkedRollbackAppExceptionTest() throws TestFailedException {
+    try {
+      rollbackBean.checkedRollbackAppException();
+    } catch (CheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: checkedRollbackAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void checkedRollbackAppExceptionTestLocal()
+      throws TestFailedException {
+    try {
+      rollbackBean.checkedRollbackAppExceptionLocal();
+    } catch (CheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  // tests used by */appexception/annotated/
+
+  /*
+   * testName: atCheckedAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atCheckedAppExceptionTest() throws TestFailedException {
+    for (CommonIF b : appExceptionBeans) {
+      try {
+        b.atCheckedAppException();
+        throw new TestFailedException(
+            "Did not get expected exception: AtCheckedAppException");
+      } catch (AtCheckedAppException e) {
+        appendReason("Got expected exception: ", e);
+      }
+    }
+  }
+
+  /*
+   * testName: atCheckedAppExceptionTest2
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atCheckedAppExceptionTest2() throws TestFailedException {
+    try {
+      rollbackBean.atCheckedAppException();
+    } catch (AtCheckedAppException e) {
+      throw new TestFailedException("Unexpected exception", e);
+    }
+  }
+
+  /*
+   * testName: atCheckedAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atCheckedAppExceptionTestLocal() throws TestFailedException {
+    try {
+      rollbackBean.atCheckedAppExceptionLocal();
+    } catch (AtCheckedAppException e) {
+      throw new TestFailedException("Unexpected exception", e);
+    }
+  }
+
+  /*
+   * testName: atUncheckedAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atUncheckedAppExceptionTest() throws TestFailedException {
+    for (CommonIF b : appExceptionBeans) {
+      try {
+        b.atUncheckedAppException();
+        throw new TestFailedException(
+            "Did not get expected exception: AtUncheckedAppException");
+      } catch (AtUncheckedAppException e) {
+        appendReason("Got expected exception: ", e);
+      }
+    }
+  }
+
+  /*
+   * testName: atUncheckedAppExceptionTest2
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atUncheckedAppExceptionTest2() throws TestFailedException {
+    try {
+      rollbackBean.atUncheckedAppException();
+    } catch (AtUncheckedAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: atUncheckedAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void atUncheckedAppExceptionTestLocal() throws TestFailedException {
+    try {
+      rollbackBean.atUncheckedAppExceptionLocal();
+    } catch (AtUncheckedAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  // tests used by */appexception/override/
+
+  /*
+   * testName: uncheckedAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void uncheckedAppExceptionTest() throws TestFailedException {
+    try {
+      bean.uncheckedAppException();
+      throw new TestFailedException(
+          "Did not get expected exception: UncheckedAppException");
+    } catch (UncheckedAppException e) {
+      appendReason("Got expected exception: ", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedAppExceptionTest2
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void uncheckedAppExceptionTest2() throws TestFailedException {
+    try {
+      rollbackBean.uncheckedAppException();
+    } catch (UncheckedAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void uncheckedAppExceptionTestLocal() throws TestFailedException {
+    try {
+      rollbackBean.uncheckedAppExceptionLocal();
+    } catch (UncheckedAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedRollbackAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void uncheckedRollbackAppExceptionTest() throws TestFailedException {
+    try {
+      rollbackBean.uncheckedRollbackAppException();
+    } catch (UncheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedRollbackAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void uncheckedRollbackAppExceptionTestLocal()
+      throws TestFailedException {
+    try {
+      rollbackBean.uncheckedRollbackAppExceptionLocal();
+    } catch (UncheckedRollbackAppException e) {
+      throw new TestFailedException("Unexpected exception:", e);
+    }
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/JsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/JsfClientBase.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.appexception.common.inheritance;
+
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBException;
+
+/**
+ * Exception hierarchy used in this test client:
+ *
+ * RuntimeException AtUncheckedAppException @ApplicationException() Exception1
+ * No annotation Exception2 No annotation Exception3
+ * <application-exception>(inherited=false) Exception4 a system exception
+ * Exception5 a system exception Exception6
+ * <application-exception>(inherited=true) Exception7 No annotation
+ */
+abstract public class JsfClientBase extends EJBLiteJsfClientBase {
+  protected static final String BEAN_LOOKUP_NAME = "ejb/InheritanceBean";
+
+  @EJB(name = BEAN_LOOKUP_NAME, beanName = "InheritanceBean")
+  private InheritanceIF bean;
+
+  /**
+   * For stateful and stateless bean, a system exception in previous test method
+   * may cause the bean instance to be discarded, and the next test (if in the
+   * same VM) may get NoSuchObectLocalException. Stateful and Stateless
+   * directory can override this method to always look up to ensure a new
+   * reference is used in each test.
+   */
+  protected InheritanceIF getBean() {
+    return bean;
+  }
+
+  /*
+   * testName: uncheckedAppException1
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedAppException1() {
+    try {
+      getBean().uncheckedAppException1();
+      throw new RuntimeException("Expecting Exception1, but got none.");
+    } catch (Exception1 e) {
+      appendReason("Got the expected ", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedAppException2
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedAppException2() {
+    try {
+      getBean().uncheckedAppException2();
+      throw new RuntimeException("Expecting Exception2, but got none.");
+    } catch (Exception2 e) {
+      appendReason("Got the expected ", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedAppException3
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedAppException3() {
+    try {
+      getBean().uncheckedAppException3();
+      throw new RuntimeException("Expecting Exception3, but got none.");
+    } catch (Exception3 e) {
+      appendReason("Got the expected ", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedSystemException4
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedSystemException4() {
+    try {
+      getBean().uncheckedSystemException4();
+      throw new RuntimeException("Expecting EJBException, but got none.");
+    } catch (EJBException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception4) {
+        appendReason("Got expected EJBException and Exception4.");
+      } else {
+        throw new RuntimeException(
+            "Expecting EJBException with Exception4, but got " + cause);
+      }
+    }
+  }
+
+  /*
+   * testName: uncheckedSystemException5
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedSystemException5() {
+    try {
+      getBean().uncheckedSystemException5();
+      throw new RuntimeException("Expecting EJBException, but got none.");
+    } catch (EJBException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception5) {
+        appendReason("Got expected EJBException and Exception5.");
+      } else {
+        throw new RuntimeException(
+            "Expecting EJBException with Exception5, but got " + cause);
+      }
+    }
+  }
+
+  /*
+   * testName: uncheckedAppException6
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedAppException6() {
+    try {
+      getBean().uncheckedAppException6();
+      throw new RuntimeException("Expecting Exception6, but got none.");
+    } catch (Exception6 e) {
+      appendReason("Got the expected ", e);
+    }
+  }
+
+  /*
+   * testName: uncheckedAppException7
+   * 
+   * @test_Strategy:
+   */
+  public void uncheckedAppException7() {
+    try {
+      getBean().uncheckedAppException7();
+      throw new RuntimeException("Expecting Exception7, but got none.");
+    } catch (Exception7 e) {
+      appendReason("Got the expected ", e);
+    }
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,17 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
 package com.sun.ts.tests.ejb30.lite.appexception.singleton.annotated;
 
 import com.sun.ts.tests.ejb30.common.appexception.AppExceptionIF;
 
 import jakarta.ejb.EJB;
+import java.io.Serializable;
 
-public class Client
-    extends com.sun.ts.tests.ejb30.lite.appexception.common.ClientBase {  
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient
+    extends com.sun.ts.tests.ejb30.lite.appexception.common.JsfClientBase implements Serializable {
+  
+  private static final long serialVersionUID = -2564031884412676327L;
+  
   @Override
   @EJB(beanInterface = NoInterfaceAppExceptionBean.class, beanName = "NoInterfaceAppExceptionBean")
   protected void setNoInterfaceBean(AppExceptionIF noInterfaceBean) {

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/annotated/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,7 +39,8 @@ com/sun/ts/tests/ejb30/common/appexception/RollbackIF.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedAppException.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedRollbackAppException.class,
 com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
-com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class
+com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/appexception/common/JsfClientBase.class
 	">
         </ts.vehicles>
     </target>

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,14 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
+
 package com.sun.ts.tests.ejb30.lite.appexception.singleton.inheritance;
 
+import java.io.Serializable;
 
-public class Client extends
-    com.sun.ts.tests.ejb30.lite.appexception.common.inheritance.ClientBase {
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.appexception.common.inheritance.JsfClientBase implements Serializable {
+
+  private static final long serialVersionUID = -2564671884412676327L;
+
 
   /*
    * @testName: uncheckedAppException1

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/singleton/inheritance/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,8 @@ com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/Exception6.class,
 com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/Exception7.class,
 com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/InheritanceIF.class,
 com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/InheritanceBeanBase.class,
-com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/ClientBase.class
+com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/JsfClientBase.class
 	">
         </ts.vehicles>
     </target>

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,17 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
-package com.sun.ts.tests.ejb30.lite.appexception.singleton.annotated;
+package com.sun.ts.tests.ejb30.lite.appexception.stateful.annotated;
 
 import com.sun.ts.tests.ejb30.common.appexception.AppExceptionIF;
 
 import jakarta.ejb.EJB;
+import java.io.Serializable;
 
-public class Client
-    extends com.sun.ts.tests.ejb30.lite.appexception.common.ClientBase {  
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient
+    extends com.sun.ts.tests.ejb30.lite.appexception.common.JsfClientBase implements Serializable {
+  
+  private static final long serialVersionUID = -2564031884412600327L;
+
   @Override
   @EJB(beanInterface = NoInterfaceAppExceptionBean.class, beanName = "NoInterfaceAppExceptionBean")
   protected void setNoInterfaceBean(AppExceptionIF noInterfaceBean) {

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,7 +39,8 @@ com/sun/ts/tests/ejb30/common/appexception/RollbackIF.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedAppException.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedRollbackAppException.class,
 com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
-com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class
+com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/appexception/common/JsfClientBase.class
 	">
         </ts.vehicles>
     </target>

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,14 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
-package com.sun.ts.tests.ejb30.lite.appexception.singleton.inheritance;
+package com.sun.ts.tests.ejb30.lite.appexception.stateful.inheritance;
 
+import com.sun.ts.tests.ejb30.lite.appexception.common.inheritance.InheritanceIF;
+import java.io.Serializable;
 
-public class Client extends
-    com.sun.ts.tests.ejb30.lite.appexception.common.inheritance.ClientBase {
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.appexception.common.inheritance.JsfClientBase implements Serializable {
+  
+  private static final long serialVersionUID = -2564031884423676327L;
+
+  @Override
+  protected InheritanceIF getBean() {
+    return (InheritanceIF) lookup(BEAN_LOOKUP_NAME, "InheritanceBean", null);
+  }
 
   /*
    * @testName: uncheckedAppException1

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,6 +36,7 @@ com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/Exception7.class,
 com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/InheritanceIF.class,
 com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/InheritanceBeanBase.class,
 com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/appexception/common/inheritance/JsfClientBase.class,
 com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class
 	">
         </ts.vehicles>

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,17 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
-package com.sun.ts.tests.ejb30.lite.appexception.singleton.annotated;
+package com.sun.ts.tests.ejb30.lite.appexception.stateless.annotated;
 
 import com.sun.ts.tests.ejb30.common.appexception.AppExceptionIF;
 
 import jakarta.ejb.EJB;
+import java.io.Serializable;
 
-public class Client
-    extends com.sun.ts.tests.ejb30.lite.appexception.common.ClientBase {  
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient
+    extends com.sun.ts.tests.ejb30.lite.appexception.common.JsfClientBase implements Serializable {
+  
+  private static final long serialVersionUID = -2564031114412676327L;
+
+
   @Override
   @EJB(beanInterface = NoInterfaceAppExceptionBean.class, beanName = "NoInterfaceAppExceptionBean")
   protected void setNoInterfaceBean(AppExceptionIF noInterfaceBean) {

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,7 +39,8 @@ com/sun/ts/tests/ejb30/common/appexception/RollbackIF.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedAppException.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedRollbackAppException.class,
 com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
-com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class
+com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/appexception/common/JsfClientBase.class
 	">
         </ts.vehicles>
     </target>

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,23 +14,53 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
-package com.sun.ts.tests.ejb30.lite.appexception.singleton.annotated;
+package com.sun.ts.tests.ejb30.lite.appexception.stateless.override;
 
 import com.sun.ts.tests.ejb30.common.appexception.AppExceptionIF;
 
 import jakarta.ejb.EJB;
+import java.io.Serializable;
 
-public class Client
-    extends com.sun.ts.tests.ejb30.lite.appexception.common.ClientBase {  
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient
+    extends com.sun.ts.tests.ejb30.lite.appexception.common.JsfClientBase implements Serializable {
+  
+  private static final long serialVersionUID = -2564031884412336327L;
+
+
   @Override
   @EJB(beanInterface = NoInterfaceAppExceptionBean.class, beanName = "NoInterfaceAppExceptionBean")
   protected void setNoInterfaceBean(AppExceptionIF noInterfaceBean) {
     this.noInterfaceBean = noInterfaceBean;
   }
 
+  // tests used by both */appexception/annotated/ and */appexception/override/
+
+  /*
+   * @testName: atCheckedRollbackAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  /*
+   * @testName: atCheckedRollbackAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
+  /*
+   * @testName: atUncheckedRollbackAppExceptionTest
+   * 
+   * @test_Strategy:
+   *
+   */
+  /*
+   * @testName: atUncheckedRollbackAppExceptionTestLocal
+   * 
+   * @test_Strategy:
+   *
+   */
   /*
    * @testName: checkedAppExceptionTest
    * 
@@ -61,62 +91,35 @@ public class Client
    * @test_Strategy:
    *
    */
+
+  // tests used by */appexception/override/
+
   /*
-   * @testName: atCheckedAppExceptionTest
+   * @testName: uncheckedAppExceptionTest
    * 
    * @test_Strategy:
    *
    */
   /*
-   * @testName: atCheckedAppExceptionTest2
+   * @testName: uncheckedAppExceptionTest2
    * 
    * @test_Strategy:
    *
    */
   /*
-   * @testName: atCheckedAppExceptionTestLocal
+   * @testName: uncheckedAppExceptionTestLocal
    * 
    * @test_Strategy:
    *
    */
   /*
-   * @testName: atUncheckedAppExceptionTest
+   * @testName: uncheckedRollbackAppExceptionTest
    * 
    * @test_Strategy:
    *
    */
   /*
-   * @testName: atUncheckedAppExceptionTest2
-   * 
-   * @test_Strategy:
-   *
-   */
-  /*
-   * @testName: atUncheckedAppExceptionTestLocal
-   * 
-   * @test_Strategy:
-   *
-   */
-  /*
-   * @testName: atCheckedRollbackAppExceptionTest
-   * 
-   * @test_Strategy:
-   *
-   */
-  /*
-   * @testName: atCheckedRollbackAppExceptionTestLocal
-   * 
-   * @test_Strategy:
-   *
-   */
-  /*
-   * @testName: atUncheckedRollbackAppExceptionTest
-   * 
-   * @test_Strategy:
-   *
-   */
-  /*
-   * @testName: atUncheckedRollbackAppExceptionTestLocal
+   * @testName: uncheckedRollbackAppExceptionTestLocal
    * 
    * @test_Strategy:
    *

--- a/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/appexception/stateless/override/build.xml
@@ -40,7 +40,8 @@ com/sun/ts/tests/ejb30/common/appexception/RollbackIF.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedAppException.class,
 com/sun/ts/tests/ejb30/common/appexception/UncheckedRollbackAppException.class,
 com/sun/ts/tests/ejb30/common/helper/TestFailedException.class,
-com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class
+com/sun/ts/tests/ejb30/lite/appexception/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/appexception/common/JsfClientBase.class
 	">
         </ts.vehicles>
     </target>


### PR DESCRIPTION
**Describe the change**
Initial change to fix the ejb30/lite/appexception tests in ejblitejsf vehicle by converting .jsp to .xhtml. 

The change does fixes the failures in ejblitejsf vehicle but causes failures in ejbliteservlet & ejbliteservlet2 vehicles. 

CC @scottmarlow

PS : The changes in Client files with added annotation of `@jakarta.inject.Named` & `@jakarta.enterprise.context.RequestScoped` is causing test failures in ejbliteservlet & ejbliteservlet2 vehicles. 
The ejbliteservlet & ejbliteservlet2 vehicles uses jsp too (see https://github.com/eclipse-ee4j/jakartaee-tck/tree/master/src/com/sun/ts/tests/common/vehicle/ejbliteservlet2). 

@arjantijms Is there a way to use the same Client (eg. [src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/Client.java](https://github.com/eclipse-ee4j/jakartaee-tck/blob/master/src/com/sun/ts/tests/ejb30/lite/appexception/stateful/annotated/Client.java) ) with annotations `@jakarta.inject.Named` & `@jakarta.enterprise.context.RequestScoped` for ejbliteservlet & ejbliteservlet2 vehicles that has jsp.

Is using a separate client (say JsfClient) for  ejblitejsf vehicle better? 


Update : The latest changes addresses all failures in ejb30/lite/appexception using the recommendations provided.
There are more changes required to fix the same failures in other suites by having separate Clients for ejblitejsf vehicle tests. Those will be addressed in subsequent PRs.