### PR TITLE
Challenge for com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfCli…

### DIFF
--- a/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/Client.java
+++ b/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/Client.java
@@ -36,8 +36,9 @@ public class Client extends EJBLiteClientBase {
   /*
    * @testName: unmappedEnvEntry
    *
-   * @test_Strategy: this @Resource has no mapped <env-entry> in descriptor, so
-   * the default value of the field is unchanged.
+   * @test_Strategy: this @Resource injection corresponds to the <env-entry>
+   * without <env-entry-value> in descriptor, so the default value of the field
+   * is unchanged.
    */
   public void unmappedEnvEntry() {
     assertEquals("Check correct the default value is retained. ", 1,

--- a/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfClient.java
+++ b/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/JsfClient.java
@@ -35,8 +35,9 @@ public class JsfClient extends EJBLiteJsfClientBase {
   /*
    * @testName: unmappedEnvEntry
    *
-   * @test_Strategy: this @Resource has no mapped <env-entry> in descriptor, so
-   * the default value of the field is unchanged.
+   * @test_Strategy: this @Resource injection corresponds to the <env-entry>
+   * without <env-entry-value> in descriptor, so the default value of the field
+   * is unchanged.
    */
   public void unmappedEnvEntry() {
     assertEquals("Check correct the default value is retained. ", 1,

--- a/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/ejb-jar.xml
+++ b/src/com/sun/ts/tests/ejb30/lite/xmloverride/resource/ejb-jar.xml
@@ -37,7 +37,11 @@
         <env-entry-type>java.lang.Integer</env-entry-type>
         <env-entry-value>0</env-entry-value>
       </env-entry>
-      
+      <env-entry>
+        <env-entry-name>unmappedEnvEntry</env-entry-name>
+        <env-entry-type>java.lang.Integer</env-entry-type>
+      </env-entry>
+
     </session>
   </enterprise-beans>
 </ejb-jar>


### PR DESCRIPTION
…ent.java\#unmappedEnvEntry_from_ejblitejsf

Fixes #1063

Signed-off-by: Cheng Fang <cfang@redhat.com>

**Fixes Issue**
https://github.com/eclipse-ee4j/jakartaee-tck/issues/1063

**Describe the change**
Add `<env-entry>` with name `unmappedEnvEntry` to ejb-jar.xml to declare this resource. This `<env-entry>` element contains no `<env-entry-value>` to preserve the original test strategy.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
