### PR TITLE
Add CDI Language Model TCK requirement for Standalone TCKs that must be run

### DIFF
--- a/user_guides/jakartaee/src/main/jbake/content/intro.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/intro.adoc
@@ -530,7 +530,7 @@ All Jakarta EE 10 Web Profile implementations must also pass the standalone TCKs
 * Jakarta Authentication -- see https://jakarta.ee/specifications/authentication/3.0/ for additional details
 * Jakarta Bean Validation -- see https://jakarta.ee/specifications/bean-validation/3.0/ for additional details
 * Jakarta Concurrency -- see https://jakarta.ee/specifications/concurrency/3.0/ for additional details
-* Jakarta Contexts and Dependency Injection -- see https://jakarta.ee/specifications/cdi/4.0/ for additional details
+* Jakarta Contexts and Dependency Injection (including Language Model TCK) -- see https://jakarta.ee/specifications/cdi/4.0/ for additional details
 * Jakarta Debugging Support for Other Languages -- see https://jakarta.ee/specifications/debugging/ for additional details
 * Jakarta Dependency Injection -- see https://jakarta.ee/specifications/dependency-injection/2.0/ for additional details
 * Jakarta Faces -- see https://jakarta.ee/specifications/faces/4.0/ for additional details

--- a/user_guides/jakartaee/src/main/jbake/content/intro.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/intro.adoc
@@ -514,7 +514,7 @@ also pass the standalone TCKs for the following technologies:
 * Jakarta Batch -- see https://jakarta.ee/specifications/batch/2.1/ for additional details
 * Jakarta Bean Validation -- see https://jakarta.ee/specifications/bean-validation/3.0/ for additional details
 * Jakarta Concurrency -- see https://jakarta.ee/specifications/concurrency/3.0/ for additional details
-* Jakarta Contexts and Dependency Injection -- see https://jakarta.ee/specifications/cdi/4.0/ for additional details
+* Jakarta Contexts and Dependency Injection (including Language Model TCK) -- see https://jakarta.ee/specifications/cdi/4.0/ for additional details
 * Jakarta Debugging Support for Other Languages -- see https://jakarta.ee/specifications/debugging/ for additional details
 * Jakarta Dependency Injection -- see https://jakarta.ee/specifications/dependency-injection/2.0/ , for additional details
 * Jakarta Faces -- see https://jakarta.ee/specifications/faces/4.0/ for additional details


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

All CDI 4.0 implementations also need to run the CDI Language Model TCK that is part of the CDI 4.0 TCK distribution.