### PR TITLE
Fix tests in ejb30/lite/stateful/concurrency/metadata/descriptor

### DIFF
--- a/install/jakartaee/other/vehicle.properties
+++ b/install/jakartaee/other/vehicle.properties
@@ -156,8 +156,8 @@ com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/JsfCli
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/accesstimeout/descriptor/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/JsfClient.java = ejblitejsf
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/annotated/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/descriptor/JsfClient.java = ejblitejsf
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/descriptor/Client.java = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor = ejblitejsf
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/descriptor = ejbliteservlet ejbliteservlet2 ejblitejsp ejbembed
 
 
 com/sun/ts/tests/ejb30/lite/async/singleton/annotated/JsfClient.java = ejblitejsf

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/JsfClient.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.descriptor;
+package com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.jsfdescriptor;
 
 import java.io.Serializable;
 

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/JsfClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,9 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
 package com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.descriptor;
 
 import java.io.Serializable;

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/build.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
 
 <project name="ejb3 lite" basedir="." default="usage">
    <import file="../../../../../common/import.xml"/>
-   <property name="app.name" value="ejblite_stateful_concurrency_metadata_descriptor"/>
+   <property name="app.name" value="ejblite_stateful_concurrency_metadata_jsfdescriptor"/>
    <property name="app.common" value="com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common"/>
    <property name="app.common.2" value="com/sun/ts/tests/ejb30/lite/stateful/concurrency/common"/>
    
@@ -28,9 +28,8 @@
 com/sun/ts/tests/ejb30/common/helper/ServiceLocator.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/Pinger.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyIF.class,
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyClientBase.class,
-
-com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/ClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/common/StatefulConcurrencyJsfClientBase.class,
+com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/JsfClientBase.class,
 com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/common/StatefulConcurrencyBeanBase.class
         ">
         </ts.vehicles>

--- a/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/ejb-jar.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/stateful/concurrency/metadata/jsfdescriptor/ejb-jar.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="4.0" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+    <enterprise-beans>
+        <session>
+            <ejb-name>DefaultConcurrencyBean</ejb-name>
+            <business-local>com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF</business-local>
+            <local-bean />
+            <ejb-class>com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.common.StatefulConcurrencyBeanBase</ejb-class>
+            <session-type>Stateful</session-type>
+        </session>
+        <session>
+            <ejb-name>ContainerConcurrencyBean</ejb-name>
+            <business-local>com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF</business-local>
+            <local-bean />
+            <ejb-class>com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.common.StatefulConcurrencyBeanBase</ejb-class>
+            <session-type>Stateful</session-type>
+            <concurrency-management-type>Container</concurrency-management-type>
+        </session>
+        <session>
+            <ejb-name>NotAllowedConcurrencyBean</ejb-name>
+            <business-local>com.sun.ts.tests.ejb30.lite.stateful.concurrency.common.StatefulConcurrencyIF</business-local>
+            <local-bean />
+            <ejb-class>com.sun.ts.tests.ejb30.lite.stateful.concurrency.metadata.common.StatefulConcurrencyBeanBase</ejb-class>
+            <session-type>Stateful</session-type>
+            <concurrent-method>
+                <method>
+                    <method-name>ping</method-name>
+                    <method-params/>
+                </method>
+                <lock>Write</lock>
+                <access-timeout>
+                    <timeout>0</timeout>
+                    <unit>Nanoseconds</unit>
+                </access-timeout>
+            </concurrent-method>
+            
+        </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/968

**Describe the change**
This separates the faces tests from ejb30/lite/stateful/concurrency/metadata/descriptor to ejb30/lite/stateful/concurrency/metadata/jsfdescriptor. The non-faces vehicle tests are fixed with this. The 3 faces tests show failure while testing as it is not sure if it is due to the test env. Will need to address that in a separate change if it persists.

cc @gurunrao @scottmarlow 