### PR TITLE
Update ts.jte settings when running with Java SE 17 to add --add-opens

### DIFF
--- a/bin/xml/ts.top.import.xml
+++ b/bin/xml/ts.top.import.xml
@@ -39,6 +39,14 @@
     </condition>
     <property name="noSecurityManager" value="false"/>
 
+    <if>
+        <isset property="env.JVMOPTS_RUNTESTCOMMAND"/>
+        <then>
+            <property name="JVMOPTS_RUNTESTCOMMAND"
+                        value="${env.JVMOPTS_RUNTESTCOMMAND}"/>
+        </then>
+    </if>
+
     <!-- Set the archives to deploy - default to wars-->
     <target name="setup.archive.set">
         <fileset dir="${dist.dir}/${pkg.dir}" id="deploy.vi.archive.set">

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -162,6 +162,13 @@ ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwo
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} stop-domain
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
 
+if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+   echo "enabling GlassFish --add-opens options for JDK17"
+   export JVMOPTS_RUNTESTCOMMAND="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
+   echo "will use $JVMOPTS_RUNTESTCOMMAND "
+fi
+
+
 # Change default ports for RI
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --interactive=false  --user admin --passwordfile ${ADMIN_PASSWORD_FILE} delete-jvm-options -Dosgi.shell.telnet.port=6666
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Dosgi.shell.telnet.port=6667

--- a/install/jakartaee/bin/ts.jte
+++ b/install/jakartaee/bin/ts.jte
@@ -206,8 +206,6 @@ orb.port=3699
 #  options to pass when running ExecTSTestCmd command.
 #  This is a convenience intended for adding Java SE 17+ options.
 ########################################################################
-<property environment="env"/>
-<property name="JVMOPTS_RUNTESTCOMMAND" value="${env.JVMOPTS_RUNTESTCOMMAND}"/>
 
 ########################################################################
 ## Settings for Sun RI Java EE Implementation

--- a/install/jakartaee/bin/ts.jte
+++ b/install/jakartaee/bin/ts.jte
@@ -202,6 +202,12 @@ orb.host=localhost
 orb.port=3699
 
 ########################################################################
+## Environment variable JVMOPTS_RUNTESTCOMMAND may be set to JVM 
+#  options to pass when running ExecTSTestCmd command.
+#  This is a convenience intended for adding Java SE 17+ options.
+########################################################################
+
+########################################################################
 ## Settings for Sun RI Java EE Implementation
 # @javaee.home.ri The location of the RI.
 # @orb.host       Hostname of the machine running the RI.
@@ -1092,6 +1098,7 @@ s1as.classpathsuffix=${javaee.home}/lib/tsprovider.jar
 #                        test directories which make use of this command
 #                        are servlet and jsp.
 ########################################################################
+
 command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         CLASSPATH=${ts.harness.classpath}${pathsep}${ts.home}/classes${pathsep}\
         ${JAVA_HOME}/../lib/tools.jar${pathsep}\
@@ -1125,6 +1132,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         SYSTEMROOT=${SYSTEMROOT} \
         PATH="${javaee.home}/nativelib" \
         ${JAVA_HOME}/bin/java \
+        ${JVMOPTS_RUNTESTCOMMAND} \
         -Xss2048k \
         -Dcts.tmp=$harness.temp.directory \
         -Djava.protocol.handler.pkgs=javax.net.ssl \
@@ -1163,6 +1171,7 @@ command.testExecuteAppClient= \
         APPCPATH=${ts.home}/lib/tsharness.jar${pathsep}${ts.home}/lib/cts.jar${pathsep}${ts.home}/lib/glassfishporting.jar${pathsep}${javaee.home}/lib/jpa_alternate_provider.jar${pathsep}${ts.home}/lib/tssv.jar${pathsep}${javaee.home}/modules/weld-osgi-bundle.jar${pathsep}${javaee.home}/modules/jakarta.enterprise.cdi-api.jar \
         TZ=${tz} \
         ${JAVA_HOME}/bin/java \
+        ${JVMOPTS_RUNTESTCOMMAND} \
         -Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader  \
         -Djava.security.policy=${javaee.home}/lib/appclient/client.policy \
         -Dcts.tmp=$harness.temp.directory \
@@ -1233,6 +1242,7 @@ command.testExecuteEjbEmbed=com.sun.ts.lib.harness.ExecTSTestCmd \
         windir=${windir} \
         SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
+        ${JVMOPTS_RUNTESTCOMMAND} \
         -Dcts.tmp=$harness.temp.directory \
         -Djava.util.logging.config.file=${javaee.home}/domains/domain1/config/logging.properties \
         -Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds} \
@@ -1252,6 +1262,7 @@ command.testExecuteAppClient2= \
         APPCPATH=${ts.home}/lib/tsharness.jar${pathsep}${ts.home}/lib/cts.jar${pathsep}${ts.home}/lib/glassfishporting.jar${pathsep}${ts.home}/lib/riinterceptors.jar \
 	TZ=${tz} \
         ${RI_JAVA_HOME}/bin/java \
+        ${JVMOPTS_RUNTESTCOMMAND} \
         -Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader \
         -Djava.security.policy=${javaee.home.ri}/lib/appclient/client.policy \
         -Dcts.tmp=$harness.temp.directory \
