### PR TITLE
exclude Servlet setMaxAgePositiveTest tests for accepted https://github.com/jakartaee/servlet/issues/471 challenge

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -77,3 +77,8 @@ com/sun/ts/tests/jpa/core/annotations/mapkeytemporal/Client.java#elementCollecti
 #
 com/sun/ts/tests/securityapi/idstore/noidstore/Client.java#testIdentityStoreValidate_noIDStore
 com/sun/ts/tests/securityapi/ham/sam/delegation/Client.java#testSAMDelegatesHAM
+
+#
+#
+com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest

--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -79,6 +79,9 @@ com/sun/ts/tests/securityapi/idstore/noidstore/Client.java#testIdentityStoreVali
 com/sun/ts/tests/securityapi/ham/sam/delegation/Client.java#testSAMDelegatesHAM
 
 #
-#
+# https://github.com/jakartaee/servlet/issues/471 TCK Challenge: Cookie setMaxAgePositiveTest using incorrect CookiePolicy for Date parsing
 com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
+
+# https://github.com/jakartaee/servlet/issues/472 TCK Challenge: doHeadTest shouldn't validate optional payload header fields
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest/URLClient.java#doHeadTest

--- a/install/servlet/bin/ts.jtx
+++ b/install/servlet/bin/ts.jtx
@@ -20,6 +20,10 @@
 #
 
 #
-#
+# https://github.com/jakartaee/servlet/issues/471 TCK Challenge: Cookie setMaxAgePositiveTest using incorrect CookiePolicy for Date parsing
 com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
 com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
+
+# https://github.com/jakartaee/servlet/issues/472 TCK Challenge: doHeadTest shouldn't validate optional payload header fields
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/httpservletrequest/URLClient.java#doHeadTest
+

--- a/install/servlet/bin/ts.jtx
+++ b/install/servlet/bin/ts.jtx
@@ -18,3 +18,8 @@
 #
 # Servlet 6.0 TCK Exclude List
 #
+
+#
+#
+com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
+com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -30,7 +30,7 @@
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
     <property name="deliverable.version"           value="10.0"/>
-    <property name="deliverable.tck.version"           value="10.0.0"/>
+    <property name="deliverable.tck.version"           value="10.0.1"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxm/**/*, **/jaxm1.0.1/**/*,

--- a/release/tools/servlet.xml
+++ b/release/tools/servlet.xml
@@ -22,7 +22,7 @@
 	<import file="../../bin/xml/ts.common.props.xml"/>
 
 	<property name="deliverable.version"  value="6.0"/>
-        <property name="deliverable.tck.version"  value="6.0.0"/>
+        <property name="deliverable.tck.version"  value="6.0.1"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Fixes Issue**
https://github.com/jakartaee/servlet/issues/471

**Describe the change**
Exclude the following tests from Servlet + Platform TCK:
```
com/sun/ts/tests/servlet/pluggability/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
com/sun/ts/tests/servlet/api/jakarta_servlet_http/cookie/URLClient.java#setMaxAgePositiveTest
```

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
