### PR TITLE
More changes for #998 package ejb30.lite.stateful.concurrency.accesstimeout

### DIFF
--- a/install/jakartaee/bin/build.xml
+++ b/install/jakartaee/bin/build.xml
@@ -23,8 +23,39 @@
 	<import file="../../../bin/xml/ts.top.import.xml" optional="true"/>
 
 	<property name="all.test.dir" value="
-                  com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout
-                  "/>
+                  com/sun/ts/tests/jaxp,
+                  com/sun/ts/tests/jacc,
+                  com/sun/ts/tests/jaspic,
+                  com/sun/ts/tests/signaturetest/javaee,
+                  com/sun/ts/tests/integration,
+                  com/sun/ts/tests/el,
+                  com/sun/ts/tests/ejb,
+                  com/sun/ts/tests/ejb30,
+                  com/sun/ts/tests/ejb32,
+                  com/sun/ts/tests/jpa,
+                  com/sun/ts/tests/jdbc,
+                  com/sun/ts/tests/connector,
+                  com/sun/ts/tests/xa,
+                  com/sun/ts/tests/jaxrs,
+                  com/sun/ts/tests/servlet,
+                  com/sun/ts/tests/javaee,
+                  com/sun/ts/tests/jsf,
+                  com/sun/ts/tests/jsp,
+                  com/sun/ts/tests/jstl,
+                  com/sun/ts/tests/appclient,
+                  com/sun/ts/tests/javamail,
+                  com/sun/ts/tests/assembly,
+                  com/sun/ts/tests/jta,
+                  com/sun/ts/tests/samples,
+                  com/sun/ts/tests/jms,
+                  com/sun/ts/tests/jsonp,
+                  com/sun/ts/tests/jsonb,
+                  com/sun/ts/tests/jaxws/common,
+                  com/sun/ts/tests/jaxws/wsi/constants,
+                  com/sun/ts/tests/webservices12,
+                  com/sun/ts/tests/webservices13,
+                  com/sun/ts/tests/websocket,
+                  com/sun/ts/tests/securityapi"/>
 
 	<!--
           These jaspic dirs involve tests that are not required for Java EE 6.

--- a/install/jakartaee/bin/build.xml
+++ b/install/jakartaee/bin/build.xml
@@ -23,39 +23,8 @@
 	<import file="../../../bin/xml/ts.top.import.xml" optional="true"/>
 
 	<property name="all.test.dir" value="
-                  com/sun/ts/tests/jaxp,
-                  com/sun/ts/tests/jacc,
-                  com/sun/ts/tests/jaspic,
-                  com/sun/ts/tests/signaturetest/javaee,
-                  com/sun/ts/tests/integration,
-                  com/sun/ts/tests/el,
-                  com/sun/ts/tests/ejb,
-                  com/sun/ts/tests/ejb30,
-                  com/sun/ts/tests/ejb32,
-                  com/sun/ts/tests/jpa,
-                  com/sun/ts/tests/jdbc,
-                  com/sun/ts/tests/connector,
-                  com/sun/ts/tests/xa,
-                  com/sun/ts/tests/jaxrs,
-                  com/sun/ts/tests/servlet,
-                  com/sun/ts/tests/javaee,
-                  com/sun/ts/tests/jsf,
-                  com/sun/ts/tests/jsp,
-                  com/sun/ts/tests/jstl,
-                  com/sun/ts/tests/appclient,
-                  com/sun/ts/tests/javamail,
-                  com/sun/ts/tests/assembly,
-                  com/sun/ts/tests/jta,
-                  com/sun/ts/tests/samples,
-                  com/sun/ts/tests/jms,
-                  com/sun/ts/tests/jsonp,
-                  com/sun/ts/tests/jsonb,
-                  com/sun/ts/tests/jaxws/common,
-                  com/sun/ts/tests/jaxws/wsi/constants,
-                  com/sun/ts/tests/webservices12,
-                  com/sun/ts/tests/webservices13,
-                  com/sun/ts/tests/websocket,
-                  com/sun/ts/tests/securityapi"/>
+                  com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout
+                  "/>
 
 	<!--
           These jaspic dirs involve tests that are not required for Java EE 6.

--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -152,8 +152,8 @@ com/sun/ts/tests/ejb30/lite/stateful/timeout = ejblitejsp ejbembed
 
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/JsfClient.java = ejblitejsf
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/JsfClient.java = ejblitejsf
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor = ejblitejsf
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/JsfClient.java = ejblitejsf
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/descriptor/JsfClient.java = ejblitejsf

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/build.xml
@@ -31,7 +31,7 @@ com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyIF.cl
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
 
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/AccessTimeoutIF.class,
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase*.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/PlainAccessTimeoutBeanBase.class
         ">
         </ts.vehicles>

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/BeanClassLevelAccessTimeoutBean.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/BeanClassLevelAccessTimeoutBean.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.jsfdescriptor;
+
+import java.util.concurrent.Future;
+
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF;
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.PlainAccessTimeoutBeanBase;
+import jakarta.ejb.Stateful;
+
+@Stateful
+public class BeanClassLevelAccessTimeoutBean extends PlainAccessTimeoutBeanBase
+    implements AccessTimeoutIF {
+
+  @Override
+  public Future<String> beanClassLevel() {
+    return ping();
+  }
+
+  @Override
+  public Future<String> beanClassLevel2() {
+    return ping();
+  }
+
+  @Override
+  public Future<String> beanClassMethodLevel() {
+    return ping();
+  }
+
+}

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/JsfClient.java
@@ -17,7 +17,9 @@
 /*
  * $Id$
  */
