### PR TITLE
Core Profile TCK Service release 10.0.1

### DIFF
--- a/core-profile-tck/ca-sigtest/pom.xml
+++ b/core-profile-tck/ca-sigtest/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>jakarta.ee.tck.coreprofile</groupId>
     <artifactId>core-tck-parent</artifactId>
-    <version>10.0.0</version>
+    <version>10.0.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/core-profile-tck/cdi-tck-suite/pom.xml
+++ b/core-profile-tck/cdi-tck-suite/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>jakarta.ee.tck.coreprofile</groupId>
     <artifactId>core-tck-parent</artifactId>
-    <version>10.0.0</version>
+    <version>10.0.1</version>
   </parent>
 
   <artifactId>cdi-lite-tck-suite</artifactId>

--- a/core-profile-tck/jsonp-tck-ext/pom.xml
+++ b/core-profile-tck/jsonp-tck-ext/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>jakarta.ee.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>10.0.0</version>
+        <version>10.0.1</version>
     </parent>
 
     <artifactId>core-tck-jsonp-extension</artifactId>

--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -22,7 +22,7 @@
   <groupId>jakarta.ee.tck.coreprofile</groupId>
   <artifactId>core-tck-parent</artifactId>
   <packaging>pom</packaging>
-  <version>10.0.0</version>
+  <version>10.0.1</version>
   <name>Jakarta Core TCK</name>
 
   <!-- Metadata -->

--- a/core-profile-tck/restful-tck-suite/pom.xml
+++ b/core-profile-tck/restful-tck-suite/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>jakarta.ee.tck.coreprofile</groupId>
     <artifactId>core-tck-parent</artifactId>
-    <version>10.0.0</version>
+    <version>10.0.1</version>
   </parent>
 
   <artifactId>rest-tck-suite</artifactId>

--- a/core-profile-tck/tck-dist/RELEASE-NOTES.adoc
+++ b/core-profile-tck/tck-dist/RELEASE-NOTES.adoc
@@ -1,5 +1,12 @@
 = Jakarta Core Profile TCK Release notes
 
+== Version 10.0.1
+
+Adds bug fixes for two Core Profile TCK challenges:
+
+* https://github.com/eclipse-ee4j/jakartaee-tck/issues/1134[Expected status code in CustomJsonbSerializationIT]
+* https://github.com/eclipse-ee4j/jakartaee-tck/issues/1135[Invalid Custom JsonbResolver]
+
 == Version 10.0.0
 
 Version 10.0.0 is the initial version of the Jakarta Core Profile TCK

--- a/core-profile-tck/tck-dist/pom.xml
+++ b/core-profile-tck/tck-dist/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>jakarta.ee.tck.coreprofile</groupId>
       <artifactId>core-tck-parent</artifactId>
-      <version>10.0.0</version>
+      <version>10.0.1</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/core-profile-tck/tck/pom.xml
+++ b/core-profile-tck/tck/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>jakarta.ee.tck.coreprofile</groupId>
     <artifactId>core-tck-parent</artifactId>
-    <version>10.0.0</version>
+    <version>10.0.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>core-profile-tck-impl</artifactId>

--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
@@ -25,7 +25,6 @@ import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
 
 import ee.jakarta.tck.core.rest.JaxRsActivator;
-import jakarta.json.bind.spi.JsonbProvider;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -65,7 +64,6 @@ public class CustomJsonbSerializationIT {
                 .addClass(SomeMessage.class)
                 .addClass(Utils.class)
                 .addClass(JaxRsActivator.class)
-                .addAsServiceProvider(JsonbProvider.class, CustomJsonbResolver.class)
                 .addAsResource(new StringAsset(pubKeyString), "key.pub");
         ;
         System.out.printf("test archive: %s\n", archive.toString(true));

--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
+import java.util.List;
 
 import ee.jakarta.tck.core.rest.JaxRsActivator;
 import jakarta.ws.rs.BadRequestException;
@@ -142,7 +143,9 @@ public class CustomJsonbSerializationIT {
                     .invoke();
 
             System.out.printf("Response(%d), reason=%s\n", response.getStatus(), response.getStatusInfo().getReasonPhrase());
-            Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            final List<Integer> expected = List.of(Response.Status.BAD_REQUEST.getStatusCode(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+            Assertions.assertTrue(expected.contains(response.getStatus()),
+                    () -> String.format("Expected one of %s got %d: %s", expected, response.getStatus(), response.readEntity(String.class)));
         }
 
     }


### PR DESCRIPTION
Cherry-pick changes from: 
- https://github.com/eclipse-ee4j/jakartaee-tck/pull/1136 Do not add the CustomJsonbResolver as a service provider 
- https://github.com/eclipse-ee4j/jakartaee-tck/pull/1137 Allow the response type to be either 400 or 500
- https://github.com/eclipse-ee4j/jakartaee-tck/pull/1138 Create a core profile tck service release
- https://github.com/eclipse-ee4j/jakartaee-tck/pull/1139 Update core profile tck to 10.0.1