### PR TITLE
mention that entity beans and embeddable container implementations may still be tested

### DIFF
--- a/user_guides/jakartaee/src/main/jbake/content/intro.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/intro.adoc
@@ -184,9 +184,13 @@ The complete list of Jakarta EE 10 technologies for the Platform can be found in
 * Jakarta Transactions
 * Jakarta WebSocket
 
+The following (removed from Jakarta EE 10 Platform) technologies may be tested via the Jakarta EE Platform TCK:
+
+* Jakarta Enterprise Beans entity beans and associated Jakarta Enterprise Beans QL
+* Jakarta Enterprise Beans embeddable container 
+
 The following optional technologies may also be tested via the Jakarta EE Platform TCK:
 
-* Jakarta Enterprise Beans and earlier entity beans and associated Jakarta Enterprise Beans QL 
 * Jakarta Enterprise Beans 2.x API group 
 * Jakarta Enterprise Beans Container Managed Persistence, Bean Managed Persistence
 * Jakarta Enterprise Web Services 

--- a/user_guides/jakartaee/src/main/jbake/content/rules-wp.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules-wp.adoc
@@ -546,7 +546,7 @@ required for the Jakarta EE 10 Web Profile:
 * jakarta.annotation.sql
 * jakarta.decorator
 * jakarta.ejb
-* jakarta.ejb.embeddable
+* jakarta.ejb.embeddable (removed from Jakarta EE 10 Platform but still part of Jakarta Enterprise Beans 4.0)
 * jakarta.ejb.spi
 * jakarta.el
 * jakarta.enterprise.context

--- a/user_guides/jakartaee/src/main/jbake/content/rules.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules.adoc
@@ -558,7 +558,7 @@ required for Jakarta EE 10.0:
 * jakarta.batch.runtime.context
 * jakarta.decorator
 * jakarta.ejb
-* jakarta.ejb.embeddable
+* jakarta.ejb.embeddable (removed from Jakarta EE 10 Platform but still part of Jakarta Enterprise Beans 4.0)
 * jakarta.ejb.spi
 * jakarta.el
 * jakarta.enterprise.concurrent


### PR DESCRIPTION

Signed-off-by: Scott Marlow <smarlow@redhat.com>

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow

As part of [EE 10 release plan](https://github.com/eclipse-ee4j/jakartaee-platform/blob/gh-pages/jakartaee10/JakartaEE10ReleasePlan.md#removal-of-two-ejb-features), we removed (Enterprise Beans) entity beans + embeddable container which can be seen via https://github.com/eclipse-ee4j/jakartaee-platform/blob/master/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc#removed-jakarta-technologies

The purpose of this pull request is to describe that the removed features can still be tested by the EE 10 Platform TCK (via `ejb_1x_optional or` `javaee_optional` for entity beans and `ejb_embeddable_optional` for embeddable container).