### PR TITLE
Migrate ejb30/bb/session/stateful/concurrency tests to have new client for ejblitejsf tests

### DIFF
--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -334,10 +334,10 @@ com/sun/ts/tests/ejb30/bb/async/stateless/metadata/JsfClient.java = ejblitejsf
 com/sun/ts/tests/ejb30/bb/async/stateless/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp
 
 com/sun/ts/tests/ejb30/bb/session/stateful/timeout = ejblitejsp 
-com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp 
-com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/JsfClient.java = ejblitejsf 
-com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp
-com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/JsfClient.java = ejblitejsf 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/JsfClient.java = ejblitejsf 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/JsfClient.java = ejblitejsf 
 
 com/sun/ts/tests/ejb32/lite  = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp ejbembed
 com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed

--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -334,6 +334,7 @@ com/sun/ts/tests/ejb30/bb/async/stateless/metadata/JsfClient.java = ejblitejsf
 com/sun/ts/tests/ejb30/bb/async/stateless/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp
 
 com/sun/ts/tests/ejb30/bb/session/stateful/timeout = ejblitejsp 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp
 com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp 
 com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/JsfClient.java = ejblitejsf 
 com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp

--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -334,7 +334,10 @@ com/sun/ts/tests/ejb30/bb/async/stateless/metadata/JsfClient.java = ejblitejsf
 com/sun/ts/tests/ejb30/bb/async/stateless/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp
 
 com/sun/ts/tests/ejb30/bb/session/stateful/timeout = ejblitejsp 
-com/sun/ts/tests/ejb30/bb/session/stateful/concurrency = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/JsfClient.java = ejblitejsf 
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp
+com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/JsfClient.java = ejblitejsf 
 
 com/sun/ts/tests/ejb32/lite  = ejbliteservlet ejbliteservlet2 ejblitejsf ejblitejsp ejbembed
 com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/JsfClient.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.bb.session.stateful.concurrency.accesstimeout.annotated;
