### PR TITLE
[1135] Do not add the CustomJsonbResolver as a service provider for a…

### DIFF
--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
@@ -25,7 +25,6 @@ import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
 
 import ee.jakarta.tck.core.rest.JaxRsActivator;
-import jakarta.json.bind.spi.JsonbProvider;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -65,7 +64,6 @@ public class CustomJsonbSerializationIT {
                 .addClass(SomeMessage.class)
                 .addClass(Utils.class)
                 .addClass(JaxRsActivator.class)
-                .addAsServiceProvider(JsonbProvider.class, CustomJsonbResolver.class)
                 .addAsResource(new StringAsset(pubKeyString), "key.pub");
         ;
         System.out.printf("test archive: %s\n", archive.toString(true));


### PR DESCRIPTION
… JsonbProvider.

Signed-off-by: James R. Perkins <jperkins@redhat.com>

**Fixes Issue**
resolves #1135

**Describe the change**
Removes the registration of the `CustomJsonbResolver` as a service provider for `JsonbProvider`.

**Additional context**
Jakarta Core Profile TCK challenge fix

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
