### PR TITLE
(reapply) mention that entity beans and embeddable container implementations may still be tested

### DIFF
--- a/user_guides/jakartaee/src/main/jbake/content/intro.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/intro.adoc
@@ -184,9 +184,13 @@ The complete list of Jakarta EE 10 technologies for the Platform can be found in
 * Jakarta Transactions
 * Jakarta WebSocket
 
+The following (removed from Jakarta EE 10 Platform) technologies may be tested via the Jakarta EE Platform TCK:
+
+* Jakarta Enterprise Beans entity beans and associated Jakarta Enterprise Beans QL
+* Jakarta Enterprise Beans embeddable container 
+
 The following optional technologies may also be tested via the Jakarta EE Platform TCK:
 
-* Jakarta Enterprise Beans and earlier entity beans and associated Jakarta Enterprise Beans QL 
 * Jakarta Enterprise Beans 2.x API group 
 * Jakarta Enterprise Beans Container Managed Persistence, Bean Managed Persistence
 * Jakarta Enterprise Web Services 

--- a/user_guides/jakartaee/src/main/jbake/content/rules-wp.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules-wp.adoc
@@ -546,7 +546,7 @@ required for the Jakarta EE 10 Web Profile:
 * jakarta.annotation.sql
 * jakarta.decorator
 * jakarta.ejb
-* jakarta.ejb.embeddable
+* jakarta.ejb.embeddable (removed from Jakarta EE 10 Platform but still part of Jakarta Enterprise Beans 4.0)
 * jakarta.ejb.spi
 * jakarta.el
 * jakarta.enterprise.context

--- a/user_guides/jakartaee/src/main/jbake/content/rules.adoc
+++ b/user_guides/jakartaee/src/main/jbake/content/rules.adoc
@@ -558,7 +558,7 @@ required for Jakarta EE 10.0:
 * jakarta.batch.runtime.context
 * jakarta.decorator
 * jakarta.ejb
-* jakarta.ejb.embeddable
+* jakarta.ejb.embeddable (removed from Jakarta EE 10 Platform but still part of Jakarta Enterprise Beans 4.0)
 * jakarta.ejb.spi
 * jakarta.el
 * jakarta.enterprise.concurrent


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

verified locally that this change is equal to what we wanted merged by https://github.com/eclipse-ee4j/jakartaee-tck/pull/1105 change only without the wf-core-tck-runner change.

```
git diff entitybean_embededableejb applyuserguidechange
diff --git a/core-profile-tck/examples/wf-core-tck-runner b/core-profile-tck/examples/wf-core-tck-runner
index 8571693aa..ad73e6919 160000
--- a/core-profile-tck/examples/wf-core-tck-runner
+++ b/core-profile-tck/examples/wf-core-tck-runner
@@ -1 +1 @@
-Subproject commit 8571693aa968b97cf5961dc157a3b0402eff0ce8
+Subproject commit ad73e6919a35e9d8e56352e1382fe47489f78abe
```