### PR TITLE
Update for #969, jsp to xhtml for ejblitejsf vehicle for com/sun/ts/tests/ejb30/lite/async/

### DIFF
--- a/bin/xml/ts.vehicles.xml
+++ b/bin/xml/ts.vehicles.xml
@@ -436,7 +436,7 @@
                                            com/sun/ts/tests/ejb30/common/lite/*.class,
                                            com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                            ${harness.pkg.dir}/ServiceEETest*.class"
-                                 excludes="@{excludedfiles}, ${pkg.dir}/**/JsfClient.class"/>
+                                 excludes="@{excludedfiles}"/>
                     </ts.ejbjar>
                 </then>
                 </elseif>
@@ -472,7 +472,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/Client.class"
+                                    excludes="${runner.classes}, @{excludedfiles}"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="faces-config.xml,beans.xml" prefix="WEB-INF"/>
@@ -529,7 +529,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/JsfClient.class"
+                                    excludes="${runner.classes}, @{excludedfiles}"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="ejblitejsp.tld" prefix="WEB-INF/tlds"/>
@@ -653,7 +653,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/JsfClient.class"
+                                    excludes="${runner.classes}, @{excludedfiles}"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="*.jar" prefix="WEB-INF/lib" excludes="ejbembed_vehicle*.jar"/>
@@ -782,7 +782,7 @@
                                               com/sun/ts/tests/ejb30/common/lite/*.class,
                                               com/sun/ts/tests/ejb30/common/helper/Helper.class,
                                               ${harness.pkg.dir}/ServiceEETest*.class"
-                                    excludes="${runner.classes}, @{excludedfiles}, ${pkg.dir}/**/JsfClient.class"
+                                    excludes="${runner.classes}, @{excludedfiles}"
                                     prefix="WEB-INF/classes"/>
                         <zipfileset dir="${basedir}" includes="ejb-jar.xml, beans.xml" prefix="WEB-INF"/>
                         <zipfileset dir="${dist.dir}/${pkg.dir}" includes="*.jar" prefix="WEB-INF/lib" excludes="ejbembed_vehicle*.jar"/>

--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -149,6 +149,26 @@ com/sun/ts/tests/ejb30/lite/appexception/stateful/inheritance/Client.java = ejbl
 com/sun/ts/tests/ejb30/lite/appexception/stateless/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/appexception/stateless/override/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/stateful/timeout = ejblitejsp ejbembed
+
+com/sun/ts/tests/ejb30/lite/async/singleton/annotated/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/singleton/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/singleton/descriptor/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/singleton/descriptor/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/singleton/metadata/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/singleton/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/stateful/annotated/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/stateful/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/stateful/descriptor/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/stateful/descriptor/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/stateful/metadata/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/stateful/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/stateless/annotated/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/stateless/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/stateless/descriptor/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/stateless/descriptor/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/async/stateless/metadata/JsfClient.java = ejblitejsf
+com/sun/ts/tests/ejb30/lite/async/stateless/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+
 com/sun/ts/tests/ejb30/lite/tx/cm/singleton/webrw = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/lite/tx/cm/stateless/webrw = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/lite/tx/cm/stateful/webrw = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
@@ -158,7 +178,8 @@ com/sun/ts/tests/ejb30/lite/packaging/war/datasource/global  = ejblitejsf
 com/sun/ts/tests/ejb30/lite/basic/mock = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp 
 com/sun/ts/tests/ejb30/lite/naming/context/Client.java#lookup = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/timer = ejbliteservlet 
-com/sun/ts/tests/ejb30/lite/async = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp 
+
+com/sun/ts/tests/ejb30/lite/async = ejbliteservlet ejbliteservlet2 ejblitejsp 
 com/sun/ts/tests/ejb30/bb/async = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/bb/session/stateful/timeout = ejblitejsp 
 com/sun/ts/tests/ejb30/bb/session/stateful/concurrency = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp 

