### PR TITLE
Remove extra == at end of section title, #1040

### DIFF
--- a/user_guides/jakartaee/src/main/jbake/content/title.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/title.adoc
@@ -5,7 +5,7 @@ next=TCKpreface.html
 prev=toc.html
 ~~~~~~
 Jakarta EE Platform, Enterprise Edition 10 Test Compatibility Kit User's Guide, Release 10 for Jakarta EE
-===========================================================================================================
+=========================================================================================================
 
 [[oracle]] 
 Eclipse Foundation™


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

**Fixes Issue**
#1040 

**Describe the change**
Extra '=' characters at end of section title were screwing up the generation.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
