### PR TITLE
User guide update to remove COMPAT option and list migrated Standalone TCK

### DIFF
--- a/user_guides/jakartaee/src/main/jbake/content/config.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/config.adoc
@@ -226,25 +226,6 @@ container: +
 -Djava.security.manager
 
 ----
-+
-Add this option to the list of other `-D JVM` options for this property. +
-As mentioned previously, these settings can vary, but must match
-whatever you used when setting up the Jakarta EE 10 CI server.
-..  Add the following JVM option for JSTL test runs with JDK 11: +
-+
-[source,oac_no_warn]
-----
--Djava.locale.providers=COMPAT
-
-----
-+
-The JVM compatibility option should be passed while starting implementation
-under test. +
-`-Djava.locale.providers=COMPAT` option will enable JDK 8 compatibility mode, +
-JDK 8 compatibility mode is required for tags TCK tests with Dates, TimeZones 
-to PASS with JDK 11. +
-`-Djava.locale.providers=COMPAT` should not be passed to JVM, when tests are 
-run with JDK 8.
 .  Install the Jakarta EE 10 CI and configure basic settings, as described
 in link:install.html#GBFTP[Chapter 4, "Installation."]
 .  Start the Jakarta EE 10 CI application server. +

--- a/user_guides/jakartaee/src/main/jbake/content/rules-wp.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules-wp.adoc
@@ -407,12 +407,18 @@ EE-WP21 Compliance testing for Jakarta EE 10 Web Profile consists of running
 the Jakarta EE 10 Web Profile tests and the following Technology
 Compatibility Kits (TCKs):
 
+* Jakarta Authentication 3.0
+* Jakarta Bean Validation 3.0
+* Jakarta Concurrency 3.0
 * Jakarta Contexts and Dependency Injection 4.0
 * Jakarta Dependency Injection 2.0
-* Jakarta Bean Validation 3.0
-* Jakarta XML Binding 4.0 (If XML Binding is supported)
+* Jakarta Faces 4.0
 * Jakarta JSON Processing 2.1
 * Jakarta JSON Binding 3.0
+* Jakarta RESTful Web Services 3.1
+* Jakarta Security 3.0
+* Jakarta XML Binding 4.0 (If XML Binding is supported)
+
 
 In addition to the compatibility rules outlined in this TCK User's
 Guide, Jakarta EE 10 implementations must also adhere to all of the

--- a/user_guides/jakartaee/src/main/jbake/content/rules.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules.adoc
@@ -413,12 +413,17 @@ programmatic behavior of the Runtime in the absence of that comment.
 EE21 Compliance testing for Jakarta EE 10.0 consists of running Jakarta EE 10.0
 TCK and the following Technology Compatibility Kits (TCKs):
 
+* Jakarta Authentication 3.0
+* Jakarta Bean Validation 3.0
+* Jakarta Concurrency 3.0
 * Jakarta Contexts and Dependency Injection 4.0
 * Jakarta Dependency Injection 2.0 
-* Jakarta Bean Validation 3.0
-* Jakarta XML Binding 4.0 (If XML Binding is supported)
+* Jakarta Faces 4.0
 * Jakarta JSON Processing 2.1
 * Jakarta JSON Binding 3.0
+* Jakarta RESTful Web Services 3.1
+* Jakarta Security 3.0
+* Jakarta XML Binding 4.0 (If XML Binding is supported)
 
 In addition to the compatibility rules outlined in this TCK User's
 Guide, Jakarta EE 10.0 implementations must also adhere to all of the

--- a/user_guides/jakartaee/src/main/jbake/content/rules.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules.adoc
@@ -414,6 +414,7 @@ EE21 Compliance testing for Jakarta EE 10.0 consists of running Jakarta EE 10.0
 TCK and the following Technology Compatibility Kits (TCKs):
 
 * Jakarta Authentication 3.0
+* Jakarta Batch 2.1
 * Jakarta Bean Validation 3.0
 * Jakarta Concurrency 3.0
 * Jakarta Contexts and Dependency Injection 4.0


### PR DESCRIPTION
User guide update to remove COMPAT option and list migrated Standalone TCK