-package com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.descriptor;
+package com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.jsfdescriptor;
+
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.CONCURRENT_INVOCATION_TIMES;
 
 import java.io.Serializable;
 import java.util.List;
@@ -26,8 +28,6 @@ import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.Acc
 import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.JsfClientBase;
 import jakarta.ejb.EJB;
 import jakarta.ejb.EJBs;
-
-import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.CONCURRENT_INVOCATION_TIMES;
 
 @EJBs({
     @EJB(name = AccessTimeoutIF.beanClassLevelAccessTimeoutBeanLocal, beanName = "BeanClassLevelAccessTimeoutBean", beanInterface = AccessTimeoutIF.class) })

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/JsfClient.java
@@ -19,13 +19,21 @@
  */
 package com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.jsfdescriptor;
 
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.annotatedSuperClassAccessTimeoutBeanLocal;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.annotatedSuperClassAccessTimeoutBeanRemote;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.beanClassLevelAccessTimeoutBeanLocal;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.beanClassLevelAccessTimeoutBeanRemote;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.beanClassMethodLevelAccessTimeoutBeanLocal;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.beanClassMethodLevelAccessTimeoutBeanRemote;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.beanClassMethodLevelOverrideAccessTimeoutBeanLocal;
+import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF.beanClassMethodLevelOverrideAccessTimeoutBeanRemote;
 import static com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF.CONCURRENT_INVOCATION_TIMES;
 
 import java.io.Serializable;
 import java.util.List;
 
 import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF;
-import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.JsfClientBase;
+import com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyJsfClientBase;
 import jakarta.ejb.EJB;
 import jakarta.ejb.EJBs;
 
@@ -33,23 +41,47 @@ import jakarta.ejb.EJBs;
     @EJB(name = AccessTimeoutIF.beanClassLevelAccessTimeoutBeanLocal, beanName = "BeanClassLevelAccessTimeoutBean", beanInterface = AccessTimeoutIF.class) })
 @jakarta.inject.Named("client")
 @jakarta.enterprise.context.RequestScoped
