### PR TITLE
[1134] Allow the response type to be either 400 or 500. In Jakarta RE…

### DIFF
--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
+import java.util.List;
 
 import ee.jakarta.tck.core.rest.JaxRsActivator;
 import jakarta.json.bind.spi.JsonbProvider;
@@ -144,7 +145,9 @@ public class CustomJsonbSerializationIT {
                     .invoke();
 
             System.out.printf("Response(%d), reason=%s\n", response.getStatus(), response.getStatusInfo().getReasonPhrase());
-            Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            final List<Integer> expected = List.of(Response.Status.BAD_REQUEST.getStatusCode(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+            Assertions.assertTrue(expected.contains(response.getStatus()),
+                    () -> String.format("Expected one of %s got %d: %s", expected, response.getStatus(), response.readEntity(String.class)));
         }
 
     }


### PR DESCRIPTION
…STful Web Services 3.1 a default ExceptionMapper is required. The suggestion of the specification is to return 500 as the response status.

**Fixes Issue**
resolves #1134 

**Describe the change**
Allow the response type to be either 400 or 500. In Jakarta RESTful Web Services 3.1 a default ExceptionMapper is required. The suggestion of the specification is to return 500 as the response status. 

**Additional context**
Jakarta Core Profile TCK challenge fix

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
