### PR TITLE
Migrate ejb30/lite/view & ejb30/lite/xmloverride tests to new ejblitejsf vehicle

### DIFF
--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -258,12 +258,12 @@ com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/JsfClient.java = ejblitejsf
 
 com/sun/ts/tests/ejb30/lite/view/equals/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/view/equals/JsfClient.java  = ejblitejsf
-com/sun/ts/tests/ejb30/lite/view/singleton/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
-com/sun/ts/tests/ejb30/lite/view/singleton/JsfClient.java  = ejblitejsf
-com/sun/ts/tests/ejb30/lite/view/stateful/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
-com/sun/ts/tests/ejb30/lite/view/stateful/JsfClient.java  = ejblitejsf
-com/sun/ts/tests/ejb30/lite/view/stateless/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
-com/sun/ts/tests/ejb30/lite/view/stateless/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/view/singleton/annotated/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/singleton/annotated/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/view/stateful/annotated/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/stateful/annotated/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/view/stateless/annotated/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/stateless/annotated/JsfClient.java  = ejblitejsf
 
 com/sun/ts/tests/ejb30/lite/xmloverride/resource/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfClient.java  = ejblitejsf

--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -256,6 +256,21 @@ com/sun/ts/tests/ejb30/lite/tx/cm/stateful/sessionsync/JsfClient.java = ejblitej
 com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/tx/cm/stateful/annotated/JsfClient.java = ejblitejsf
 
+com/sun/ts/tests/ejb30/lite/view/equals/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/equals/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/view/singleton/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/singleton/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/view/stateful/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/stateful/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/view/stateless/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/view/stateless/JsfClient.java  = ejblitejsf
+
+com/sun/ts/tests/ejb30/lite/xmloverride/resource/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfClient.java  = ejblitejsf
+com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/Client.java  = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java  = ejblitejsf
+
+
 com/sun/ts/tests/ejb30/lite/packaging/embed  = ejbembed
 com/sun/ts/tests/ejb30/lite/packaging/war  = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/lite/packaging/war/datasource/global  = ejblitejsf

