### PR TITLE
Possibility to reconfigure GlassFish logging configuration

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -150,6 +150,10 @@ mkdir -p "${CTS_HOME}/ri"
 unzip -q "${GF_BUNDLE_ZIP}" -d "${CTS_HOME}/ri"
 chmod -R 777 "${CTS_HOME}/ri"
 
+if [ -n "$GF_LOGGING_CFG_RI" ]; then
+  cp "$GF_LOGGING_CFG_RI" "${CTS_HOME}/ri/${GF_RI_TOPLEVEL_DIR}/glassfish/domains/domain1/config/logging.properties"
+fi
+
 export ADMIN_PASSWORD_FILE="${CTS_HOME}/admin-password.txt"
 echo "AS_ADMIN_PASSWORD=adminadmin" > "${ADMIN_PASSWORD_FILE}"
 
@@ -262,6 +266,10 @@ if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
   replace="--add-opens=java.base\\/java.io=ALL-UNNAMED --add-opens=java.base\\/java.lang=ALL-UNNAMED --add-opens=java.base\\/java.util=ALL-UNNAMED --add-opens=java.base\\/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming\\/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi\\/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management\\/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming\\/com.sun.jndi.ldap=ALL-UNNAMED"
   sed -i.bak "s/$search/$replace/" ${TS_HOME}/bin/ts.jte
   echo "updated ts.jte to use -add-opens for Java SE 17 "
+fi
+
+if [ -n "$GF_LOGGING_CFG_VI" ]; then
+  cp "$GF_LOGGING_CFG_VI" "${CTS_HOME}/ri/${GF_VI_TOPLEVEL_DIR}/glassfish/domains/domain1/config/logging.properties"
 fi
 
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${CTS_HOME}/change-admin-password.txt change-admin-password

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -257,11 +257,11 @@ fi
 
 # do ts.jte parameter substitution here of ${JVMOPTS_RUNTESTCOMMAND}
 if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-   echo "update ts.jte for GlassFish to use --add-opens options for Java SE 17"
-   search="..JVMOPTS_RUNTESTCOMMAND."
-   replace="--add-opens=java.base\\/java.io=ALL-UNNAMED --add-opens=java.base\\/java.lang=ALL-UNNAMED --add-opens=java.base\\/java.util=ALL-UNNAMED --add-opens=java.base\\/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming\\/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi\\/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management\\/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming\\/com.sun.jndi.ldap=ALL-UNNAMED"
-   sed -i.bak "s/$search/$replace/" ${TS_HOME}/bin/ts.jte
-   echo "updated ts.jte to use -add-opens for Java SE 17 "
+  echo "update ts.jte for GlassFish to use --add-opens options for Java SE 17"
+  search="..JVMOPTS_RUNTESTCOMMAND."
+  replace="--add-opens=java.base\\/java.io=ALL-UNNAMED --add-opens=java.base\\/java.lang=ALL-UNNAMED --add-opens=java.base\\/java.util=ALL-UNNAMED --add-opens=java.base\\/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming\\/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi\\/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management\\/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming\\/com.sun.jndi.ldap=ALL-UNNAMED"
+  sed -i.bak "s/$search/$replace/" ${TS_HOME}/bin/ts.jte
+  echo "updated ts.jte to use -add-opens for Java SE 17 "
 fi
 
 ${CTS_HOME}/vi/$GF_VI_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${CTS_HOME}/change-admin-password.txt change-admin-password

--- a/rm-generated.sh
+++ b/rm-generated.sh
@@ -48,6 +48,7 @@ rm -rf ./src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/Clie
 rm -rf ./src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/DataSourceBean.java
 rm -rf ./src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/DataSourceMBean.java
 rm -rf ./src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/DataSourceRepeatableBean.java
+rm -rf ./src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/JsfClient.java
 rm -rf ./src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/ejb-jar.xml
 rm -rf ./src/com/sun/ts/tests/ejb30/misc/datasource/appclientejb/Client.java
 rm -rf ./src/com/sun/ts/tests/ejb30/misc/datasource/appclientejb/DataSourceBean.java


### PR DESCRIPTION
**Describe the change**
Added possibility to provide custom logging.properties. Default is using the configuration provided with GlassFish.

**Additional context**
This change is extremely useful when we need to analyze what happened and why, or even compare logs between GlassFish versions. (kdiff3 in Kubuntu is great for that as it can ignore some patterns, ie. timestamp).

**Two additional commits**
* One is just formatting to keep conventions of the bash script
* Second adds removal of one file to the `rm-generated-sh` script I created recently in 5e8abe0192

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