+
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.CONCURRENT_INVOCATION_TIMES;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF;
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.JsfClientBase;
+
+import jakarta.ejb.ConcurrentAccessException;
+import jakarta.ejb.ConcurrentAccessTimeoutException;
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBs;
+
+@EJBs({
+    @EJB(name = AccessTimeoutIF.beanClassMethodLevelOverrideAccessTimeoutBeanRemote, beanName = "BeanClassMethodLevelOverrideAccessTimeoutBean", beanInterface = AccessTimeoutRemoteIF.class),
+    @EJB(name = AccessTimeoutIF.beanClassMethodLevelAccessTimeoutBeanRemote, beanName = "BeanClassMethodLevelAccessTimeoutBean", beanInterface = AccessTimeoutRemoteIF.class),
+    @EJB(name = AccessTimeoutIF.beanClassLevelAccessTimeoutBeanRemote, beanName = "BeanClassLevelAccessTimeoutBean", beanInterface = AccessTimeoutRemoteIF.class),
+    @EJB(name = AccessTimeoutIF.annotatedSuperClassAccessTimeoutBeanRemote, beanName = "AnnotatedSuperClassAccessTimeoutBean", beanInterface = AccessTimeoutRemoteIF.class)
+
+})
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends JsfClientBase {
+  protected List<Exception> concurrentPing(AccessTimeoutIF b, String m)
+      throws InterruptedException {
+    List<Future<String>> futureList = new ArrayList<Future<String>>();
+    List<Exception> exceptionList = new ArrayList<Exception>();
+    for (int i = 0; i < CONCURRENT_INVOCATION_TIMES; i++) {
+      Future<String> f = null;
+
+      if (m.equals("beanClassLevel")) {
+        f = b.beanClassLevel();
+      } else if (m.equals("beanClassLevel2")) {
+        f = b.beanClassLevel2();
+      } else if (m.equals("beanSuperClassLevel")) {
+        f = b.beanSuperClassLevel();
+      } else if (m.equals("beanSuperClassMethodLevel")) {
+        f = b.beanSuperClassMethodLevel();
+      } else if (m.equals("beanSuperClassMethodLevelOverride")) {
+        f = b.beanSuperClassMethodLevelOverride();
+      } else if (m.equals("beanClassMethodLevel")) {
+        f = b.beanClassMethodLevel();
+      } else if (m.equals("beanClassMethodLevelOverride")) {
+        f = b.beanClassMethodLevelOverride();
+      } else {
+        throw new RuntimeException("Bad method name: " + m);
+      }
+
+      futureList.add(f);
+    }
+    for (Future<String> f : futureList) {
+      ConcurrentAccessException e = null;
+      try {
+        f.get();
+      } catch (ExecutionException ee) {
+        e = (ConcurrentAccessTimeoutException) ee.getCause();
+      }
+      exceptionList.add(e);
+    }
+    return exceptionList;
+  }
+
+  /*
+   * @testName: beanClassLevel
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanClassLevel() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getBeanClassLevelAccessTimeoutBeanRemote(), getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
+
+  /*
+   * @testName: beanClassLevel2
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanClassLevel2() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getBeanClassLevelAccessTimeoutBeanRemote(), getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
+
+  /*
+   * @testName: beanSuperClassLevel
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanSuperClassLevel() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getAnnotatedSuperClassAccessTimeoutBeanRemote(), getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
+
+  /*
+   * @testName: beanSuperClassMethodLevel
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanSuperClassMethodLevel() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getAnnotatedSuperClassAccessTimeoutBeanRemote(), getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
+
+  /*
+   * @testName: beanSuperClassMethodLevelOverride
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanSuperClassMethodLevelOverride() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getAnnotatedSuperClassAccessTimeoutBeanRemote(), getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList,
+        CONCURRENT_INVOCATION_TIMES, 0);
+  }
+
+  /*
+   * @testName: beanClassMethodLevel
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanClassMethodLevel() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getBeanClassMethodLevelAccessTimeoutBeanRemote(), getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
+
+  /*
+   * @testName: beanClassMethodLevelOverride
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void beanClassMethodLevelOverride() throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(
+        getBeanClassMethodLevelOverrideAccessTimeoutBeanRemote(),
+        getTestName());
+    checkConcurrentAccessTimeoutResult(exceptionList,
+        CONCURRENT_INVOCATION_TIMES, 0);
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/accesstimeout/annotated/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,9 +32,11 @@ com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/Pinger.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyIF.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyJsfClientBase.class,
 
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/AccessTimeoutIF.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase*.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClassLevelAnnotatedAccessTimeoutBeanBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/MethodLevelAnnotatedAccessTimeoutBeanBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/PlainAccessTimeoutBeanBase.class

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/JsfClient.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb30.bb.session.stateful.concurrency.metadata.annotated;
+
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.CONCURRENT_INVOCATION_TIMES;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.containerConcurrencyBeanNoInterface;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.containerConcurrencyBeanRemote;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.defaultConcurrencyBeanNoInterface;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.defaultConcurrencyBeanRemote;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.notAllowedConcurrencyBeanNoInterface;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.notAllowedConcurrencyBeanRemote;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF;
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.common.JsfClientBase;
+
+import jakarta.ejb.ConcurrentAccessException;
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBs;
+
+@EJBs({
+    @EJB(name = containerConcurrencyBeanNoInterface, beanName = "ContainerConcurrencyBean", beanInterface = ContainerConcurrencyBean.class),
+    @EJB(name = defaultConcurrencyBeanNoInterface, beanName = "DefaultConcurrencyBean", beanInterface = DefaultConcurrencyBean.class),
+    @EJB(name = notAllowedConcurrencyBeanNoInterface, beanName = "NotAllowedConcurrencyBean", beanInterface = NotAllowedConcurrencyBean.class),
+
+    @EJB(name = containerConcurrencyBeanRemote, beanName = "ContainerConcurrencyBean", beanInterface = StatefulConcurrencyRemoteIF.class),
+    @EJB(name = defaultConcurrencyBeanRemote, beanName = "DefaultConcurrencyBean", beanInterface = StatefulConcurrencyRemoteIF.class),
+    @EJB(name = notAllowedConcurrencyBeanRemote, beanName = "NotAllowedConcurrencyBean", beanInterface = StatefulConcurrencyRemoteIF.class) })
+@jakarta.inject.Named("client")
+@jakarta.enterprise.context.RequestScoped
+public class JsfClient extends JsfClientBase {
+
+  /*
+   * @testName: notAllowed
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void notAllowed() throws InterruptedException {
+    StatefulConcurrencyIF[] bs = { getNotAllowedConcurrencyBeanNoInterface(),
+        getNotAllowedConcurrencyBeanRemote() };
+    for (StatefulConcurrencyIF b : bs) {
+      checkConcurrentAccessResult(concurrentPing(b), 1, 1);
+    }
+  }
+
+  /*
+   * @testName: containerConcurrent
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void containerConcurrent() throws InterruptedException {
+    containerConcurrent(getContainerConcurrencyBeanLocal(),
+        getContainerConcurrencyBeanNoInterface(),
+        getContainerConcurrencyBeanRemote());
+  }
+
+  /*
+   * @testName: defaultConcurrent
+   * 
+   * @test_Strategy:
+   */
+  @Override
+  public void defaultConcurrent() throws InterruptedException {
+    containerConcurrent(getDefaultConcurrencyBeanLocal(),
+        getDefaultConcurrencyBeanNoInterface(),
+        getDefaultConcurrencyBeanRemote());
+  }
+
+  @Override
+  protected List<Exception> concurrentPing(StatefulConcurrencyIF b)
+      throws InterruptedException {
+    List<Future<String>> futureList = new ArrayList<Future<String>>();
+    List<Exception> exceptionList = new ArrayList<Exception>();
+    for (int i = 0; i < CONCURRENT_INVOCATION_TIMES; i++) {
+      futureList.add(b.ping());
+    }
+    for (Future<String> f : futureList) {
+      ConcurrentAccessException e = null;
+      String targetBeanHash = null;
+      try {
+        targetBeanHash = f.get();
+        appendReason("The identityHashCode of the target bean instance: "
+            + targetBeanHash);
+      } catch (ExecutionException ee) {
+        e = (ConcurrentAccessException) ee.getCause();
+      }
+      exceptionList.add(e);
+    }
+    return exceptionList;
+  }
+}

--- a/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/bb/session/stateful/concurrency/metadata/annotated/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,9 @@ com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/Pinger.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyIF.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyJsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/StatefulConcurrencyBeanBase.class
         ">
         </ts.vehicles>

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,6 @@
 com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/Pinger.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyIF.class,
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyJsfClientBase.class,
 

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/build.xml
@@ -32,8 +32,8 @@ com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClien
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyJsfClientBase.class,
 
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/AccessTimeoutIF.class,
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase*.class,
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/JsfClientBase*.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/PlainAccessTimeoutBeanBase.class
         ">
         </ts.vehicles>


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/968

**Describe the change**
Adds new faces client for tests in ejb30/bb/session/stateful/concurrency that runs in ejblitejsf vehicle


CC @starksm64 @gurunrao @scottmarlow 