--- a/src/com/sun/ts/tests/ejb30/lite/async/common/AsyncJsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/common/AsyncJsfClientBase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.common;
+
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+import com.sun.ts.tests.ejb30.common.statussingleton.StatusSingletonBean;
+import jakarta.ejb.EJB;
+
+abstract public class AsyncJsfClientBase extends EJBLiteJsfClientBase {
+
+  private static final long DEFAULT_MAX_WAIT_MILLIS = 1000 * 60;
+
+  private static final long POLL_INTERVAL_MILLIS = 500;
+
+  @EJB(beanName = "StatusSingletonBean")
+  protected StatusSingletonBean statusSingleton;
+
+  protected Integer getAndResetResult(Integer key, long... maxWaitMillis) {
+    final long waitFor = maxWaitMillis.length == 0 ? DEFAULT_MAX_WAIT_MILLIS
+        : maxWaitMillis[0];
+    final long stopTime = System.currentTimeMillis() + waitFor;
+    boolean avail = statusSingleton.isResultAvailable(key);
+    while (!avail && System.currentTimeMillis() < stopTime) {
+      TestUtil.sleep((int) POLL_INTERVAL_MILLIS);
+      avail = statusSingleton.isResultAvailable(key);
+    }
+    return statusSingleton.getAndResetResult(key);
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/common/annotated/AnnotatedJsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/common/annotated/AnnotatedJsfClientBase.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.common.annotated;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.ejb30.common.calc.CalculatorException;
+import com.sun.ts.tests.ejb30.common.helper.TestFailedException;
+import com.sun.ts.tests.ejb30.lite.async.common.AsyncJsfClientBase;
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBException;
+
+abstract public class AnnotatedJsfClientBase extends AsyncJsfClientBase {
+  protected int num1 = 10;
+
+  protected int num2 = 20;
+
+  protected int expectedSum = num1 + num2;
+
+  protected final static int DESTROYED_COUNT = 50;
+
+  @EJB(name = "annotatedMethodsIF", beanName = "AsyncAnnotatedMethodsBean")
+  private AsyncAnnotatedMethodsIF annotatedMethodsIF;
+
+  // cannot field-inject here since subdirectory may have different
+  // beanInterface.
+  // In stateful directory, the beanInterfaces are StatefulAsyncIF and
+  // StatefulAsync2IF
+
+  // Async2Bean, AsyncIF
+  protected AsyncIF interface1;
+
+  // Async2Bean, Async2IF
+  protected Async2IF interface2;
+
+  protected AsyncIF noInterface; // no-interface AsyncBean
+
+  final protected AsyncIF[] beans = new AsyncIF[3];
+
+  final protected AsyncAnnotatedMethodsCommonIF[] annotatedMethodsLocal = new AsyncAnnotatedMethodsCommonIF[1];
+
+  abstract protected void setNoInterface(AsyncIF noInterface);
+
+  abstract public void setInterface1(AsyncIF interface1);
+
+  abstract public void setInterface2(Async2IF interface2);
+
+  /**
+   * Used to verify the status of bean instances after the async business method
+   * throws RuntimeException or Error. For singleton, the same bean instance is
+   * retained; for stateless, it should be a different bean instance; for
+   * stateful, any subsequent access should result in
+   * jakarta.ejb.NoSuchEJBException.
+   * 
+   * @param b
+   * @throws ExecutionException
+   * @throws InterruptedException
+   */
+  protected void assertBeanInstances(AsyncIF b)
+      throws ExecutionException, InterruptedException {
+  }
+
+  @Override
+  public void setup(String[] args, Properties p) {
+    // For stateless and singleton test directories, it would be OK to
+    // initialize the bean collections inside a
+    // PostConstruct methods with the injected values. But for stateful, any
+    // system exception will cause the
+    // bean instance to be discarded and no longer available for the subsequent
+    // test. So we will need to look
+    // up a new bean reference for each test method. To be consistent, just use
+    // the same approach for all
+    // bean types.
+    super.setup(args, p);
+    beans[0] = (AsyncIF) lookup("interface1", "Async2Bean", AsyncIF.class);
+    beans[1] = (AsyncIF) lookup("interface2", "Async2Bean", Async2IF.class);
+    beans[2] = (AsyncIF) lookup("noInterface", "AsyncBean", null);
+
+    annotatedMethodsLocal[0] = (AsyncAnnotatedMethodsCommonIF) lookup(
+        "annotatedMethodsIF", "AsyncAnnotatedMethodsBean",
+        AsyncAnnotatedMethodsIF.class);
+  }
+
+  /*
+   * testName: addAway
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns void, and updates the result in
+   * a singleton, which is retrieved by the client.
+   */
+  public void addAway() {
+    for (int i = 0; i < beans.length; i++) {
+      statusSingleton.removeResult(i);
+      final int expected = expectedSum + i;
+      beans[i].addAway(num1, num2, i);
+      assertEquals("Check result stored in singleton.", expected,
+          getAndResetResult(i));
+    }
+  }
+
+  /*
+   * testName: voidRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method throws RuntimeException, which is not
+   * visible to the client, and no effect on client execution. Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+
+  public void voidRuntimeException()
+      throws InterruptedException, ExecutionException {
+    final Integer key = 1;
+    for (final AsyncIF b : beans) {
+      statusSingleton.removeResult(key);
+      b.voidRuntimeException(key);
+      final Integer completed = getAndResetResult(key);
+      appendReason(
+          "Is voidRuntimeException async method completed? " + completed);
+      assertBeanInstances(b);
+    }
+  }
+
+  /*
+   * testName: futureRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * RuntimeException, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+
+  public void futureRuntimeException()
+      throws InterruptedException, ExecutionException {
+    for (final AsyncIF b : beans) {
+      try {
+        b.futureRuntimeException().get();
+        throw new RuntimeException(
+            "Expecting ExecutionException, but got none.");
+      } catch (final ExecutionException ex) {
+        appendReason("Got expected ExecutionException "
+            + TestUtil.printStackTraceToString(ex));
+        final EJBException ejbException = (EJBException) ex.getCause();
+        assertBeanInstances(b);
+      }
+    }
+  }
+
+  /*
+   * testName: futureError
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * AssertionError, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such an Error.
+   */
+
+  public void futureError() throws InterruptedException, ExecutionException {
+    for (final AsyncIF b : beans) {
+      try {
+        b.futureError().get();
+        throw new RuntimeException(
+            "Expecting ExecutionException, but got none.");
+      } catch (final ExecutionException ex) {
+        appendReason(
+            String.format("%nGot expected ExecutionException from %s%n%s", b,
+                TestUtil.printStackTraceToString(ex)));
+        final EJBException ejbException = (EJBException) ex.getCause();
+        assertBeanInstances(b);
+      }
+    }
+  }
+
+  /*
+   * testName: futureException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws checked
+   * Exception, which is retrieved with Future.get().
+   */
+
+  public void futureException()
+      throws InterruptedException, ExecutionException {
+    final String expectedMsg = "futureException";
+    for (final AsyncIF b : beans) {
+      try {
+        b.futureException().get();
+        throw new RuntimeException(
+            "Expecting ExecutionException, but got none.");
+      } catch (final ExecutionException ex) {
+        final Throwable cause = ex.getCause();
+        final String actualMsg = cause.getMessage();
+        if (actualMsg == null) {
+          throw new RuntimeException("Unexpected exception ", cause);
+        }
+        assertEquals(null, expectedMsg,
+            actualMsg.substring(0, expectedMsg.length()));
+      } catch (final CalculatorException e) {
+        throw new RuntimeException("Unexpected " + e);
+      }
+    }
+  }
+
+  /*
+   * testName: futureValueList
+   * 
+   * @test_Strategy: async method returns Future<List<String>>
+   */
+
+  public void futureValueList()
+      throws InterruptedException, ExecutionException {
+    final List<String> la = null;
+    final List<String> lb = Arrays.asList("b", "bb");
+    final List<String> lc = Arrays.asList("c", "cc");
+
+    for (final AsyncIF b : beans) {
+      assertEquals(null, la, b.futureValueList(la).get());
+      assertEquals(null, lb, b.futureValueList(lb).get());
+      assertEquals(null, lc, b.futureValueList(lc).get());
+    }
+  }
+
+  /*
+   * testName: addReturn
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns Future.
+   */
+
+  public void addReturn() throws InterruptedException, ExecutionException {
+    for (final AsyncIF bean : beans) {
+      final Future<Integer> future = bean.addReturn(num1, num2);
+      assertEquals("Check Future result " + future, expectedSum, future.get());
+    }
+  }
+
+  /*
+   * testName: addSyncThrowException
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method throws TestFailedException, which should
+   * be received by client.
+   */
+
+  public void addSyncThrowException() {
+    // only use local bean for this test, since the bean method
+    // addSyncReturn calls addReturn, which returns a non-serializable
+    // impl of Future<Integer>
+    try {
+      annotatedMethodsIF.addSyncThrowException(num1, num2);
+      throw new RuntimeException(
+          "Expecting TestFailedException, but got none.");
+    } catch (final TestFailedException ex) {
+      appendReason("Got expected ", ex);
+    }
+  }
+
+  /*
+   * testName: addSyncReturn
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method should block for the return value.
+   */
+
+  public void addSyncReturn() {
+    final long waitMillis = 2000;
+    final long start = System.currentTimeMillis();
+
+    // only use local bean for this test, since the bean method addSyncReturn
+    // calls addReturn, which returns a non-serializable impl of Future<Integer>
+    annotatedMethodsIF.addSyncReturn(num1, num2, waitMillis);
+    final long end = System.currentTimeMillis();
+    final long elapsed = end - start;
+    if (elapsed >= waitMillis) {
+      appendReason("Time elapsed >= waitMillis: " + elapsed + " " + waitMillis);
+    } else {
+      throw new RuntimeException(
+          "For a blocking method elapsed time should >= waitMillis: " + elapsed
+              + " " + waitMillis);
+    }
+  }
+
+  /*
+   * testName: addReturnWaitMillis
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. Asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method should return immediately.
+   */
+
+  public void addReturnWaitMillis()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    final long waitMillis = 2000;
+
+    for (AsyncAnnotatedMethodsCommonIF b : annotatedMethodsLocal) {
+      final long start = System.currentTimeMillis();
+      final Future<Integer> result = b.addReturn(num1, num2, waitMillis);
+      final long end = System.currentTimeMillis();
+      final long elapsed = end - start;
+      if (elapsed < waitMillis) {
+        appendReason(
+            "Time elapsed < waitMillis: " + elapsed + " " + waitMillis);
+      } else {
+        throw new RuntimeException(
+            "For async method elapsed time should < waitMillis: " + elapsed
+                + " " + waitMillis);
+      }
+
+      assertEquals("", expectedSum, result.get());
+      assertEquals("", expectedSum, result.get(10, TimeUnit.MILLISECONDS));
+      assertEquals("", true, result.isDone());
+      assertEquals("", false, result.isCancelled());
+      assertEquals("", false, result.cancel(false));
+      assertEquals("", false, result.cancel(true));
+    }
+  }
+
+  /*
+   * testName: cancelMayInterruptIfRunningFalse
+   * 
+   * @test_Strategy: cancel an async invocation with mayInterruptIfRunning set
+   * to true or false. If the client's cancel request is sent before the
+   * previous async method is dispatched, the async method will not be executed.
+   * So need to make sure the cancel request is not sent until the bean has
+   * started processing the first async method.
+   * 
+   * The bean method also needs to wait for the client's cancel request, and
+   * then call SessionContext.wasCancelCalled.
+   */
+  public void cancelMayInterruptIfRunningFalse()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    cancelMayInterruptIfRunning(false);
+  }
+
+  /*
+   * testName: cancelMayInterruptIfRunningTrue
+   * 
+   * @test_Strategy: see cancelMayInterruptIfRunningFalse
+   */
+  public void cancelMayInterruptIfRunningTrue()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    cancelMayInterruptIfRunning(true);
+  }
+
+  /*
+   * testName: passByValueOrReference
+   * 
+   * @test_Strategy:
+   */
+  public void passByValueOrReference() {
+    final String a = "a", b = "b";
+    for (int i = 0; i <= 2; i++) { // local invocations
+      final String[] params = { a, b };
+      beans[i].passByValueOrReference(params);
+      assertNotEquals(beans[i].toString(), a, params[0]);
+      assertNotEquals(beans[i].toString(), b, params[1]);
+    }
+  }
+
+  /*
+   * testName: passByValueOrReferenceAsync
+   * 
+   * @test_Strategy:
+   */
+  public void passByValueOrReferenceAsync()
+      throws InterruptedException, ExecutionException {
+    final String a = "a", b = "b";
+    for (int i = 0; i <= 2; i++) { // local invocations
+      final String[] params = { a, b };
+      beans[i].passByValueOrReferenceAsync(params).get();
+      assertNotEquals(beans[i].toString(), a, params[0]);
+      assertNotEquals(beans[i].toString(), b, params[1]);
+    }
+  }
+
+  private void cancelMayInterruptIfRunning(boolean mayInterruptIfRunning)
+      throws ExecutionException, InterruptedException, TimeoutException {
+    statusSingleton.removeResult(AsyncIF.CANCEL_IN_BEAN_KEY);
+    statusSingleton.removeResult(AsyncIF.CANCEL_IN_CLIENT_KEY);
+    final Future<Boolean> result = noInterface.cancelMayInterruptIfRunning();
+
+    final long stopTime = System.currentTimeMillis() + AsyncIF.MAX_WAIT_MILLIS;
+
+    while (!statusSingleton.isResultAvailable(AsyncIF.CANCEL_IN_BEAN_KEY)
+        && System.currentTimeMillis() < stopTime) {
+      Thread.sleep(AsyncIF.POLL_INTERVAL_MILLIS);
+    }
+    if (statusSingleton.isResultAvailable(AsyncIF.CANCEL_IN_BEAN_KEY)) {
+      appendReason("The bean has started processing the async method.");
+    } else {
+      throw new RuntimeException(
+          "The bean has not started processing the async method after waiting millis "
+              + AsyncIF.MAX_WAIT_MILLIS);
+    }
+
+    result.cancel(mayInterruptIfRunning);
+    // notify the statusSingleton that a cancel has been requested
+    statusSingleton.addResult(AsyncIF.CANCEL_IN_CLIENT_KEY,
+        AsyncIF.CANCEL_IN_CLIENT_VAL);
+
+    assertEquals(null, mayInterruptIfRunning, result.get());
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/common/descriptor/DescriptorJsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/common/descriptor/DescriptorJsfClientBase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.common.descriptor;
+
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBException;
+
+import static com.sun.ts.tests.ejb30.lite.async.common.descriptor.DescriptorIF.EXCEPTION_MESSAGE;
+
+abstract public class DescriptorJsfClientBase extends EJBLiteJsfClientBase {
+
+  @EJB(name = "noInterface", beanName = "DescriptorBean")
+  private DescriptorBean noInterface;
+
+  @EJB(name = "descriptorIF", beanName = "DescriptorBean")
+  private DescriptorIF descriptorIF;
+
+  @EJB(name = "descriptor2IF", beanName = "DescriptorBean")
+  private Descriptor2IF descriptor2IF;
+
+  protected DescriptorBean getNoInterface() {
+    return noInterface;
+  }
+
+  protected DescriptorIF getDescriptorIF() {
+    return descriptorIF;
+  }
+
+  protected Descriptor2IF getDescriptor2IF() {
+    return descriptor2IF;
+  }
+
+  protected TimeoutDescriptorBeanBase getTimeoutDescriptorBean() {
+    return null;
+  }
+
+  private void checkEJBException(EJBException e) {
+    RuntimeException cause = (RuntimeException) e.getCause();
+    assertEquals(null, EXCEPTION_MESSAGE, cause.getMessage());
+  }
+
+  private DescriptorIF[] getAllBeans() {
+    return new DescriptorIF[] { getNoInterface(), getDescriptorIF(),
+        getDescriptor2IF() };
+  }
+
+  private DescriptorIF[] getLocalBeans() {
+    return new DescriptorIF[] { getNoInterface(), getDescriptorIF(),
+        getDescriptor2IF() };
+  }
+
+  /*
+   * testName: allViews
+   * 
+   * @test_Strategy:
+   */
+  public void allViews() {
+    for (DescriptorIF b : getAllBeans()) {
+      b.allViews();
+      appendReason("Verified async method on " + b);
+    }
+  }
+
+  /*
+   * testName: localViews
+   * 
+   * @test_Strategy:
+   */
+  public void localViews() {
+    for (DescriptorIF b : getLocalBeans()) {
+      b.localViews();
+    }
+  }
+
+  /*
+   * testName: allParams
+   * 
+   * @test_Strategy:
+   */
+  public void allParams() {
+    for (DescriptorIF b : getAllBeans()) {
+      b.allParams();
+      b.allParams(0);
+      b.allParams("s");
+    }
+  }
+
+  /*
+   * testName: noParams
+   * 
+   * @test_Strategy:
+   */
+  public void noParams() {
+    for (DescriptorIF b : getAllBeans()) {
+      b.noParams();
+    }
+    for (DescriptorIF b : getAllBeans()) {
+      try {
+        b.noParams(0);
+      } catch (EJBException e) {
+        checkEJBException(e);
+      }
+    }
+
+  }
+
+  /*
+   * testName: intParams
+   * 
+   * @test_Strategy:
+   */
+  public void intParams() {
+    for (DescriptorIF b : getAllBeans()) {
+      b.intParams(0, 1);
+    }
+    for (DescriptorIF b : getAllBeans()) {
+      try {
+        b.intParams(0, 1, 2);
+      } catch (EJBException e) {
+        checkEJBException(e);
+      }
+    }
+  }
+
+  /*
+   * testName: intParamsLocalViews
+   * 
+   * @test_Strategy:
+   */
+  public void intParamsLocalViews() {
+    for (DescriptorIF b : getLocalBeans()) {
+      b.intParamsLocalViews(0, 1);
+    }
+    for (DescriptorIF b : getLocalBeans()) {
+      try {
+        b.intParamsLocalViews();
+      } catch (EJBException e) {
+        checkEJBException(e);
+      }
+    }
+  }
+
+  /*
+   * testName: timeoutDescriptorBean
+   * 
+   * @test_Strategy:
+   */
+  public void timeoutDescriptorBean() {
+    getTimeoutDescriptorBean().voidRuntimeException();
+    appendReason("No exception received by the client, as expected.");
+  }
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/common/metadata/MetadataJsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/common/metadata/MetadataJsfClientBase.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.common.metadata;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.sun.ts.tests.ejb30.common.calc.CalculatorException;
+import com.sun.ts.tests.ejb30.lite.async.common.AsyncJsfClientBase;
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBException;
+
+/**
+ * These tests verify various ways of specifying @Asynchronous on interfaces and
+ * bean class and their superclasses. Some of these requirements are also
+ * covered in ../annotated directory. This test directory focuses on type-level
+ * 
+ * @Asynchronous on business interface and super-interfaces, and type-level
+ * @Asynchronous on bean superclasses.
+ */
+
+public class MetadataJsfClientBase extends AsyncJsfClientBase {
+  @EJB(name = "beanClassLevel", beanName = "BeanClassLevelBean")
+  protected PlainInterfaceTypeLevelIF beanClassLevel;
+
+  protected PlainInterfaceTypeLevelIF getBeanClassLevel() {
+    return beanClassLevel;
+  }
+
+  // for stateful, after calling voidRuntimeException, the bean instance will be
+  // discarded,
+  // and the subsequent b.futureRuntimeException will generate EJBException("not
+  // such ejb...")
+  // so pass in b2 for use in the second call.
+  protected void beanClassLevelRuntimeException(PlainInterfaceTypeLevelIF b,
+      PlainInterfaceTypeLevelIF b2)
+      throws InterruptedException, TimeoutException {
+    b.voidRuntimeException();
+    try {
+      b2.futureRuntimeException().get(1, TimeUnit.MINUTES);
+      throw new RuntimeException("Expecting ExecutionException, but got none.");
+    } catch (final ExecutionException ex) {
+      final EJBException ejbException = (EJBException) ex.getCause();
+      final RuntimeException runtimeException = (RuntimeException) ejbException
+          .getCause();
+      assertEquals(null, "futureRuntimeException",
+          runtimeException.getMessage());
+    }
+  }
+
+  protected void customFutureImpl(PlainInterfaceTypeLevelIF b)
+      throws InterruptedException, ExecutionException {
+    final TimeUnit timeUnit = TimeUnit.NANOSECONDS;
+    final Future<TimeUnit> result = b.customFutureImpl(timeUnit);
+    for (int i = 0; i < 2; i++) {
+      assertEquals(result.toString(), timeUnit, result.get());
+    }
+  }
+
+  protected void beanClassLevelSyncMethod(PlainInterfaceTypeLevelIF b) {
+    try {
+      b.syncMethodException0();
+      throw new RuntimeException(
+          "Expecting CalculatorException, but got none.");
+    } catch (final CalculatorException ex) {
+      appendReason("Got expected " + ex);
+    }
+    try {
+      b.syncMethodException3();
+      throw new RuntimeException(
+          "Expecting CalculatorException, but got none.");
+    } catch (final CalculatorException ex) {
+      appendReason("Got expected " + ex);
+    }
+  }
+
+  /*
+   * testName: beanClassLevelReturnType
+   * 
+   * @test_Strategy:verify 2 types of return types in bean class: Future<T> and
+   * T.
+   */
+  public void beanClassLevelReturnType()
+      throws InterruptedException, ExecutionException {
+    final boolean expected = true;
+    assertEquals(null, expected, getBeanClassLevel().futureReturnType().get());
+  }
+
+  /*
+   * testName: beanClassLevelRuntimeException
+   * 
+   * @test_Strategy: for async method with void return type, RuntimeException is
+   * not visible to the client. For Future return type, RuntimeException is
+   * wrapped as EJBException and then as ExecutionException.
+   */
+  public void beanClassLevelRuntimeException()
+      throws InterruptedException, TimeoutException {
+    beanClassLevelRuntimeException(getBeanClassLevel(), getBeanClassLevel());
+  }
+
+  /*
+   * testName: customFutureImpl
+   * 
+   * @test_Strategy: Async method returning a custom Future impl.
+   */
+  public void customFutureImpl()
+      throws InterruptedException, ExecutionException {
+    customFutureImpl(getBeanClassLevel());
+  }
+
+  /*
+   * testName: beanClassLevelSyncMethod
+   * 
+   * @test_Strategy: syncMethodException is implemented in a bean superclass
+   * that is not annotated with @Asynchronous.
+   */
+  public void beanClassLevelSyncMethod() {
+    beanClassLevelSyncMethod(getBeanClassLevel());
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/singleton/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/singleton/annotated/JsfClient.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.singleton.annotated;
+
+import java.util.concurrent.ExecutionException;
+
+import com.sun.ts.tests.ejb30.lite.async.common.annotated.Async2IF;
+import com.sun.ts.tests.ejb30.lite.async.common.annotated.AsyncIF;
+import jakarta.ejb.EJB;
+import java.io.Serializable;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.async.common.annotated.AnnotatedJsfClientBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  @EJB(beanInterface = AsyncBean.class, name = "noInterface", beanName = "AsyncBean")
+  protected void setNoInterface(AsyncIF noInterface) {
+    this.noInterface = noInterface;
+  }
+
+  @Override
+  @EJB(name = "interface1", beanName = "Async2Bean")
+  public void setInterface1(AsyncIF interface1) {
+    this.interface1 = interface1;
+  }
+
+  @Override
+  @EJB(name = "interface2", beanName = "Async2Bean")
+  public void setInterface2(Async2IF interface2) {
+    this.interface2 = interface2;
+  }
+
+  @Override
+  protected void assertBeanInstances(AsyncIF b)
+      throws ExecutionException, InterruptedException {
+    for (int i = 0; i < DESTROYED_COUNT; i++) {
+      assertEquals("verify still the same instance ", true,
+          b.isErrorOccurredInInstance().get());
+    }
+  }
+
+  /*
+   * @testName: addAway
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns void, and updates the result in
+   * a singleton, which is retrieved by the client.
+   */
+  /*
+   * @testName: voidRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method throws RuntimeException, which is not
+   * visible to the client, and no effect on client execution. Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+  /*
+   * @testName: futureRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * RuntimeException, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+  /*
+   * @testName: futureError
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * AssertionError, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such an Error.
+   */
+  /*
+   * @testName: futureException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws checked
+   * Exception, which is retrieved with Future.get().
+   */
+  /*
+   * @testName: futureValueList
+   * 
+   * @test_Strategy: async method returns Future<List<String>>
+   */
+  /*
+   * @testName: addReturn
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns Future.
+   */
+  /*
+   * @testName: addSyncThrowException
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method throws TestFailedException, which should
+   * be received by client.
+   */
+  /*
+   * @testName: addSyncReturn
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method should block for the return value.
+   */
+  /*
+   * @testName: addReturnWaitMillis
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. Asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method should return immediately.
+   */
+
+  /*
+   * @testName: cancelMayInterruptIfRunningFalse
+   * 
+   * @test_Strategy: cancel an async invocation with mayInterruptIfRunning set
+   * to true or false. If the client's cancel request is sent before the
+   * previous async method is dispatched, the async method will not be executed.
+   * So need to make sure the cancel request is not sent until the bean has
+   * started processing the first async method.
+   * 
+   * The bean method also needs to wait for the client's cancel request, and
+   * then call SessionContext.wasCancelCalled.
+   */
+  /*
+   * @testName: cancelMayInterruptIfRunningTrue
+   * 
+   * @test_Strategy: see cancelMayInterruptIfRunningFalse
+   */
+  /*
+   * @testName: passByValueOrReference
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: passByValueOrReferenceAsync
+   * 
+   * @test_Strategy:
+   */
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/singleton/descriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/singleton/descriptor/JsfClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.singleton.descriptor;
+
+import java.io.Serializable;
+
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.DescriptorJsfClientBase;
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.TimeoutDescriptorBeanBase;
+import jakarta.ejb.EJB;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends DescriptorJsfClientBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @EJB(beanName = "TimeoutDescriptorBean")
+  private TimeoutDescriptorBean timeoutDescriptorBean;
+
+  @Override
+  protected TimeoutDescriptorBeanBase getTimeoutDescriptorBean() {
+    return timeoutDescriptorBean;
+  }
+
+  /*
+   * @testName: allViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: localViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: allParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: noParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: intParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: intParamsLocalViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: timeoutDescriptorBean
+   * 
+   * @test_Strategy:
+   */
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/singleton/metadata/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/singleton/metadata/JsfClient.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.singleton.metadata;
+
+import java.io.Serializable;
+
+/**
+ * See superclass ClientBase
+ */
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.async.common.metadata.MetadataJsfClientBase implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    /*
+   * @testName: beanClassLevelReturnType
+   * 
+   * @test_Strategy:verify 2 types of return types in bean class: Future<T> and
+   * T.
+   */
+  /*
+   * @testName: beanClassLevelRuntimeException
+   * 
+   * @test_Strategy: for async method with void return type, RuntimeException is
+   * not visible to the client. For Future return type, RuntimeException is
+   * wrapped as EJBException and then as ExecutionException.
+   */
+  /*
+   * @testName: customFutureImpl
+   * 
+   * @test_Strategy: Async method returning a custom Future impl.
+   */
+  /*
+   * @testName: beanClassLevelSyncMethod
+   * 
+   * @test_Strategy: syncMethodException is implemented in a bean superclass
+   * that is not annotated with @Asynchronous.
+   */
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateful/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateful/annotated/JsfClient.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.stateful.annotated;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import com.sun.ts.tests.ejb30.lite.async.common.annotated.Async2IF;
+import com.sun.ts.tests.ejb30.lite.async.common.annotated.AsyncIF;
+import jakarta.ejb.EJB;
+import jakarta.ejb.NoSuchEJBException;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.async.common.annotated.AnnotatedClientBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  @EJB(beanInterface = AsyncBean.class, name = "noInterface", beanName = "AsyncBean")
+  protected void setNoInterface(AsyncIF noInterface) {
+    this.noInterface = noInterface;
+  }
+
+  @Override
+  @EJB(beanInterface = StatefulAsyncIF.class, name = "interface1", beanName = "Async2Bean")
+  public void setInterface1(AsyncIF interface1) {
+    this.interface1 = interface1;
+  }
+
+  @Override
+  @EJB(beanInterface = StatefulAsync2IF.class, name = "interface2", beanName = "Async2Bean")
+  public void setInterface2(Async2IF interface2) {
+    this.interface2 = interface2;
+  }
+
+  @Override
+  protected void assertBeanInstances(AsyncIF b)
+      throws ExecutionException, InterruptedException {
+    try {
+      final boolean result = b.isErrorOccurredInInstance().get();
+      throw new RuntimeException(
+          "Expecting NoSuchEJBException, but got " + result);
+    } catch (final ExecutionException e) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof NoSuchEJBException) {
+        appendReason("Got expected " + e);
+      } else {
+        throw new RuntimeException("Unexpected " + cause);
+      }
+    } catch (NoSuchEJBException e) {
+      appendReason("Got expected " + e);
+    }
+  }
+
+  /*
+   * @testName: addAway
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns void, and updates the result in
+   * a singleton, which is retrieved by the client.
+   */
+  /*
+   * @testName: voidRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method throws RuntimeException, which is not
+   * visible to the client, and no effect on client execution. Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+  /*
+   * @testName: futureRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * RuntimeException, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+  /*
+   * @testName: futureError
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * AssertionError, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such an Error.
+   */
+  /*
+   * @testName: futureException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws checked
+   * Exception, which is retrieved with Future.get().
+   */
+  /*
+   * @testName: futureValueList
+   * 
+   * @test_Strategy: async method returns Future<List<String>>
+   */
+  /*
+   * @testName: addReturn
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns Future.
+   */
+  /*
+   * @testName: addSyncThrowException
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method throws TestFailedException, which should
+   * be received by client.
+   */
+  /*
+   * @testName: addSyncReturn
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method should block for the return value.
+   */
+  /*
+   * @testName: addReturnWaitMillis
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. Asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method should return immediately.
+   */
+
+  /*
+   * @testName: cancelMayInterruptIfRunningFalse
+   * 
+   * @test_Strategy: cancel an async invocation with mayInterruptIfRunning set
+   * to true or false. If the client's cancel request is sent before the
+   * previous async method is dispatched, the async method will not be executed.
+   * So need to make sure the cancel request is not sent until the bean has
+   * started processing the first async method.
+   * 
+   * The bean method also needs to wait for the client's cancel request, and
+   * then call SessionContext.wasCancelCalled.
+   */
+  /*
+   * @testName: cancelMayInterruptIfRunningTrue
+   * 
+   * @test_Strategy: see cancelMayInterruptIfRunningFalse
+   */
+  /*
+   * @testName: passByValueOrReference
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: passByValueOrReferenceAsync
+   * 
+   * @test_Strategy:
+   */
+
+  /*
+   * @testName: addReturnConcurrent
+   * 
+   * @test_Strategy: asynchronous invocations on stateful The asynchronous
+   * method returns Future. Verify concurrent access is properly processed by
+   * the container.
+   */
+  public void addReturnConcurrent()
+      throws InterruptedException, ExecutionException {
+    final int numOfConcurrentAccess = 50;
+    for (final AsyncIF bean : beans) {
+      final List<Future<Integer>> results = new ArrayList<Future<Integer>>();
+      for (int j = 0; j < numOfConcurrentAccess; j++) {
+        results.add(bean.addReturn(num1, num2));
+      }
+      appendReason("About to check " + results.size() + " results: ");
+      // save the result and check it later
+      for (int k = 0; k < results.size(); k++) {
+        assertEquals("Check Future result ", expectedSum, results.get(k).get());
+      }
+    }
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateful/descriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateful/descriptor/JsfClient.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2013, 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.stateful.descriptor;
+
+import java.io.Serializable;
+
+import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.Descriptor2IF;
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.DescriptorBean;
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.DescriptorJsfClientBase;
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.DescriptorIF;
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.TimeoutDescriptorBeanBase;
+import jakarta.ejb.EJB;
+
+@EJB(name = "timeoutDescriptorBean", beanInterface = TimeoutDescriptorBean.class, beanName = "TimeoutDescriptorBean")
+public class JsfClient extends DescriptorJsfClientBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  protected Descriptor2IF getDescriptor2IF() {
+    return (Descriptor2IF) ServiceLocator
+        .lookupByShortNameNoTry("descriptor2IF");
+  }
+
+  @Override
+  protected DescriptorIF getDescriptorIF() {
+    return (DescriptorIF) ServiceLocator.lookupByShortNameNoTry("descriptorIF");
+  }
+
+  @Override
+  protected DescriptorBean getNoInterface() {
+    return (DescriptorBean) ServiceLocator
+        .lookupByShortNameNoTry("noInterface");
+  }
+
+  @Override
+  protected TimeoutDescriptorBeanBase getTimeoutDescriptorBean() {
+    return (TimeoutDescriptorBeanBase) ServiceLocator
+        .lookupByShortNameNoTry("timeoutDescriptorBean");
+  }
+
+  /*
+   * @testName: allViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: localViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: allParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: noParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: intParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: intParamsLocalViews
+   * 
+   * @test_Strategy:
+   */
+
+  /*
+   * @testName: timeoutDescriptorBean
+   * 
+   * @test_Strategy:
+   */
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateful/metadata/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateful/metadata/JsfClient.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.stateful.metadata;
+
+import java.io.Serializable;
+
+import com.sun.ts.tests.ejb30.lite.async.common.metadata.PlainInterfaceTypeLevelIF;
+
+/**
+ * See superclass ClientBase
+ */
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.async.common.metadata.MetadataJsfClientBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  protected PlainInterfaceTypeLevelIF getBeanClassLevel() {
+    return (PlainInterfaceTypeLevelIF) lookup("beanClassLevel",
+        "BeanClassLevelBean", PlainInterfaceTypeLevelIF.class);
+  }
+
+  /*
+   * @testName: beanClassLevelReturnType
+   * 
+   * @test_Strategy:verify 2 types of return types in bean class: Future<T> and
+   * T.
+   */
+  /*
+   * @testName: beanClassLevelRuntimeException
+   * 
+   * @test_Strategy: for async method with void return type, RuntimeException is
+   * not visible to the client. For Future return type, RuntimeException is
+   * wrapped as EJBException and then as ExecutionException.
+   */
+  /*
+   * @testName: customFutureImpl
+   * 
+   * @test_Strategy: Async method returning a custom Future impl.
+   */
+  /*
+   * @testName: beanClassLevelSyncMethod
+   * 
+   * @test_Strategy: syncMethodException is implemented in a bean superclass
+   * that is not annotated with @Asynchronous.
+   */
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateless/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateless/annotated/JsfClient.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.stateless.annotated;
+
+import java.io.Serializable;
+import java.util.concurrent.ExecutionException;
+
+import com.sun.ts.tests.ejb30.lite.async.common.annotated.Async2IF;
+import com.sun.ts.tests.ejb30.lite.async.common.annotated.AsyncIF;
+import jakarta.ejb.EJB;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends
+    com.sun.ts.tests.ejb30.lite.async.common.annotated.AnnotatedJsfClientBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  @EJB(beanInterface = AsyncBean.class, name = "noInterface", beanName = "AsyncBean")
+  protected void setNoInterface(AsyncIF noInterface) {
+    this.noInterface = noInterface;
+  }
+
+  @Override
+  @EJB(name = "interface1", beanName = "Async2Bean")
+  public void setInterface1(AsyncIF interface1) {
+    this.interface1 = interface1;
+  }
+
+  @Override
+  @EJB(name = "interface2", beanName = "Async2Bean")
+  public void setInterface2(Async2IF interface2) {
+    this.interface2 = interface2;
+  }
+
+  @Override
+  protected void assertBeanInstances(AsyncIF b)
+      throws ExecutionException, InterruptedException {
+    for (int i = 0; i < DESTROYED_COUNT; i++) {
+      assertEquals("verify not the same instance ", false,
+          b.isErrorOccurredInInstance().get());
+    }
+  }
+
+  /*
+   * @testName: addAway
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns void, and updates the result in
+   * a singleton, which is retrieved by the client.
+   */
+  /*
+   * @testName: voidRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method throws RuntimeException, which is not
+   * visible to the client, and no effect on client execution. Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+  /*
+   * @testName: futureRuntimeException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * RuntimeException, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such a RuntimeException.
+   */
+  /*
+   * @testName: futureError
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws
+   * AssertionError, which is retrieved with Future.get(). Also verify that
+   * stateless bean instance is discarded after such an Error.
+   */
+  /*
+   * @testName: futureException
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method with Future return type throws checked
+   * Exception, which is retrieved with Future.get().
+   */
+  /*
+   * @testName: futureValueList
+   * 
+   * @test_Strategy: async method returns Future<List<String>>
+   */
+  /*
+   * @testName: addReturn
+   * 
+   * @test_Strategy: asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method returns Future.
+   */
+  /*
+   * @testName: addSyncThrowException
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method throws TestFailedException, which should
+   * be received by client.
+   */
+  /*
+   * @testName: addSyncReturn
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. synchronous/blocking invocations on stateless, stateful, and
+   * singleton. The synchronous method should block for the return value.
+   */
+  /*
+   * @testName: addReturnWaitMillis
+   * 
+   * @test_Strategy: Some methods on the interface are annotated as async and
+   * some are not. Asynchronous invocations on stateless, stateful, and
+   * singleton. The asynchronous method should return immediately.
+   */
+
+  /*
+   * @testName: cancelMayInterruptIfRunningFalse
+   * 
+   * @test_Strategy: cancel an async invocation with mayInterruptIfRunning set
+   * to true or false. If the client's cancel request is sent before the
+   * previous async method is dispatched, the async method will not be executed.
+   * So need to make sure the cancel request is not sent until the bean has
+   * started processing the first async method.
+   * 
+   * The bean method also needs to wait for the client's cancel request, and
+   * then call SessionContext.wasCancelCalled.
+   */
+  /*
+   * @testName: cancelMayInterruptIfRunningTrue
+   * 
+   * @test_Strategy: see cancelMayInterruptIfRunningFalse
+   */
+  /*
+   * @testName: passByValueOrReference
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: passByValueOrReferenceAsync
+   * 
+   * @test_Strategy:
+   */
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateless/descriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateless/descriptor/JsfClient.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.stateless.descriptor;
+
+import java.io.Serializable;
+
+import com.sun.ts.tests.ejb30.lite.async.common.descriptor.DescriptorJsfClientBase;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends DescriptorJsfClientBase implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+  /*
+   * @testName: allViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: localViews
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: allParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: noParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: intParams
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: intParamsLocalViews
+   * 
+   * @test_Strategy:
+   */
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/async/stateless/metadata/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/async/stateless/metadata/JsfClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.async.stateless.metadata;
+
+import java.io.Serializable;
+
+import com.sun.ts.tests.ejb30.lite.async.common.metadata.MetadataJsfClientBase;
+
+/**
+ * See superclass ClientBase
+ */
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends MetadataJsfClientBase implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+  /*
+   * @testName: beanClassLevelReturnType
+   * 
+   * @test_Strategy:verify 2 types of return types in bean class: Future<T> and
+   * T.
+   */
+  /*
+   * @testName: beanClassLevelRuntimeException
+   * 
+   * @test_Strategy: for async method with void return type, RuntimeException is
+   * not visible to the client. For Future return type, RuntimeException is
+   * wrapped as EJBException and then as ExecutionException.
+   */
+  /*
+   * @testName: customFutureImpl
+   * 
+   * @test_Strategy: Async method returning a custom Future impl.
+   */
+  /*
+   * @testName: beanClassLevelSyncMethod
+   * 
+   * @test_Strategy: syncMethodException is implemented in a bean superclass
+   * that is not annotated with @Asynchronous.
+   */
+}


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/969

**Related Issue(s)**
#968 

**Describe the change**
Update the com/sun/ts/tests/ejb30/lite/async tests to use a new JsfClient.java for the ejblitejsf vehicle and leave the ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed vehicles mapped to Client.java

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
