### PR TITLE
exclude CDI_SE tests when running JSON-B TCK

### DIFF
--- a/glassfish-runner/jsonb-tck/pom.xml
+++ b/glassfish-runner/jsonb-tck/pom.xml
@@ -89,6 +89,9 @@
               <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
               <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/lib/appclient/weld-se-shaded.jar</additionalClasspathElement>
           </additionalClasspathElements>
+          <excludes>
+             <exclude>ee.jakarta.tck.json.bind.cdi.customizedmapping.adapters.AdaptersCustomizationCDITest,ee.jakarta.tck.json.bind.cdi.customizedmapping.serializers.SerializersCustomizationCDITest</exclude>
+          </excludes>
           </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Workaround GlassFish 7 Web Profile not support CDI_SE tests

https://ci.eclipse.org/jakartaee-tck/job/10/job/jakarta-jsonb-tck-glassfish-run/lastCompletedBuild/testReport shows zero failures running JSON-B TCK with GlassFish 7 nightly build web profile.

**Fixes Issue**

https://github.com/eclipse-ee4j/jsonb-api/issues/326


