### PR TITLE
Remove thrown Exception on PostConstruct

### DIFF
--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
@@ -11,17 +11,20 @@
 
 package ee.jakarta.tck.core.rest.jsonb.cdi;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyFactory;
-import java.security.PublicKey;
-import java.security.spec.EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 
 @ApplicationScoped
 public class KeysProducer {
@@ -33,22 +36,26 @@ public class KeysProducer {
      * @throws Exception - on failure to read or initialize public key
      */
     @PostConstruct
-    private void loadKeys() throws Exception {
-        byte[] pubKeyData;
-        try (InputStream keyIS = getClass().getResourceAsStream("/key.pub")) {
-            if (keyIS == null) {
-                throw new IllegalStateException("Failed to find /key.pub");
+    private void loadKeys() {
+        try {
+            byte[] pubKeyData;
+            try (InputStream keyIS = getClass().getResourceAsStream("/key.pub")) {
+                if (keyIS == null) {
+                    throw new IllegalStateException("Failed to find /key.pub");
+                }
+                pubKeyData = keyIS.readAllBytes();
             }
-            pubKeyData = keyIS.readAllBytes();
-        }
-        String pubKeyString = new String(pubKeyData, StandardCharsets.UTF_8);
-        System.out.println(pubKeyString);
-        byte[] keyData = Base64.getDecoder().decode(pubKeyString);
-        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(keyData);
-        System.out.println(publicKeySpec);
+            String pubKeyString = new String(pubKeyData, StandardCharsets.UTF_8);
+            System.out.println(pubKeyString);
+            byte[] keyData = Base64.getDecoder().decode(pubKeyString);
+            EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(keyData);
+            System.out.println(publicKeySpec);
 
-        KeyFactory keyFactory = KeyFactory.getInstance("EC");
-        publicKey = keyFactory.generatePublic(publicKeySpec);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            publicKey = keyFactory.generatePublic(publicKeySpec);
+        } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            System.out.println(exception.getStackTrace());
+        }
     }
 
     @Produces


### PR DESCRIPTION
**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/1050

**Describe the change**
The [JavaDocs](https://jakarta.ee/specifications/annotations/2.1/apidocs/jakarta.annotation/jakarta/annotation/postconstruct) specify that PostConstruct on a class that is not an interceptor must not declare checked exception

Therefore I have removed the thrown Exception and replaced it with a catch.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