--- a/src/com/sun/ts/tests/ejb30/lite/view/common/JsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/common/JsfClientBase.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.view.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.ts.tests.ejb30.common.busiface.AnnotatedLocalBusinessInterface1;
+import com.sun.ts.tests.ejb30.common.busiface.AnnotatedLocalBusinessInterface2;
+import com.sun.ts.tests.ejb30.common.busiface.BusinessLocal1Base;
+import com.sun.ts.tests.ejb30.common.busiface.BusinessLocalIF1;
+import com.sun.ts.tests.ejb30.common.busiface.BusinessLocalIF2;
+import com.sun.ts.tests.ejb30.common.busiface.Constants;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+
+import jakarta.ejb.EJB;
+
+public class JsfClientBase extends EJBLiteJsfClientBase {
+  protected static final String[] args = { Constants.VALUE };
+
+  protected static final String[] resultReset = { Constants.VALUE_RESET };
+
+  @EJB(beanName = "SerializableLocalBean")
+  protected BusinessLocalIF1 serializableLocalBean;
+
+  @EJB(beanName = "ExternalizableLocalBean")
+  protected BusinessLocalIF1 externalizableLocalBean;
+
+  @EJB(beanName = "SessionBeanLocalBean")
+  protected BusinessLocalIF1 sessionBeanLocalBean;
+
+  @EJB(beanName = "BusinessBean")
+  protected BusinessLocalIF1 businessBean1;
+
+  @EJB(beanName = "BusinessBean")
+  protected BusinessLocalIF2 businessBean2;
+
+  @EJB(beanName = "AnnotatedInterfaceBean")
+  protected AnnotatedLocalBusinessInterface1 annotatedInterfaceBean1;
+
+  @EJB(beanName = "AnnotatedInterfaceBean")
+  protected AnnotatedLocalBusinessInterface2 annotatedInterfaceBean2;
+
+  // injected in subclass
+  protected BusinessLocal1Base localAndNoInterfaceBeanNoInterfaceView;
+
+  @EJB(beanName = "LocalAndNoInterfaceBean")
+  protected BusinessLocalIF1 localAndNoInterfaceBeanLocalView;
+
+  @EJB(beanName = "SuperclassBean")
+  private BusinessLocalIF1 superclassBean;
+
+  /*
+   * testName: multipleInterfacesLocal
+   * 
+   * @assertion_ids: EJB:JAVADOC:125
+   * 
+   * @test_Strategy:
+   */
+  public void multipleInterfacesLocal() {
+    assertEquals("Multi local interfaces:", resultReset[0],
+        businessBean1.businessMethodLocal1(args)[0]);
+    assertEquals("Multi local interfaces:", resultReset[0],
+        businessBean2.businessMethodLocal2(args)[0]);
+  }
+
+  /*
+   * testName: singleInterfaceLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy: overridden in stateful to skip TimedObjectLocalBean
+   */
+  public void singleInterfaceLocal() {
+    assertEquals("local interface & Serializable:", resultReset[0],
+        serializableLocalBean.businessMethodLocal1(args)[0]);
+    assertEquals("local interface & Externalizable:", resultReset[0],
+        externalizableLocalBean.businessMethodLocal1(args)[0]);
+    assertEquals("local interface & SessionBean:", resultReset[0],
+        sessionBeanLocalBean.businessMethodLocal1(args)[0]);
+  }
+
+  /*
+   * testName: multipleAnnotatedInterfacesLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  public void multipleAnnotatedInterfacesLocal() {
+    assertEquals("Multi @local interfaces:", resultReset[0],
+        annotatedInterfaceBean1.businessMethodLocal1(args)[0]);
+    assertEquals("Multi @local interfaces:", resultReset[0],
+        annotatedInterfaceBean2.businessMethodLocal1(args)[0]);
+  }
+
+  /*
+   * testName: localAndNoInterfaceView
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  public void localAndNoInterfaceView() {
+    appendReason(
+        "localAndNoInterfaceBeanLocalView: " + localAndNoInterfaceBeanLocalView,
+        "localAndNoInterfaceBeanNoInterfaceView: "
+            + localAndNoInterfaceBeanNoInterfaceView);
+    assertEquals("Local and no-interface view:", resultReset[0],
+        localAndNoInterfaceBeanLocalView.businessMethodLocal1(args)[0]);
+    assertEquals("Local and no-interface view:", resultReset[0],
+        localAndNoInterfaceBeanNoInterfaceView.businessMethodLocal1(args)[0]);
+  }
+
+  /*
+   * testName: getBusinessObjectInSuperclassBean
+   * 
+   * @test_Strategy: Try to get the business object with a particular interface,
+   * and call a method on the obtained business object. It verifies that the
+   * bean SuperclassBean only expose a local interface BusinessLocalIF1, and no
+   * no-interface view.
+   */
+  public void getBusinessObjectInSuperclassBean() {
+    List<String> expected = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SuperclassBean.class.getSimpleName());
+    String[] businessObjects = new String[2];
+    superclassBean.businessMethodLocal1(businessObjects);
+    assertEquals(null, expected, Arrays.asList(businessObjects));
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/view/equals/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/equals/JsfClient.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.view.equals;
+
+import com.sun.ts.tests.ejb30.common.busiface.AnnotatedLocalBusinessInterface1;
+import com.sun.ts.tests.ejb30.common.busiface.BusinessLocalIF1;
+import com.sun.ts.tests.ejb30.common.busiface.BusinessLocalIF2;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+
+import jakarta.ejb.EJB;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends EJBLiteJsfClientBase {
+
+  @EJB(name = "noInterfaceStateless", beanName = "StatelessEqualsBean")
+  private StatelessEqualsBean noInterfaceStateless;
+
+  @EJB(name = "noInterfaceStatelessAgain", beanName = "StatelessEqualsBean")
+  private StatelessEqualsBean noInterfaceStatelessAgain;
+
+  @EJB(beanName = "StatelessEqualsBean", name = "businessLocalIF1Stateless")
+  private BusinessLocalIF1 businessLocalIF1Stateless;
+
+  @EJB(beanName = "StatelessEqualsBean", name = "businessLocalIF2Stateless")
+  private BusinessLocalIF2 businessLocalIF2Stateless;
+
+  @EJB(beanName = "StatelessEqualsBean", name = "annotatedLocalBusinessInterface1Stateless")
+  private AnnotatedLocalBusinessInterface1 annotatedLocalBusinessInterface1Stateless;
+
+  @EJB(name = "noInterfaceStateful", beanName = "StatefulEqualsBean")
+  private StatefulEqualsBean noInterfaceStateful;
+
+  @EJB(name = "noInterfaceStatefulAgain", beanName = "StatefulEqualsBean")
+  private StatefulEqualsBean noInterfaceStatefulAgain;
+
+  @EJB(beanName = "StatefulEqualsBean", name = "businessLocalIF1Stateful")
+  private BusinessLocalIF1 businessLocalIF1Stateful;
+
+  @EJB(beanName = "StatefulEqualsBean", name = "businessLocalIF2Stateful")
+  private BusinessLocalIF2 businessLocalIF2Stateful;
+
+  @EJB(beanName = "SingletonEqualsBean", name = "businessLocalIF1Singleton")
+  private BusinessLocalIF1 businessLocalIF1Singleton;
+
+  @EJB(beanName = "SingletonEqualsBean", name = "businessLocalIF1SingletonAgain")
+  private BusinessLocalIF1 businessLocalIF1SingletonAgain;
+
+  @EJB(beanName = "SingletonEqualsBean", name = "businessLocalIF2Singleton")
+  private BusinessLocalIF2 businessLocalIF2Singleton;
+
+  /*
+   * @testName: statelessEquals
+   */
+  public void statelessEquals() {
+    StatelessEqualsBean b0 = (StatelessEqualsBean) lookup(
+        "noInterfaceStateless", "StatelessEqualsBean",
+        StatelessEqualsBean.class);
+    StatelessEqualsBean b00 = (StatelessEqualsBean) lookup(
+        "noInterfaceStatelessAgain", "StatelessEqualsBean",
+        StatelessEqualsBean.class);
+
+    // self equals, equals among bean refs to the same EJB of the same business
+    // interface
+    assertEquals(null, noInterfaceStateless, noInterfaceStateless);
+    assertEquals(null, b0, b0);
+    assertEquals(null, b0, b00);
+    assertEquals(null, noInterfaceStateless, b0);
+    assertEquals(null, noInterfaceStateless, noInterfaceStatelessAgain);
+
+    // not equals if having different business interface
+    assertNotEquals(null, noInterfaceStateless, businessLocalIF1Stateless);
+    assertNotEquals(null, noInterfaceStateless, businessLocalIF2Stateless);
+    assertNotEquals(null, noInterfaceStateless,
+        annotatedLocalBusinessInterface1Stateless);
+
+    assertNotEquals(null, businessLocalIF1Stateless, businessLocalIF2Stateless);
+    assertNotEquals(null, businessLocalIF1Stateless,
+        annotatedLocalBusinessInterface1Stateless);
+
+    assertNotEquals(null, annotatedLocalBusinessInterface1Stateless,
+        businessLocalIF2Stateless);
+
+    // different bean types of the same business interface are not equal
+    assertNotEquals(null, businessLocalIF1Singleton, businessLocalIF1Stateless);
+    assertNotEquals(null, businessLocalIF1Stateful, businessLocalIF1Stateless);
+    assertNotEquals(null, businessLocalIF1Stateful, businessLocalIF1Singleton);
+
+    // bean ref from calling getBusinessObject
+    StatelessEqualsBean bob0 = noInterfaceStateless
+        .getBusinessObject(StatelessEqualsBean.class);
+    StatelessEqualsBean bob00 = noInterfaceStateless
+        .getBusinessObject(StatelessEqualsBean.class);
+
+    assertEquals(null, bob0, bob00);
+    assertEquals(null, bob00, noInterfaceStatelessAgain);
+
+    StatelessEqualsBean boba = noInterfaceStatelessAgain
+        .getBusinessObject(StatelessEqualsBean.class);
+    StatelessEqualsBean bobaa = noInterfaceStatelessAgain
+        .getBusinessObject(StatelessEqualsBean.class);
+
+    assertEquals(null, boba, bob0);
+    assertEquals(null, bobaa, noInterfaceStateless);
+  }
+
+  /*
+   * @testName: statefulEquals
+   */
+  public void statefulEquals() {
+    StatefulEqualsBean b0 = (StatefulEqualsBean) lookup("noInterfaceStateful",
+        "StatefulEqualsBean", StatefulEqualsBean.class);
+    StatefulEqualsBean b00 = (StatefulEqualsBean) lookup(
+        "noInterfaceStatefulAgain", "StatefulEqualsBean",
+        StatefulEqualsBean.class);
+
+    // self equals, not equals among bean refs to the same EJB of the same
+    // business interface
+    assertEquals(null, noInterfaceStateful, noInterfaceStateful);
+    assertEquals(null, b0, b0);
+    assertNotEquals(null, b00, b0);
+    assertNotEquals(null, noInterfaceStateful, b0);
+    assertNotEquals(null, noInterfaceStateful, noInterfaceStatefulAgain);
+
+    // not equals if having different business interface
+    assertNotEquals(null, noInterfaceStateful, businessLocalIF1Stateful);
+    assertNotEquals(null, noInterfaceStateful, businessLocalIF2Stateful);
+
+    assertNotEquals(null, businessLocalIF1Stateful, businessLocalIF2Stateful);
+
+    // bean ref from calling getBusinessObject
+    StatefulEqualsBean bob0 = noInterfaceStateful
+        .getBusinessObject(StatefulEqualsBean.class);
+    StatefulEqualsBean bob00 = noInterfaceStateful
+        .getBusinessObject(StatefulEqualsBean.class);
+
+    assertEquals(null, bob0, bob00);
+    assertEquals(null, bob00, noInterfaceStateful);
+
+    StatefulEqualsBean boba = noInterfaceStatefulAgain
+        .getBusinessObject(StatefulEqualsBean.class);
+    StatefulEqualsBean bobaa = noInterfaceStatefulAgain
+        .getBusinessObject(StatefulEqualsBean.class);
+
+    assertNotEquals(null, boba, bob0);
+    assertNotEquals(null, bobaa, noInterfaceStateful);
+  }
+
+  /*
+   * @testName: singletonEquals
+   */
+  public void singletonEquals() {
+    BusinessLocalIF1 b0 = (BusinessLocalIF1) lookup("businessLocalIF1Singleton",
+        "SingletonEqualsBean", BusinessLocalIF1.class);
+    BusinessLocalIF1 b00 = (BusinessLocalIF1) lookup(
+        "businessLocalIF1SingletonAgain", "SingletonEqualsBean",
+        BusinessLocalIF1.class);
+
+    // self equals, equals among bean refs to the same EJB of the same business
+    // interface
+    assertEquals(null, b0, b0);
+    assertEquals(null, b0, b00);
+    assertEquals(null, businessLocalIF1Singleton,
+        businessLocalIF1SingletonAgain);
+
+    // not equals if having different business interface
+    assertNotEquals(null, businessLocalIF1Singleton, businessLocalIF2Singleton);
+  }
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/JsfClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.view.singleton.annotated;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.ejb.EJB;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends com.sun.ts.tests.ejb30.lite.view.common.JsfClientBase {
+
+  @EJB(beanName = "LocalAndNoInterfaceBean", beanInterface = LocalAndNoInterfaceBean.class)
+  protected void setLocalAndNoInterfaceBeanNoInterfaceView(
+      LocalAndNoInterfaceBean b) {
+    this.localAndNoInterfaceBeanNoInterfaceView = b;
+  }
+
+  @EJB(beanName = "SubclassExtendsPOJOBean")
+  private SubclassExtendsPOJOBean subclassExtendsPOJOBean;
+
+  @EJB(beanName = "SubclassExtendsBeanBean")
+  private SubclassExtendsBeanBean subclassExtendsBeanBean;
+
+  /*
+   * @testName: multipleInterfacesLocal
+   * 
+   * @assertion_ids: EJB:JAVADOC:125
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: singleInterfaceLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: multipleAnnotatedInterfacesLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: localAndNoInterfaceView
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: getBusinessObjectInSuperclassBean
+   * 
+   * @test_Strategy: Try to get the business object with a particular interface,
+   * and call a method on the obtained business object. The expected result is
+   * the interface that was used to get the business object. It shows it has
+   * succeeded in getting the desired business interface.
+   */
+  /*
+   * @testName: getBusinessObjectInSubclassBean
+   * 
+   * @test_Strategy:Try to get the business object with a particular interface,
+   * and call a method on the obtained business object. Expecting 2 results, the
+   * first result is the IllegalStateException when getting business object with
+   * BusinessLocalIF1; the second result is "SubclassBean". This is to verify
+   * that BusinessLocalIF1, which is implemented by the superclass of the bean
+   * class is not exposed as a business interface of the subclass bean.
+   */
+  public void getBusinessObjectInSubclassBean() {
+    List<String> expected = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SubclassExtendsPOJOBean.class.getSimpleName());
+    String[] businessObjects = new String[2];
+    subclassExtendsPOJOBean.businessMethodLocal1(businessObjects);
+    assertEquals(null, expected, Arrays.asList(businessObjects));
+
+    List<String> expected2 = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SubclassExtendsBeanBean.class.getSimpleName());
+    String[] businessObjects2 = new String[2];
+    subclassExtendsBeanBean.businessMethodLocal1(businessObjects2);
+    assertEquals(null, expected2, Arrays.asList(businessObjects2));
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/view/singleton/annotated/build.xml
@@ -33,6 +33,7 @@ com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface1.class,
 com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface2.class,
 com/sun/ts/tests/ejb30/common/busiface/Constants.class,
 com/sun/ts/tests/ejb30/lite/view/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/view/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/view/common/SuperclassBean.class,
 com/sun/ts/tests/ejb30/lite/view/common/SuperclassBeanBase.class
         ">

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/JsfClient.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.view.stateful.annotated;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.ejb.EJB;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends com.sun.ts.tests.ejb30.lite.view.common.JsfClientBase {
+
+  @EJB(beanName = "LocalAndNoInterfaceBean", beanInterface = LocalAndNoInterfaceBean.class)
+  protected void setLocalAndNoInterfaceBeanNoInterfaceView(
+      LocalAndNoInterfaceBean b) {
+    this.localAndNoInterfaceBeanNoInterfaceView = b;
+  }
+
+  @EJB(beanName = "SubclassExtendsPOJOBean")
+  private SubclassExtendsPOJOBean subclassExtendsPOJOBean;
+
+  @EJB(beanName = "SubclassExtendsBeanBean")
+  private SubclassExtendsBeanBean subclassExtendsBeanBean;
+
+  /*
+   * @testName: singleInterfaceLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy: overridden in stateful to skip TimedObjectLocalBean
+   */
+  @Override
+  public void singleInterfaceLocal() {
+    assertEquals("local interface & Serializable:", resultReset[0],
+        serializableLocalBean.businessMethodLocal1(args)[0]);
+    assertEquals("local interface & Externalizable:", resultReset[0],
+        externalizableLocalBean.businessMethodLocal1(args)[0]);
+    assertEquals("local interface & SessionBean:", resultReset[0],
+        sessionBeanLocalBean.businessMethodLocal1(args)[0]);
+  }
+
+  /*
+   * @testName: multipleInterfacesLocal
+   * 
+   * @assertion_ids: EJB:JAVADOC:125
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: multipleAnnotatedInterfacesLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: localAndNoInterfaceView
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+
+  /*
+   * @testName: getBusinessObjectInSubclassBean
+   * 
+   * @test_Strategy:Try to get the business object with a particular interface,
+   * and call a method on the obtained business object. Expecting 2 results, the
+   * first result is the IllegalStateException when getting business object with
+   * BusinessLocalIF1; the second result is "SubclassBean". This is to verify
+   * that BusinessLocalIF1, which is implemented by the superclass of the bean
+   * class is not exposed as a business interface of the subclass bean.
+   */
+  public void getBusinessObjectInSubclassBean() {
+    List<String> expected = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SubclassExtendsPOJOBean.class.getSimpleName());
+    String[] businessObjects = new String[2];
+    subclassExtendsPOJOBean.businessMethodLocal1(businessObjects);
+    assertEquals(null, expected, Arrays.asList(businessObjects));
+
+    List<String> expected2 = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SubclassExtendsBeanBean.class.getSimpleName());
+    String[] businessObjects2 = new String[2];
+    subclassExtendsBeanBean.businessMethodLocal1(businessObjects2);
+    assertEquals(null, expected2, Arrays.asList(businessObjects2));
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateful/annotated/build.xml
@@ -33,6 +33,7 @@ com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface1.class,
 com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface2.class,
 com/sun/ts/tests/ejb30/common/busiface/Constants.class,
 com/sun/ts/tests/ejb30/lite/view/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/view/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/view/common/SuperclassBean.class,
 com/sun/ts/tests/ejb30/lite/view/common/SuperclassBeanBase.class
         ">

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/JsfClient.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.view.stateless.annotated;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.ejb.EJB;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends com.sun.ts.tests.ejb30.lite.view.common.JsfClientBase {
+
+  @EJB(beanName = "LocalAndNoInterfaceBean", beanInterface = LocalAndNoInterfaceBean.class)
+  protected void setLocalAndNoInterfaceBeanNoInterfaceView(
+      LocalAndNoInterfaceBean b) {
+    this.localAndNoInterfaceBeanNoInterfaceView = b;
+  }
+
+  @EJB(beanName = "SubclassExtendsPOJOBean")
+  private SubclassExtendsPOJOBean subclassExtendsPOJOBean;
+
+  @EJB(beanName = "SubclassExtendsBeanBean")
+  private SubclassExtendsBeanBean subclassExtendsBeanBean;
+
+  /*
+   * @testName: multipleInterfacesLocal
+   * 
+   * @assertion_ids: EJB:JAVADOC:125
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: singleInterfaceLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: multipleAnnotatedInterfacesLocal
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: localAndNoInterfaceView
+   * 
+   * @assertion_ids:
+   * 
+   * @test_Strategy:
+   */
+  /*
+   * @testName: getBusinessObjectInSubclassBean
+   * 
+   * @test_Strategy:Try to get the business object with a particular interface,
+   * and call a method on the obtained business object. Expecting 2 results, the
+   * first result is the IllegalStateException when getting business object with
+   * BusinessLocalIF1; the second result is "SubclassBean". This is to verify
+   * that BusinessLocalIF1, which is implemented by the superclass of the bean
+   * class is not exposed as a business interface of the subclass bean.
+   */
+  public void getBusinessObjectInSubclassBean() {
+    List<String> expected = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SubclassExtendsPOJOBean.class.getSimpleName());
+    String[] businessObjects = new String[2];
+    subclassExtendsPOJOBean.businessMethodLocal1(businessObjects);
+    assertEquals(null, expected, Arrays.asList(businessObjects));
+
+    List<String> expected2 = Arrays.asList(
+        IllegalStateException.class.getSimpleName(),
+        SubclassExtendsBeanBean.class.getSimpleName());
+    String[] businessObjects2 = new String[2];
+    subclassExtendsBeanBean.businessMethodLocal1(businessObjects2);
+    assertEquals(null, expected2, Arrays.asList(businessObjects2));
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/view/stateless/annotated/build.xml
@@ -33,6 +33,7 @@ com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface1.class,
 com/sun/ts/tests/ejb30/common/busiface/AnnotatedLocalBusinessInterface2.class,
 com/sun/ts/tests/ejb30/common/busiface/Constants.class,
 com/sun/ts/tests/ejb30/lite/view/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/view/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/view/common/SuperclassBean.class,
 com/sun/ts/tests/ejb30/lite/view/common/SuperclassBeanBase.class
         ">

--- a/src/com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.xmloverride.ejbref;
+
+import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+import com.sun.ts.tests.ejb30.common.lite.NumberIF;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends EJBLiteJsfClientBase {
+
+  private TestBean getTestBean() {
+    return (TestBean) ServiceLocator
+        .lookupNoTry("java:global/" + getModuleName() + "/TestBean");
+  }
+
+  /*
+   * @testName: resolveByEjbLinkInXml
+   * 
+   * @test_Strategy: @EJB in TestBean is incomplete. But the corresponding
+   * ejb-local-ref in ejb-jar.xml resolves it with ejb-link.
+   */
+  public void resolveByEjbLinkInXml() {
+    assertEquals("Check correct target EJB is resolved. ", 1,
+        getTestBean().getNumber());
+  }
+
+  /*
+   * @testName: availableInWebComponent
+   * 
+   * @test_Strategy: the ejb-local-ref declared in ejb-jar.xml should be
+   * available for lookup in web components.
+   */
+  public void availableInWebComponent() {
+    if (getContainer() != null) {
+      return; // skip if running in ejbembed
+    }
+    NumberIF overrideBean = (NumberIF) ServiceLocator.lookupNoTry(
+        "java:comp/env/com.sun.ts.tests.ejb30.lite.xmloverride.ejbref.TestBean/overrideBean");
+    assertEquals("Look up OverrideBean and invoke: ", 1,
+        overrideBean.getNumber());
+  }
+
+  /*
+   * @testName: overrideLookup
+   * 
+   * @test_Strategy: lookup-name in ejb-jar.xml overrides lookup attr in @EJB
+   */
+  public void overrideLookup() {
+    assertEquals("Check correct target EJB is resolved. ", 1,
+        getTestBean().overrideLookup());
+  }
+
+  /*
+   * @testName: overrideInterfaceType
+   * 
+   * @test_Strategy: <local> in ejb-jar.xml overrides beanInterface attr in @EJB
+   */
+  public void overrideInterfaceType() {
+    assertEquals("Check correct target EJB is resolved. ", 1,
+        getTestBean().overrideInterfaceType());
+  }
+
+  /*
+   * @testName: overrideBeanName
+   * 
+   * @test_Strategy: <ejb-link> in ejb-jar.xml overrides beanName attr in @EJB
+   */
+  public void overrideBeanName() {
+    assertEquals("Check correct target EJB is resolved. ", 1,
+        getTestBean().overrideBeanName());
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfClient.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.lite.xmloverride.resource;
+
+import com.sun.ts.tests.ejb30.common.helper.ServiceLocator;
+import com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase;
+
+import jakarta.annotation.Resource;
+
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends EJBLiteJsfClientBase {
+  @Resource(name = "unmappedEnvEntry")
+  private Integer unmappedEnvEntry = 1;
+
+  private TestBean getTestBean() {
+    return (TestBean) ServiceLocator
+        .lookupNoTry("java:global/" + getModuleName() + "/TestBean");
+  }
+
+  /*
+   * @testName: unmappedEnvEntry
+   *
+   * @test_Strategy: this @Resource has no mapped <env-entry> in descriptor, so
+   * the default value of the field is unchanged.
+   */
+  public void unmappedEnvEntry() {
+    assertEquals("Check correct the default value is retained. ", 1,
+        unmappedEnvEntry);
+  }
+}


### PR DESCRIPTION
**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/987, https://github.com/eclipse-ee4j/jakartaee-tck/issues/986 

**Related Issue(s)**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/968

**Describe the change**
Create new Faces client for tests running in ejblitejsf vehicle 

**Additional context**
There are 4 test failures post this change in ejb30/lite/xmloverride due to `javax.naming.NameNotFoundException`
com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java#overrideBeanName_from_ejblitejsf
com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java#overrideInterfaceType_from_ejblitejsf
com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java#resolveByEjbLinkInXml_from_ejblitejsf
com/sun/ts/tests/ejb30/lite/xmloverride/ejbref/JsfClient.java#resolveByEjbLinkInXml_from_ejblitejsf

These can be addressed in a separate PR.

CC @scottmarlow @gurunrao @starksm64 
