### PR TITLE
revert WEB PROFILE signature test without concurrency as in 9.1.X

### DIFF
--- a/src/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java
+++ b/src/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -87,7 +87,7 @@ public class JavaEESigTest extends SigTestEE {
       + " cdi di beanval persistence jaxb saaj jaxws connector"
       + " jacc jaspic jsonp jta el servlet jsf jaxrs websocket batch concurrency jsonb securityapi";
 
-  public static final String KEYWORD_WEB = "caj ejb persistence el jsf jsonp jsp servlet jta jaxrs cdi di beanval interceptors websocket concurrency jsonb securityapi";
+  public static final String KEYWORD_WEB = "caj ejb persistence el jsf jsonp jsp servlet jta jaxrs cdi di beanval interceptors websocket jsonb securityapi";
 
   public static final ArrayList<String> KEYWORD_JAVAEE_FULL_OPTIONAL_TECHS = new ArrayList<String>();
 


### PR DESCRIPTION
revert WEB PROFILE signature test without concurrency as in 9.1.X (https://github.com/eclipse-ee4j/jakartaee-tck/blob/9.1.x/src/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java#L90 to be used as reference).
Signed-off-by: gurunrao <gurunandan.rao@oracle.com>

