### PR TITLE
add exports jvm option for jdk.internal.vm.annotation sig test failure.

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -188,6 +188,7 @@ ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwo
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} set server-config.network-config.network-listeners.network-listener.admin-listener.port=5858
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Dorg.glassfish.orb.iiop.orbserverid=200
 
+
 sleep 5
 echo "Stopping RI domain"
 ${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} stop-domain
@@ -262,6 +263,7 @@ ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --password
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} version
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options -Djava.security.manager
+${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} create-jvm-options --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} stop-domain
 
 sleep 5


### PR DESCRIPTION
Fix for signature test failure ( detailed log - https://ci.eclipse.org/jakartaee-tck/job/10/job/eftl-jakartaeetck-run-100/71/testReport/junit/com.sun.ts.tests.signaturetest.javaee/JavaEESigTest/signatureTest_from_servlet/)

`caused by: java.lang.reflect.InaccessibleObjectException: Unable to make public abstract java.lang.String jdk.internal.vm.annotation.Contended.value() accessible: module java.base does not "exports jdk.internal.vm.annotation" to unnamed module @29ecdfb0
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:198)
	at java.base/java.lang.reflect.AccessibleObject.setAccessible(AccessibleObject.java:123)`
Signed-off-by: gurunrao <gurunandan.rao@oracle.com>