-public class JsfClient extends JsfClientBase implements Serializable {
+public class JsfClient extends StatefulConcurrencyJsfClientBase implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
   /*
-   * @testName: beanClassLevel
-   * 
-   * @test_Strategy: ejb-jar.xml declares <concurrent-method> and their
-   * <access-timeout>
+   * testName: beanClassLevel
+   *
+   * @test_Strategy:
    */
+  public void beanClassLevel() throws InterruptedException {
+    beanClassLevel(getBeanClassLevelAccessTimeoutBeanLocal());
+  }
+
+  protected void beanClassLevel(final AccessTimeoutIF b)
+      throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(new Runnable() {
+      public void run() {
+        b.beanClassLevel();
+      }
+    });
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
 
   /*
-   * @testName: beanClassLevel2
-   * 
-   * @test_Strategy: ejb-jar.xml declares <concurrent-method> and their
-   * <access-timeout>
+   * testName: beanClassLevel2
+   *
+   * @test_Strategy:
    */
+  public void beanClassLevel2() throws InterruptedException {
+    beanClassLevel2(getBeanClassLevelAccessTimeoutBeanLocal());
+  }
+
+  protected void beanClassLevel2(final AccessTimeoutIF b)
+      throws InterruptedException {
+    List<Exception> exceptionList = concurrentPing(new Runnable() {
+      public void run() {
+        b.beanClassLevel2();
+      }
+    });
+    checkConcurrentAccessTimeoutResult(exceptionList, 1, 1);
+  }
 
   /*
    * @testName: pingMethodInBeanSuperClass
@@ -73,7 +105,6 @@ public class JsfClient extends JsfClientBase implements Serializable {
    * @test_Strategy: beanClassMethodLevel is a concurrent method with default
    * access-timeout. It is not declared in ejb-jar.xml with <concurrent-method>
    */
-  @Override
   public void beanClassMethodLevel() throws InterruptedException {
     final AccessTimeoutIF b = getBeanClassLevelAccessTimeoutBeanLocal();
     List<Exception> exceptionList = concurrentPing(new Runnable() {
@@ -83,6 +114,71 @@ public class JsfClient extends JsfClientBase implements Serializable {
     });
     checkConcurrentAccessTimeoutResult(exceptionList,
         CONCURRENT_INVOCATION_TIMES, 0);
+  }
+
+  // remote view tests are only available in JavaEE profile
+  protected AccessTimeoutIF getBeanClassMethodLevelOverrideAccessTimeoutBeanLocal() {
+    return (AccessTimeoutIF) lookup(
+        beanClassMethodLevelOverrideAccessTimeoutBeanLocal, null, null);
+  }
+
+  protected AccessTimeoutIF getBeanClassMethodLevelAccessTimeoutBeanLocal() {
+    return (AccessTimeoutIF) lookup(beanClassMethodLevelAccessTimeoutBeanLocal,
+        null, null);
+  }
+
+  protected AccessTimeoutIF getBeanClassLevelAccessTimeoutBeanLocal() {
+    return (AccessTimeoutIF) lookup(beanClassLevelAccessTimeoutBeanLocal, null,
+        null);
+  }
+
+  protected AccessTimeoutIF getAnnotatedSuperClassAccessTimeoutBeanLocal() {
+    return (AccessTimeoutIF) lookup(annotatedSuperClassAccessTimeoutBeanLocal,
+        null, null);
+  }
+
+  protected AccessTimeoutIF getBeanClassMethodLevelOverrideAccessTimeoutBeanRemote() {
+    return (AccessTimeoutIF) lookup(
+        beanClassMethodLevelOverrideAccessTimeoutBeanRemote, null, null);
+  }
+
+  protected AccessTimeoutIF getBeanClassMethodLevelAccessTimeoutBeanRemote() {
+    return (AccessTimeoutIF) lookup(beanClassMethodLevelAccessTimeoutBeanRemote,
+        null, null);
+  }
+
+  protected AccessTimeoutIF getBeanClassLevelAccessTimeoutBeanRemote() {
+    return (AccessTimeoutIF) lookup(beanClassLevelAccessTimeoutBeanRemote, null,
+        null);
+  }
+
+  protected AccessTimeoutIF getAnnotatedSuperClassAccessTimeoutBeanRemote() {
+    return (AccessTimeoutIF) lookup(annotatedSuperClassAccessTimeoutBeanRemote,
+        null, null);
+  }
+
+  protected void checkConcurrentAccessTimeoutResult(
+      List<Exception> exceptionList, int nullCountExpected,
+      int concurrentAccessTimeoutExceptionCountExpected) {
+    int nullCount = 0;
+    int concurrentAccessTimeoutExceptionCount = 0;
+    for (Exception e : exceptionList) {
+      if (e == null) {
+        appendReason("Got no exception, which may be correct.");
+        nullCount++;
+      } else if (e instanceof ConcurrentAccessTimeoutException) {
+        appendReason(
+            "Got ConcurrentAccessTimeoutException, which may be correct: ", e);
+        concurrentAccessTimeoutExceptionCount++;
+      } else {
+        throw new RuntimeException(
+            "Expecting null or ConcurrentAccessTimeoutException, but got ", e);
+      }
+    }
+    assertEquals("Check nullCount", nullCountExpected, nullCount);
+    assertEquals("Check concurrentAccessExceptionCount",
+        concurrentAccessTimeoutExceptionCountExpected,
+        concurrentAccessTimeoutExceptionCount);
   }
 
 }

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/JsfClient.java
@@ -34,6 +34,8 @@ import java.util.List;
 
 import com.sun.ts.tests.ejb30.lite.stateful.concurrency.accesstimeout.common.AccessTimeoutIF;
 import com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyJsfClientBase;
+
+import jakarta.ejb.ConcurrentAccessTimeoutException;
 import jakarta.ejb.EJB;
 import jakarta.ejb.EJBs;
 

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,9 +29,10 @@ com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/Pinger.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyIF.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyJsfClientBase.class,
 
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/AccessTimeoutIF.class,
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/common/PlainAccessTimeoutBeanBase.class
         ">
         </ts.vehicles>

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/ejb-jar.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/jsfdescriptor/ejb-jar.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="4.0" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+    <enterprise-beans>
+        <session>
+            <ejb-name>BeanClassLevelAccessTimeoutBean</ejb-name>
+            <concurrent-method>
+                <method>
+                    <method-name>beanClassLevel</method-name>
+                </method>
+                <lock>Write</lock>
+                <access-timeout>
+                    <!-- timeout value should equal to BEAN_CLASS_LEVEL_TIMEOUT_MILLIS in AccessTimeoutIF -->
+                    <timeout>5000</timeout>
+                    <unit>Milliseconds</unit>
+                </access-timeout>
+            </concurrent-method>
+            <concurrent-method>
+                <method>
+                    <method-name>beanClassLevel2</method-name>
+                </method>
+                <lock>Write</lock>
+                <access-timeout>
+                    <timeout>5000000</timeout>
+                    <unit>Microseconds</unit>
+                </access-timeout>
+            </concurrent-method>
+            <concurrent-method>
+                <method>
+                    <method-name>ping</method-name>
+                    <method-params/>
+                </method>
+                <lock>Write</lock>
+                <access-timeout>
+                    <timeout>5000000000</timeout>
+                    <unit>Nanoseconds</unit>
+                </access-timeout>
+            </concurrent-method>
+        </session>
+
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
https://github.com/eclipse-ee4j/jakartaee-tck/issues/998

https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-scottmarlow/job/ejb30.lite.stateful.concurrency.accesstimeout.descriptor/5/testReport/ shows zero failures in ejb30.lite.stateful.concurrency.accesstimeout testing