@@ -1315,6 +1326,7 @@ command.testExecute2=com.sun.ts.lib.harness.ExecTSTestCmd \
         SYSTEMROOT=${SYSTEMROOT} \
         PATH="${javaee.home}/nativelib" \
         ${RI_JAVA_HOME}/bin/java \
+        ${JVMOPTS_RUNTESTCOMMAND} \
         -Dcts.tmp=$harness.temp.directory \
         -Djava.protocol.handler.pkgs=javax.net.ssl \
         -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \

--- a/install/jakartaee/bin/ts.jte
+++ b/install/jakartaee/bin/ts.jte
@@ -206,6 +206,8 @@ orb.port=3699
 #  options to pass when running ExecTSTestCmd command.
 #  This is a convenience intended for adding Java SE 17+ options.
 ########################################################################
+<property environment="env"/>
+<property name="JVMOPTS_RUNTESTCOMMAND" value="${env.JVMOPTS_RUNTESTCOMMAND}"/>
 
 ########################################################################
 ## Settings for Sun RI Java EE Implementation


### PR DESCRIPTION
**Fixes Issue**

(https://github.com/eclipse-ee4j/jakartaee-tck/issues/959) except for the `ejbembed` + `ejblitejsf` tests as per https://github.com/eclipse-ee4j/jakartaee-tck/issues/959#issuecomment-1121404341

**Describe the change**

Introduce JVMOPTS_RUNTESTCOMMAND system environment variable that can be referenced in ts.jte as needed to pass in additional JDK 17+ options as needed.

**Additional context**

(updated) https://github.com/eclipse-ee4j/jakartaee-tck/issues/962 may address test failures that we see with `ejblitejsf` (ViewHandlingStrategyNotFoundException).

For the `ejbembed` failures, it doesn't seem like the [JVMOPTS_RUNTESTCOMMAND change was used](tests as per https://github.com/eclipse-ee4j/jakartaee-tck/issues/959#issuecomment-1121404341).  From my local test output:
```
   [runcts] OUT => [javatest.batch] 05-09-2022 13:16:48:  Harness - keywords (to be passed to tests) set to:  all
   [runcts] OUT => [javatest.batch] 05-09-2022 13:16:48:  Harness - sClassPathFromExecProps = /tmp/ee10/jakartaeetck/bin/xml/../../dist/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/ejbembed_vehicle_ejb.jar
   [runcts] OUT => [javatest.batch] command: com.sun.ts.lib.harness.ExecTSTestCmd CLASSPATH=/tmp/ee10/jakartaeetck/bin/xml/../../lib/tsharness.jar:/tmp/ee10/jakartaeetck/bin/xml/../../lib/cts.jar:/tmp/ee10/jakartaeetck/bin/xml/../../lib/glassfishporting.jar:/tmp/ee10/jakartaeetck/bin/xml/../../lib/commons-lang3-3.3.2.jar:/tmp/ee10/vi/glassfish7/glassfish/../javadb/lib/derbyclient.jar:/tmp/ee10/vi/glassfish7/glassfish/../javadb/lib/derbyshared.jar:/tmp/ee10/vi/glassfish7/glassfish/../javadb/lib/derbytools.jar:/tmp/ee10/vi/glassfish7/glassfish/lib/embedded/glassfish-embedded-static-shell.jar:/tmp/ee10/jakartaeetck/bin/xml/../../dist/com/sun/ts/tests/ejb30/lite/singleton/dependson/triangle/ejbembed_vehicle_ejb.jar DISPLAY=:0.0 HOME=/root TMP= windir= SYSTEMROOT= /home/smarlow/jdk-17/bin/java -Dcts.tmp=/tmp/ee10/jakartaeetck/bin/xml/../../tmp -Djava.util.logging.config.file=/tmp/ee10/vi/glassfish7/glassfish/domains/domain1/config/logging.properties -Dtest.ejb.stateful.timeout.wait.seconds=120 -Ddeliverable.class=com.sun.ts.lib.deliverable.cts.CTSDeliverable com.sun.ts.tests.common.vehicle.VehicleClient -p /tmp/ee10/jakartaeetck/bin/xml/../../tmp/tstest.jte -t triangleNoStartUp -vehicle ejbembed
   [runcts] OUT => [javatest.batch] ************************************************************
   [runcts] OUT => [javatest.batch] * props file set to "/tmp/root-cts-props.txt"
   [runcts] OUT => [javatest.batch] ************************************************************
   [runcts] OUT => [javatest.batch] [#|2022-05-09T13:16:48.525-0400|INFO||javax.enterprise.system.container.ejb.org.glassfish.ejb.embedded|_ThreadID=1;_ThreadName=main;_TimeMillis=1652116608525;_LevelValue=800;|[EJBContainerProviderImpl] Using installation location /tmp/ee10/vi/glassfish7/glassfish|#]
 ```

Perhaps the special `testExecuteEjbEmbed` handling in  https://github.com/eclipse-ee4j/jakartaee-tck/blob/master/src/com/sun/ts/lib/harness/TSScript.java#L382 is ignoring options that are not supported for the `testExecuteEjbEmbed` command.

CC @alwin-joseph @arjantijms
