### PR TITLE
add glassfish-web.xml for pluggability tests.

### DIFF
--- a/src/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/build.xml
+++ b/src/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,6 +60,8 @@ $Id$
                       prefix="WEB-INF/classes"/>
           <zipfileset dir="${ts.home}/lib" includes="${provider.jar}"
                       prefix="WEB-INF/lib"/>
+          <zipfileset dir="." includes="glassfish-web.xml"
+                      prefix="WEB-INF"/>
         </servlet-elements>
         <jsp-elements>
           <zipfileset dir="${class.dir}" includes="${other.classes}"
@@ -68,6 +70,8 @@ $Id$
                       prefix="WEB-INF/classes"/>
           <zipfileset dir="${ts.home}/lib" includes="${provider.jar}"
                       prefix="WEB-INF/lib"/>
+          <zipfileset dir="." includes="glassfish-web.xml"
+                      prefix="WEB-INF"/>
         </jsp-elements>
 	<ear-elements>
 	    <zipfileset dir="${ts.home}/lib" includes="${provider.jar}" prefix="lib"/>

--- a/src/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/glassfish-web.xml
+++ b/src/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/glassfish-web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<glassfish-web-app>
+  <class-loader delegate="false"/>
+</glassfish-web-app>


### PR DESCRIPTION
Based on comment https://github.com/eclipse-ee4j/glassfish/issues/23892#issuecomment-1132231323  fix for GF pluggability at  TCK.
Fix will not be required if failures are fixed at GF.

Signed-off-by: gurunrao <gurunandan.rao@oracle.com>
