### PR TITLE
Update ts.jte settings when running with Java SE 17 to add --add-opens to address GlassFish JDK 17 TCK test failures

### DIFF
--- a/bin/xml/ts.top.import.xml
+++ b/bin/xml/ts.top.import.xml
@@ -39,14 +39,6 @@
     </condition>
     <property name="noSecurityManager" value="false"/>
 
-    <if>
-        <isset property="env.JVMOPTS_RUNTESTCOMMAND"/>
-        <then>
-            <property name="JVMOPTS_RUNTESTCOMMAND"
-                        value="${env.JVMOPTS_RUNTESTCOMMAND}"/>
-        </then>
-    </if>
-
     <!-- Set the archives to deploy - default to wars-->
     <target name="setup.archive.set">
         <fileset dir="${dist.dir}/${pkg.dir}" id="deploy.vi.archive.set">

--- a/bin/xml/ts.top.import.xml
+++ b/bin/xml/ts.top.import.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -162,13 +162,6 @@ ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwo
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} stop-domain
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-   echo "enabling GlassFish --add-opens options for JDK17"
-   export JVMOPTS_RUNTESTCOMMAND="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
-   echo "will use $JVMOPTS_RUNTESTCOMMAND "
-fi
-
-
 # Change default ports for RI
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --interactive=false  --user admin --passwordfile ${ADMIN_PASSWORD_FILE} delete-jvm-options -Dosgi.shell.telnet.port=6666
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Dosgi.shell.telnet.port=6667
@@ -255,6 +248,15 @@ if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
   # Change the memory setting in ts.jte as well.
   sed -i.bak 's/-Xmx1024m/-Xmx4096m/g' ${TS_HOME}/bin/ts.jte
 fi 
+
+# do ts.jte parameter substitution here of ${JVMOPTS_RUNTESTCOMMAND}
+if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+   echo "update ts.jte for GlassFish to use --add-opens options for Java SE 17"
+   search="..JVMOPTS_RUNTESTCOMMAND."
+   replace="--add-opens=java.base\\/java.io=ALL-UNNAMED --add-opens=java.base\\/java.lang=ALL-UNNAMED --add-opens=java.base\\/java.util=ALL-UNNAMED --add-opens=java.base\\/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming\\/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi\\/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management\\/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming\\/com.sun.jndi.ldap=ALL-UNNAMED"
+   sed -i.bak "s/$search/$replace/" ${TS_HOME}/bin/ts.jte
+   echo "updated ts.jte to use -add-opens for Java SE 17 "
+fi
 
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${CTS_HOME}/change-admin-password.txt change-admin-password
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain

--- a/install/jakartaee/bin/ts.jte
+++ b/install/jakartaee/bin/ts.jte
@@ -202,9 +202,10 @@ orb.host=localhost
 orb.port=3699
 
 ########################################################################
-## Environment variable JVMOPTS_RUNTESTCOMMAND may be set to JVM 
-#  options to pass when running ExecTSTestCmd command.
-#  This is a convenience intended for adding Java SE 17+ options.
+## JVMOPTS_RUNTESTCOMMAND is a marker that implementations may replace with
+#  the JVM options to pass when starting JVMs for running tests.
+#  This is intended to be used for implementations convencience.
+#  See file docker/run_jakartaeetck.sh for an example.
 ########################################################################
 
 ########################################################################


### PR DESCRIPTION
**Fixes Issue**

https://github.com/eclipse-ee4j/jakartaee-tck/issues/959

**Describe the change**
Completes the change started by https://github.com/eclipse-ee4j/jakartaee-tck/pull/964.  

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow @starksm64 
